### PR TITLE
fix: Thousend Dividers on GDD Send Amount Field

### DIFF
--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -38,12 +38,24 @@ const numberFormats = {
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
     },
+    ungroupedDecimal: {
+      style: 'decimal',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+      useGrouping: false,
+    },
   },
   de: {
     decimal: {
       style: 'decimal',
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
+    },
+    ungroupedDecimal: {
+      style: 'decimal',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+      useGrouping: false,
     },
   },
 }

--- a/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.vue
+++ b/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.vue
@@ -188,7 +188,7 @@ export default {
       this.amountFocused = false
       if (!isValid) return
       this.form.amountValue = Number(this.form.amount.replace(',', '.'))
-      this.form.amount = this.$n(this.form.amountValue, 'decimal')
+      this.form.amount = this.$n(this.form.amountValue, 'ungroupedDecimal')
     },
     normalizeEmail() {
       this.emailFocused = false


### PR DESCRIPTION
## 🍰 Pullrequest
Do not show the dividers of numbers > 1000. E.g show `12345.00` instead of `12,345.00`


