### PR TITLE
spelling & translation

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -3,7 +3,7 @@
   "welcome":"Willkommen!",
   "community": "Gemeinschaft",
   "logout":"Abmelden",
-  "login":"Login",
+  "login":"Anmeldung",
   "signup": "Registrieren",
   "reset": "Passwort zurücksetzen",
   "imprint":"Impressum",
@@ -13,7 +13,7 @@
   "back":"Zurück",
   "send":"Senden",
   "transactions":"Transaktionen",
-  "language":"Language",
+  "language":"Sprache",
   "languages":{
     "de": "Deutsch",
     "en": "English"
@@ -117,7 +117,7 @@
     }
   },
   "reset-password": {
-    "title": "Passwort Zurücksetzen",
-    "text": "Jetzt kannst du ein neues Passwort speichern, mit dem du dich zukünfitg in der GRADIDO App anmelden kannst."
+    "title": "Passwort zurücksetzen",
+    "text": "Jetzt kannst du ein neues Passwort speichern, mit dem du dich zukünftig in der Gradido-App anmelden kannst."
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -13,7 +13,7 @@
   "back":"Back",
   "send":"Send",
   "transactions":"Transactions",
-  "language":"languages",
+  "language":"Language",
   "languages":{
     "de": "Deutsch",
     "en": "English"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -13,7 +13,7 @@
   "back":"Back",
   "send":"Send",
   "transactions":"Transactions",
-  "language":"Sprache",
+  "language":"languages",
   "languages":{
     "de": "Deutsch",
     "en": "English"
@@ -119,6 +119,6 @@
   },
   "reset-password": {
     "title": "Reset Password",
-    "text": "Now you can save a new password to login to the GRADIDO App in the future."
+    "text": "Now you can save a new password to login to the Gradido-App in the future."
   }
 }

--- a/frontend/src/views/Pages/AccountOverview/GddSend.vue
+++ b/frontend/src/views/Pages/AccountOverview/GddSend.vue
@@ -184,7 +184,6 @@
         </div>
 
         <b-button variant="success" @click="onReset">{{ $t('form.close') }}</b-button>
-        <hr />
       </b-col>
     </b-row>
   </div>


### PR DESCRIPTION
## 🍰 Pullrequest

      -  Spelling: Password reset has spelling mistake - zukünftig
      -  Spelling: Password reset has GRADIDO in CAPS, should not be caps.
      -  Translate: Sprache - en must be Language - en , same for the German equivalent
      -  Translate: Login heading is not translated should be Anmeldung
      -  Design: On the 3. Send GDD page there is two horizontal lines below the "Thanks... [Button]" part. Remove one.
 
teil von : #350 