### PR TITLE
feat: Activate Coverage Report For Unit Tests In Frontend

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -19,4 +19,8 @@ package-lock.json
 *.njsproj
 *.sln
 
+# coverage folder
+
+coverage/
+
 *~

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,13 +1,13 @@
 module.exports = {
   verbose: true,
-  //collectCoverageFrom: ['**/*.{js,vue}', '!**/node_modules/**', '!**/?(*.)+(spec|test).js?(x)'],
+  collectCoverageFrom: ['src/**/*.{js,vue}', '!**/node_modules/**', '!**/?(*.)+(spec|test).js?(x)'],
   moduleFileExtensions: [
     'js',
     //'jsx',
     'json',
     'vue',
   ],
-  coverageReporters: ['lcov'],
+  // coverageReporters: ['lcov', 'text'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '\\.(css|less)$': 'identity-obj-proxy',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint --ext .js,.vue .",
     "dev": "yarn run serve",
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "dependencies": {
     "@babel/core": "^7.13.13",


### PR DESCRIPTION
## 🍰 Pullrequest
When the unit test run in the frontend, a coverage report is generated. By now, all report formats given by jest are active.
Add the end of the tests the coverage is printed to the console in text format. In the folder coverage are reports in XML, JSON and HTML.

### Issues
- relates #122

### Todo
- [ ] Evaluate how we proceed from here.
