### PR TITLE
fix_nginx_docker

### DIFF
--- a/community_server/webroot/.htaccess
+++ b/community_server/webroot/.htaccess
@@ -1,5 +1,6 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
+    RewriteCond %{REQUEST_FILENAME} !^/vue
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
 </IfModule>

--- a/community_server/webroot/.htaccess
+++ b/community_server/webroot/.htaccess
@@ -1,6 +1,5 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
-    RewriteCond %{REQUEST_FILENAME} !^/vue
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
 </IfModule>

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,6 +8,8 @@ services:
     image: gradido/frontend:development
     build:
       target: development
+    networks:
+      - external-net
     environment:
       - NODE_ENV="development"
       # - DEBUG=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,13 @@ services:
       context: ./frontend
       target: production
     networks:
-      - external-net
+      - internal-net
     ports:
-      - 8080:8080
+      - 3000:3000
     environment:
       # Envs used in Dockerfile
       # - DOCKER_WORKDIR="/app"
-      # - PORT="8080"
+      # - PORT=3000
       - BUILD_DATE
       - BUILD_VERSION
       - BUILD_COMMIT

--- a/frontend/.env.dist
+++ b/frontend/.env.dist
@@ -1,3 +1,2 @@
 LOGIN_API_URL=http://localhost/login_api/
 COMMUNITY_API_URL=http://localhost/api/
-VUE_PATH=/vue

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,7 +15,7 @@ ENV BUILD_COMMIT="0000000"
 ## SET NODE_ENV
 ENV NODE_ENV="production"
 ## App relevant Envs
-ENV PORT="8080"
+ENV PORT="3000"
 
 # Labels
 LABEL org.label-schema.build-date="${BUILD_DATE}"
@@ -82,15 +82,14 @@ FROM base as production
 
 # Copy "binary"-files from build image
 COPY --from=build ${DOCKER_WORKDIR}/dist ./dist
-#COPY --from=build ${DOCKER_WORKDIR}/node_modules ./node_modules
-#COPY --from=build ${DOCKER_WORKDIR}/nuxt.config.js ./nuxt.config.js
+# We also copy the node_modules express and serve-static for the run script
+COPY --from=build ${DOCKER_WORKDIR}/node_modules ./node_modules
 # Copy static files
-# TODO - this should be one Folder containign all stuff needed to be copied
-#COPY --from=build ${DOCKER_WORKDIR}/constants ./constants
-#COPY --from=build ${DOCKER_WORKDIR}/static ./static
-#COPY --from=build ${DOCKER_WORKDIR}/locales ./locales
+COPY --from=build ${DOCKER_WORKDIR}/public ./public
 # Copy package.json for script definitions (lock file should not be needed)
 COPY --from=build ${DOCKER_WORKDIR}/package.json ./package.json
