### PR TITLE
fix: Set Maximum Transactions Loaded  to 1000

### DIFF
--- a/frontend/src/apis/communityAPI.js
+++ b/frontend/src/apis/communityAPI.js
@@ -35,7 +35,7 @@ const communityAPI = {
   balance: async (sessionId) => {
     return apiGet(CONFIG.COMMUNITY_API_URL + 'getBalance/' + sessionId)
   },
-  transactions: async (sessionId, firstPage = 1, items = 25, order = 'DESC') => {
+  transactions: async (sessionId, firstPage = 1, items = 1000, order = 'DESC') => {
     return apiGet(
       `${CONFIG.COMMUNITY_API_URL}listTransactions/${firstPage}/${items}/${order}/${sessionId}`,
     )


### PR DESCRIPTION
## 🍰 Pullrequest
As we do not have pagination so far, we request 1000 transactions, to make sure, the user sees all transactions.


