### PR TITLE
Hide unuse components in profil

### DIFF
--- a/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.spec.js
+++ b/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.spec.js
@@ -61,7 +61,7 @@ describe('GddSend', () => {
         })
 
         it('has an GDD text icon', () => {
-          expect(wrapper.find('#input-group-2').find('div.h4').text()).toBe('GDD')
+          expect(wrapper.find('#input-group-2').find('div.m-1').text()).toBe('GDD')
         })
 
         it('has a label form.amount', () => {

--- a/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.vue
+++ b/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.vue
@@ -29,11 +29,12 @@
                 <label class="input-1" for="input-1">{{ $t('form.receiver') }}</label>
                 <b-input-group
                   id="input-group-1"
+                  class="border border-default"
                   description="We'll never share your email with anyone else."
                   size="lg"
                 >
-                  <b-input-group-prepend class="p-2 d-none d-md-block">
-                    <b-icon icon="envelope" class="display-3"></b-icon>
+                  <b-input-group-prepend class="d-none d-md-block">
+                    <b-icon icon="envelope" class="display-4 m-3"></b-icon>
                   </b-input-group-prepend>
                   <b-form-input
                     id="input-1"
@@ -67,9 +68,9 @@
                   </b-col>
                 </b-row>
                 <label class="input-2" for="input-2">{{ $t('form.amount') }}</label>
-                <b-input-group id="input-group-2" size="lg">
+                <b-input-group id="input-group-2" class="border border-default" size="lg">
                   <b-input-group-prepend class="p-2 d-none d-md-block">
-                    <div class="h4 pt-2 pr-2">GDD</div>
+                    <div class="m-1 mt-2">GDD</div>
                   </b-input-group-prepend>
 
                   <b-form-input
@@ -103,9 +104,9 @@
                   </b-col>
                 </b-row>
                 <label class="input-3" for="input-3">{{ $t('form.memo') }}</label>
-                <b-input-group id="input-group-3">
+                <b-input-group id="input-group-3" class="border border-default">
                   <b-input-group-prepend class="d-none d-md-block">
-                    <b-icon icon="chat-right-text" class="display-3 mr-3"></b-icon>
+                    <b-icon icon="chat-right-text" class="display-4 m-3 mt-4"></b-icon>
                   </b-input-group-prepend>
                   <b-form-textarea
                     id="input-3"

--- a/frontend/src/views/Pages/UserProfile/UserCard.vue
+++ b/frontend/src/views/Pages/UserProfile/UserCard.vue
@@ -8,7 +8,7 @@
         <div class="card-profile-stats d-flex justify-content-center mt-md-5">
           <div>
             <span class="heading">
-              {{ $n(balance) }}
+              {{ $n(balance, 'decimal') }}
             </span>
             <span class="description">GDD</span>
           </div>

--- a/frontend/src/views/Pages/UserProfile/UserCard_FormUserData.vue
+++ b/frontend/src/views/Pages/UserProfile/UserCard_FormUserData.vue
@@ -52,7 +52,7 @@
               <b-input type="text" v-model="form.lastName"></b-input>
             </b-col>
           </b-row>
-          <b-row class="mb-3">
+          <b-row class="mb-3" v-show="false">
             <b-col class="col-12 col-lg-3 col-md-10 col-sm-10 text-md-left text-lg-right">
               <small>{{ $t('form.description') }}</small>
             </b-col>

--- a/frontend/src/views/Pages/UserProfileOverview.spec.js
+++ b/frontend/src/views/Pages/UserProfileOverview.spec.js
@@ -27,9 +27,9 @@ describe('UserProfileOverview', () => {
       expect(wrapper.findComponent({ name: 'FormUserData' }).exists()).toBeTruthy()
     })
 
-    //it('has a user name form', () => {
+    // it('has a user name form', () => {
     //  expect(wrapper.findComponent({ name: 'FormUsername' }).exists()).toBeTruthy()
-    //})
+    // })
 
     it('has a user password form', () => {
       expect(wrapper.findComponent({ name: 'FormUserPasswort' }).exists()).toBeTruthy()

--- a/frontend/src/views/Pages/UserProfileOverview.spec.js
+++ b/frontend/src/views/Pages/UserProfileOverview.spec.js
@@ -27,9 +27,9 @@ describe('UserProfileOverview', () => {
       expect(wrapper.findComponent({ name: 'FormUserData' }).exists()).toBeTruthy()
     })
 
-    it('has a user name form', () => {
-      expect(wrapper.findComponent({ name: 'FormUsername' }).exists()).toBeTruthy()
-    })
+    //it('has a user name form', () => {
+    //  expect(wrapper.findComponent({ name: 'FormUsername' }).exists()).toBeTruthy()
+    //})
 
     it('has a user password form', () => {
       expect(wrapper.findComponent({ name: 'FormUserPasswort' }).exists()).toBeTruthy()

--- a/frontend/src/views/Pages/UserProfileOverview.vue
+++ b/frontend/src/views/Pages/UserProfileOverview.vue
@@ -2,21 +2,21 @@
   <b-container fluid>
     <user-card :balance="balance" :transactionCount="transactionCount"></user-card>
     <form-user-data />
-    <form-username />
+    <!--<form-username />-->
     <form-user-passwort />
   </b-container>
 </template>
 <script>
 import UserCard from './UserProfile/UserCard.vue'
 import FormUserData from './UserProfile/UserCard_FormUserData.vue'
-import FormUsername from './UserProfile/UserCard_FormUsername.vue'
+// import FormUsername from './UserProfile/UserCard_FormUsername.vue'
 import FormUserPasswort from './UserProfile/UserCard_FormUserPasswort.vue'
 
 export default {
   components: {
     UserCard,
     FormUserData,
-    FormUsername,
+    // FormUsername,
     FormUserPasswort,
   },
   props: {


### PR DESCRIPTION
## 🍰 Pullrequest
 border to send input fields from gdd. 
 components that are not used in the profile are disabled until used. 
![FireShot Capture 687 - Gradido Account - localhost](https://user-images.githubusercontent.com/1324583/122238290-4fa22080-cec0-11eb-9ff5-e5ce74d7a1e8.png)
![FireShot Capture 688 - Gradido Account - localhost](https://user-images.githubusercontent.com/1324583/122238297-503ab700-cec0-11eb-9638-a0082188d1e3.png)