+# Copy run scripts run/
+COPY --from=build ${DOCKER_WORKDIR}/run ./run
 
 # Run command
 CMD /bin/sh -c "yarn run start"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.9.4",
   "private": true,
   "scripts": {
-    "start": "node server.js",
+    "start": "node run/server.js",
     "serve": "vue-cli-service serve --open",
     "build": "vue-cli-service build",
     "lint": "eslint --ext .js,.vue .",

--- a/frontend/run/server.js
+++ b/frontend/run/server.js
@@ -1,0 +1,14 @@
+// Imports
+const express = require('express')
+const serveStatic = require('serve-static')
+
+// Port
+const port = process.env.PORT || 3000
+
+// Express Server
+const app = express()
+app.use(serveStatic(__dirname + '/../dist'))
+app.listen(port)
+
+// eslint-disable-next-line no-console
+console.log(`http://frontend:${port} server started.`)

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,7 +1,0 @@
-var express = require('express')
-var serveStatic = require('serve-static')
-var app = express()
-app.use(serveStatic(__dirname + '/dist'))
-var port = process.env.PORT || 5000
-app.listen(port)
-// console.log('http://localhost:5000 server started.');

--- a/frontend/src/routes/router.js
+++ b/frontend/src/routes/router.js
@@ -6,6 +6,7 @@ Vue.use(VueRouter)
 
 // configure router
 const router = new VueRouter({
+  base: '/vue',
   routes, // short for routes: routes
   linkActiveClass: 'active',
   mode: 'history',

--- a/frontend/src/views/KontoOverview/GddSend.vue
+++ b/frontend/src/views/KontoOverview/GddSend.vue
@@ -10,7 +10,7 @@
             <span class="alert-text" v-html="$t('form.scann_code')"></span>
             <b-col v-show="!scan" lg="12" class="text-right">
               <a @click="toggle" class="nav-link pointer">
-                <img src="/img/icons/gradido/qr-scan-pure.png" height="50" />
+                <img src="img/icons/gradido/qr-scan-pure.png" height="50" />
               </a>
             </b-col>
 

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -15,7 +15,7 @@ module.exports = {
     },
   },
   lintOnSave: true,
-  // publicPath: '/',
+  publicPath: '/vue',
   configureWebpack: {
     // Set up all the aliases we use in our app.
     resolve: {

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,17 +1,11 @@
 const path = require('path')
 const dotenv = require('dotenv-webpack')
 
-function resolveSrc(_path) {
-  return path.join(__dirname, _path)
-}
-
-let vue_path = process.env.VUE_PATH
-if (vue_path == undefined) {
-  vue_path = '/vue'
-}
-
 // vue.config.js
 module.exports = {
+  devServer: {
+    port: process.env.PORT || 3000,
+  },
   pluginOptions: {
     i18n: {
       locale: 'de',
@@ -21,12 +15,12 @@ module.exports = {
     },
   },
   lintOnSave: true,
-  publicPath: vue_path + '/',
+  // publicPath: '/',
   configureWebpack: {
     // Set up all the aliases we use in our app.
     resolve: {
       alias: {
-        assets: resolveSrc('src/assets'),
+        assets: path.join(__dirname, 'src/assets'),
       },
     },
     plugins: [new dotenv()],
@@ -35,5 +29,5 @@ module.exports = {
     // Enable CSS source maps.
     sourceMap: process.env.NODE_ENV !== 'production',
   },
-  outputDir: path.resolve(__dirname, './dist' + vue_path),
+  outputDir: path.resolve(__dirname, './dist'),
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,3 @@
-
-
 server {
 
 	listen 80 ;
@@ -8,12 +6,10 @@ server {
 
 	#include /etc/nginx/common/protect.conf;
 	#include /etc/nginx/common/protect_add_header.conf;
-	#include /etc/nginx/common/ssl.conf;
-	
+	#include /etc/nginx/common/ssl.conf;	
 	
 	root /var/www/cakephp/webroot;
-	index index.php;	
-	
+	index index.php;
 
 	location ~ \.php$ {
 	  fastcgi_pass community-server:9000;
@@ -23,7 +19,6 @@ server {
 	  fastcgi_buffers 16 16k;
 	  fastcgi_buffer_size 32k;
 	  include fastcgi_params;
-
 	}
 
 	location ~ /\.ht {
@@ -31,65 +26,49 @@ server {
 	}
 
 	location /account {
-			proxy_http_version 1.1;
-			proxy_set_header    Upgrade $http_upgrade;
-			proxy_set_header    Connection 'upgrade';
-			proxy_cache_bypass  $http_upgrade;
-			proxy_set_header    X-Real-IP  $remote_addr;
-			proxy_set_header    X-Forwarded-For $remote_addr;
-			proxy_set_header    Host $host;
-			rewrite  /account/(.*) /$1 break;
-			
-			#proxy_next_upstream error timeout invalid_header http_502 non_idempotent;
-			proxy_pass          http://login-server:1200;
-			proxy_redirect      off;
+		proxy_http_version 1.1;
+		proxy_set_header    Upgrade $http_upgrade;
+		proxy_set_header    Connection 'upgrade';
+		proxy_cache_bypass  $http_upgrade;
+		proxy_set_header    X-Real-IP  $remote_addr;
+		proxy_set_header    X-Forwarded-For $remote_addr;
+		proxy_set_header    Host $host;
+		rewrite  /account/(.*) /$1 break;
 
-
+		proxy_pass          http://login-server:1200;
+		proxy_redirect      off;
 	}
 	
 	location /login_api {
-			proxy_http_version 1.1;
-			proxy_set_header    Upgrade $http_upgrade;
-			proxy_set_header    Connection 'upgrade';
-			proxy_cache_bypass  $http_upgrade;
-			proxy_set_header    X-Real-IP  $remote_addr;
-			proxy_set_header    X-Forwarded-For $remote_addr;
-			proxy_set_header    Host $host;
-			rewrite  /login_api/(.*) /$1 break;
-			
-			proxy_pass          http://login-server:1201;
-			proxy_redirect      off;
+		proxy_http_version 1.1;
+		proxy_set_header    Upgrade $http_upgrade;
+		proxy_set_header    Connection 'upgrade';
+		proxy_cache_bypass  $http_upgrade;
+		proxy_set_header    X-Real-IP  $remote_addr;
+		proxy_set_header    X-Forwarded-For $remote_addr;
+		proxy_set_header    Host $host;
+		rewrite  /login_api/(.*) /$1 break;
+
+		proxy_pass          http://login-server:1201;
+		proxy_redirect      off;
 	}
 
 	location / {
-			try_files $uri $uri/ /index.php?$args;
+		try_files $uri $uri/ /index.php?$args;
 	}
 	
 	location /vue {
-
-		location /vue/sockjs-node {
-			rewrite  /vue/(.*) /$1;
-		}
-		location ~* \.(png) {
-			expires 1d;
-			rewrite  /vue/(.*) /$1;
-		}
-
-    #try_files /vue/$uri /vue/$uri/ /index.html;
-
 		proxy_http_version 1.1;
 		proxy_set_header   Upgrade $http_upgrade;
 		proxy_set_header   Connection 'upgrade';
 		proxy_set_header   X-Forwarded-For $remote_addr;
 		proxy_set_header   X-Real-IP  $remote_addr;
 		proxy_set_header   Host $host;
-		#rewrite  /vue/(.*) /$1 break;
-
-		proxy_pass         http://frontend:8080;
+		
+		proxy_pass         http://frontend:3000;
 		proxy_redirect     off;
 	}
 
 #	access_log /var/log/nginx/access.log main;
- 
 
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -69,6 +69,18 @@ server {
 		proxy_redirect     off;
 	}
 
+	location /sockjs-node {
+		proxy_http_version 1.1;
+		proxy_set_header   Upgrade $http_upgrade;
+		proxy_set_header   Connection 'upgrade';
+		proxy_set_header   X-Forwarded-For $remote_addr;
+		proxy_set_header   X-Real-IP  $remote_addr;
+		proxy_set_header   Host $host;
+		
+		proxy_pass         http://frontend:3000;
+		proxy_redirect     off;
+	}
+
 #	access_log /var/log/nginx/access.log main;
 
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### The docker part

fixed frontend production docker build & refactored frontend file structure

- frontend server runs on port 3000 by default
- frontend production docker build successfully runs & builds
- frontend production docker build is no longer reachable from the outside
- moved server.js in subfolder run/

### The nginx part
nginx fix for vue interface

- localhost/vue resolves to frontend
- localhost:3000/vue resolves to frontend in development
- images are resolved properly
- remaining services are reachable as normal
- fixed image path to be relative instead of absolute
- cleaned nginx config

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #192 (fully fixed)
- fixes #131 (the path will not be configurable it has to many implications and need cross service environment variables. We should switch at a given time from old frontend to new frontend and make an adjustment. Still this issue will be closed since its no longer applicable)
- fixes #104 (finalize this issue, last remaining point: have nginx working)
- fixes #191 (no more flickering 404s should appear)
- relates #130 (fixes routing)

### Todo
<!-- In case some parts are still missing, list them here. -->
- [x] Docker
- [x] Nginx
- [x] Describe and inform team about implications
- [x] Check which issues can actually be closed, which are partially fixed and which are not targeted
- [x] Describe how to test

### How to test:

1. Build docker debug images `docker-compose up --build`
2. You should now be able to reach `localhost/vue` and `localhost:3000/vue`, You should not be able to get a useful response `localhost:8080` nor `localhost:3000`
3. Test if everything is reachable as usual on `localhost/vue` and `localhost:3000/vue`:
   - login api calls work (login)
   - community api calls work (transaction list)
   - all images
   - any 404 pages?
4. Shut down the dockers `docker-compose down
5. Start and build docker environment in production mode: `docker-compose -f docker-compose.yml up --build`
6. You should now be able to reach `localhost/vue`, but you should not be able to reach `localhost:3000`, `localhost:3000/vue` nor `localhost:8080`
7. Finally test if everything is reachable as usual on `localhost/vue` and `localhost:3000/vue`:
   - login api calls work (login)
   - community api calls work (transaction list)
   - all images
   - any 404 pages?
   
### Implications (to be published on Discord)

1. You have to rebuild with `docker-compose up --build`
2. You can no longer reach the frontend with localhost:8080, you need to use either `localhost:3000/vue` or `localhost/vue`