### PR TITLE
feat: Update Transactions When GddTable Is Rendered

### DIFF
--- a/frontend/src/views/Layout/DashboardLayout_gdd.vue
+++ b/frontend/src/views/Layout/DashboardLayout_gdd.vue
@@ -32,6 +32,7 @@
             :balance="balance"
             :gdt-balance="GdtBalance"
             :transactions="transactions"
+            :transactionCount="transactionCount"
             @update-balance="updateBalance"
             @update-transactions="updateTransactions"
           ></router-view>
@@ -80,6 +81,7 @@ export default {
       GdtBalance: 0,
       transactions: [],
       bookedBalance: 0,
+      transactionCount: 0,
     }
   },
   methods: {
@@ -102,6 +104,7 @@ export default {
         this.transactions = result.result.data.transactions
         this.balance = Number(result.result.data.decay)
         this.bookedBalance = Number(result.result.data.balance)
+        this.transactionCount = result.result.data.count
       } else {
         // what to do when loading balance fails?
       }

--- a/frontend/src/views/Pages/AccountOverview.vue
+++ b/frontend/src/views/Pages/AccountOverview.vue
@@ -15,6 +15,8 @@
         v-if="showTransactionList"
         :transactions="transactions"
         :max="5"
+        :timestamp="timestamp"
+        :transactionCount="transactionCount"
         @update-transactions="updateTransactions"
       />
     </b-container>
@@ -30,6 +32,7 @@ export default {
   data() {
     return {
       showTransactionList: true,
+      timestamp: Date.now(),
     }
   },
   props: {
@@ -38,6 +41,7 @@ export default {
     transactions: {
       default: () => [],
     },
+    transactionCount: { type: Number, default: 0 },
   },
   components: {
     GddStatus,

--- a/frontend/src/views/Pages/AccountOverview/GddTable.vue
+++ b/frontend/src/views/Pages/AccountOverview/GddTable.vue
@@ -95,7 +95,7 @@
         <router-link
           v-else-if="transactions.length > 5"
           to="/transactions"
-          v-html="$t('transaction.show_all', { count: count })"
+          v-html="$t('transaction.show_all', { count: transactionCount })"
         ></router-link>
       </b-list-group-item>
     </b-list-group>
@@ -108,37 +108,25 @@ export default {
   props: {
     transactions: { default: [] },
     max: { type: Number, default: 25 },
+    timestamp: { type: Number, default: 0 },
+    transactionCount: { type: Number, default: 0 },
   },
   data() {
     return {
       form: [],
       fields: ['balance', 'date', 'memo', 'name', 'transaction_id', 'type', 'details'],
       items: [],
-      count: 0,
     }
   },
-  created() {
-    this.$emit('change-transactions')
-  },
-  computed: {
-    filteredItems() {
-      return this.ojectToArray(this.items).reverse()
+  watch: {
+    timestamp: {
+      immediate: true,
+      handler: 'updateTransactions',
     },
   },
   methods: {
-    ojectToArray(obj) {
-      let result = new Array(Object.keys(obj).length)
-      Object.entries(obj).forEach((entry) => {
-        const [key, value] = entry
-        result[key] = value
-      })
-      return result
-    },
-    rowClass(item, type) {
-      if (!item || type !== 'row') return
-      if (item.type === 'receive') return 'table-success'
-      if (item.type === 'send') return 'table-warning'
-      if (item.type === 'creation') return 'table-primary'
+    updateTransactions() {
+      this.$emit('update-transactions')
     },
   },
 }

--- a/frontend/src/views/Pages/UserProfileTransactionList.vue
+++ b/frontend/src/views/Pages/UserProfileTransactionList.vue
@@ -7,7 +7,12 @@
     <b-container fluid class="mt--6">
       <b-row>
         <b-col class="order-xl-1">
-          <gdd-table :transactions="transactions" @update-transactions="updateTransactions" />
+          <gdd-table
+            :timestamp="timestamp"
+            :transactionCount="transactionCount"
+            :transactions="transactions"
+            @update-transactions="updateTransactions"
+          />
         </b-col>
       </b-row>
       <b-row class="text-center mb-6" v-if="transactions.length == 0">
@@ -27,6 +32,12 @@ export default {
     transactions: {
       default: [],
     },
+    transactionCount: { type: Number, default: 0 },
+  },
+  data() {
+    return {
+      timestamp: Date.now(),
+    }
   },
   methods: {
     updateTransactions() {


### PR DESCRIPTION
## 🍰 Pullrequest
 * whenever GddTable is rendered by another parent, it triggers an API call to update the transaction list
 * track number of transactions as property an have it available in GddTable

### Issues
is there one?
