### PR TITLE
correct auto-increment basis for id in transactions

### DIFF
--- a/community_server/src/Model/Transactions/Transaction.php
+++ b/community_server/src/Model/Transactions/Transaction.php
@@ -148,6 +148,13 @@ class Transaction extends TransactionBase {
        if (!$this->mTransactionBody->save($this->getFirstPublic(), $this->mProtoTransaction->getSigMap())) {
           $this->addErrors($this->mTransactionBody->getErrors());
           $connection->rollback();
+          // correct auto-increment value to prevent gaps
+          $transactionsTable = $this->getTable('transactions');
+          $transactions = $transactionsTable->find()->select(['id'])->contain(false);
+          $count = $transactions->count();
+          $connection = ConnectionManager::get('default');
+          $connection->execute("ALTER TABLE `transactions` auto_increment = $count;");
+          
           return false;
       }
       

--- a/community_server/src/Model/Transactions/TransactionBody.php
+++ b/community_server/src/Model/Transactions/TransactionBody.php
@@ -76,10 +76,9 @@ class TransactionBody extends TransactionBase {
       
       $transactionEntity->transaction_type_id = $this->transactionTypeId;
       $transactionEntity->memo = $this->getMemo();
+      $transactionEntity->received = new Date();
       
       if ($transactionsTable->save($transactionEntity)) {
-          // reload entity to get received date filled from mysql
-        $transactionEntity = $transactionsTable->get($transactionEntity->id);
         // success
         $this->mTransactionID = $transactionEntity->id;
         if(!$this->mSpecificTransaction->save($transactionEntity->id, $firstPublic, $transactionEntity->received)) {

--- a/community_server/src/Model/Transactions/TransactionBody.php
+++ b/community_server/src/Model/Transactions/TransactionBody.php
@@ -76,9 +76,10 @@ class TransactionBody extends TransactionBase {
       
       $transactionEntity->transaction_type_id = $this->transactionTypeId;
       $transactionEntity->memo = $this->getMemo();
-      $transactionEntity->received = new Date();
       
       if ($transactionsTable->save($transactionEntity)) {
+          // reload entity to get received date filled from mysql
+        $transactionEntity = $transactionsTable->get($transactionEntity->id);
         // success
         $this->mTransactionID = $transactionEntity->id;
         if(!$this->mSpecificTransaction->save($transactionEntity->id, $firstPublic, $transactionEntity->received)) {


### PR DESCRIPTION
## 🍰 Pullrequest
correct auto-increment basis for id in transactions

With blockchain type = db the mysql table transactions act mainly as ordering service,
the sequence number will be created by mysql auto-increment id. 
But if an error occure in code and mysql rollback was called, the next call to transactions insert deliver 
a higher id so a gap is created in blockchain. 
To prevent this, I added code which set auto-increment to the count of actually transaction entrys in db after rollback.