### PR TITLE
fix: Gradido-Akademie in Footer Links to gradido.net

### DIFF
--- a/frontend/src/views/Layout/ContentFooter.spec.js
+++ b/frontend/src/views/Layout/ContentFooter.spec.js
@@ -41,38 +41,54 @@ describe('ContentFooter', () => {
       })
 
       it('links to the login page when clicked on copyright', () => {
-        expect(wrapper.find('div.copyright').find('a').attributes('href')).toEqual('#/Login')
+        expect(wrapper.find('div.copyright').find('a').attributes('href')).toEqual(
+          'https://gradido.net/en',
+        )
+      })
+    })
+
+    describe('version', () => {
+      it('shows the current version', async () => {
+        wrapper.setData({ version: 1.23 })
+        await wrapper.vm.$nextTick()
+        expect(wrapper.find('div.copyright').findAll('a').at(1).text()).toEqual('App version 1.23')
+      })
+
+      it('links to latest release on GitHub', () => {
+        expect(wrapper.find('div.copyright').findAll('a').at(1).attributes('href')).toEqual(
+          'https://github.com/gradido/gradido/releases/latest',
+        )
       })
     })
 
     describe('links to gradido.net', () => {
-      it('has a link to the gradido.net', () => {
-        expect(wrapper.findAll('a.nav-link').at(0).text()).toEqual('Gradido')
-      })
-
-      it('links to the https://gradido.net/en when locale is en', () => {
-        expect(wrapper.findAll('a.nav-link').at(0).attributes('href')).toEqual(
-          'https://gradido.net/en',
-        )
-      })
-
       it('has a link to the legal notice', () => {
-        expect(wrapper.findAll('a.nav-link').at(1).text()).toEqual('imprint')
+        expect(wrapper.findAll('a.nav-link').at(0).text()).toEqual('imprint')
       })
 
       it('links to the https://gradido.net/en/impressum when locale is en', () => {
-        expect(wrapper.findAll('a.nav-link').at(1).attributes('href')).toEqual(
+        expect(wrapper.findAll('a.nav-link').at(0).attributes('href')).toEqual(
           'https://gradido.net/en/impressum/',
         )
       })
 
       it('has a link to the privacy policy', () => {
-        expect(wrapper.findAll('a.nav-link').at(2).text()).toEqual('privacy_policy')
+        expect(wrapper.findAll('a.nav-link').at(1).text()).toEqual('privacy_policy')
       })
 
       it('links to the https://gradido.net/en/datenschutz when locale is en', () => {
-        expect(wrapper.findAll('a.nav-link').at(2).attributes('href')).toEqual(
+        expect(wrapper.findAll('a.nav-link').at(1).attributes('href')).toEqual(
           'https://gradido.net/en/datenschutz/',
+        )
+      })
+
+      it('has a link to the members area', () => {
+        expect(wrapper.findAll('a.nav-link').at(2).text()).toEqual('members_area')
+      })
+
+      it('links to the elopage', () => {
+        expect(wrapper.findAll('a.nav-link').at(2).attributes('href')).toEqual(
+          'https://elopage.com/s/gradido/sign_in?locale=en',
         )
       })
 
@@ -82,20 +98,26 @@ describe('ContentFooter', () => {
         })
 
         it('links to the https://gradido.net/de when locale is de', () => {
-          expect(wrapper.findAll('a.nav-link').at(0).attributes('href')).toEqual(
+          expect(wrapper.find('div.copyright').find('a').attributes('href')).toEqual(
             'https://gradido.net/de',
           )
         })
 
         it('links to the https://gradido.net/de/impressum when locale is de', () => {
-          expect(wrapper.findAll('a.nav-link').at(1).attributes('href')).toEqual(
+          expect(wrapper.findAll('a.nav-link').at(0).attributes('href')).toEqual(
             'https://gradido.net/de/impressum/',
           )
         })
 
         it('links to the https://gradido.net/de/datenschutz when locale is de', () => {
-          expect(wrapper.findAll('a.nav-link').at(2).attributes('href')).toEqual(
+          expect(wrapper.findAll('a.nav-link').at(1).attributes('href')).toEqual(
             'https://gradido.net/de/datenschutz/',
+          )
+        })
+
+        it('links to the German elopage when locale is de', () => {
+          expect(wrapper.findAll('a.nav-link').at(2).attributes('href')).toEqual(
+            'https://elopage.com/s/gradido/sign_in?locale=de',
           )
         })
       })

--- a/frontend/src/views/Layout/ContentFooter.vue
+++ b/frontend/src/views/Layout/ContentFooter.vue
@@ -4,10 +4,12 @@
       <b-col>
         <div class="copyright text-center text-lg-center text-muted">
           © {{ year }}
-          <a href="#/Login" class="font-weight-bold ml-1">Gradido-Akademie</a>
+          <a :href="`https://gradido.net/${$i18n.locale}`" class="font-weight-bold ml-1">
+            Gradido-Akademie
+          </a>
           |
           <a href="https://github.com/gradido/gradido/releases/latest" target="_blank">
-            App Verion {{ version }}
+            App version {{ version }}
           </a>
         </div>
       </b-col>
@@ -15,9 +17,6 @@
     <b-row align-v="center" class="justify-content-lg-between">
       <b-col>
         <b-nav class="nav-footer justify-content-center">
-          <b-nav-item :href="`https://gradido.net/${$i18n.locale}`" target="_blank">
-            Gradido
-          </b-nav-item>
           <b-nav-item :href="`https://gradido.net/${$i18n.locale}/impressum/`" target="_blank">
             {{ $t('imprint') }}
           </b-nav-item>


### PR DESCRIPTION
## 🍰 Pullrequest
 * remove Gradido in foorline of content footer
 * replace link of Gradido-Akademie in copyright line of footer
 * test version in copyright line
 * test link to member area
 
### Issues
- fixes #105 
