### PR TITLE
make response.html better accessible

### DIFF
--- a/login_server/src/cpp/tasks/SigningTransaction.cpp
+++ b/login_server/src/cpp/tasks/SigningTransaction.cpp
@@ -227,7 +227,13 @@ int SigningTransaction::run() {
 			//printf("[JsonRequestHandler::handleRequest] Exception: %s\n", ex.displayText().data());
 			addError(new ParamError("SigningTransaction", "error parsing request answer", ex.displayText().data()));
 
-			FILE* f = fopen("response.html", "wt");
+			std::string log_Path = "/var/log/grd_login/";
+			//#ifdef _WIN32
+#if defined(_WIN32) || defined(_WIN64)
+			log_Path = "./";
+#endif
+			log_Path += "response.html";
+			FILE* f = fopen(log_Path.data(), "wt");
 			if (f) {
 				std::string responseString = responseStringStream.str();
 				fwrite(responseString.data(), 1, responseString.size(), f);


### PR DESCRIPTION
save response.html by community server error into /var/logs/grd_login folder, to have access to it if used with docker (/logs)

