### PR TITLE
update transfer email text

### DIFF
--- a/community_server/src/Template/Email/text/notification_transfer.ctp
+++ b/community_server/src/Template/Email/text/notification_transfer.ctp
@@ -8,14 +8,19 @@
 $this->assign('title', __('Gradido Überweisung'));
 $receiverNames = $receiverUser->first_name . ' ' . $receiverUser->last_name;
 $senderNames = $senderUser->first_name . ' ' . $senderUser->last_name;
+$senderNamesEmail = $senderUser->getEmailWithName();
 ?><?= __('Hallo') ?> <?= $receiverNames ?>, 
  
-<?= __('Du hast soeben {0} von {1} erhalten.', $this->element('printGradido', ['number' => $gdd_cent, 'raw' => true]), $senderNames) ?> 
+<?= __('Du hast soeben {0} von {1} erhalten.', $this->element('printGradido', ['number' => $gdd_cent, 'raw' => true]), $senderNamesEmail) ?> 
 <?= __('{0} schreibt:', $senderNames) ?> 
  
 <?= $memo ?> 
  
 <?= __('Bitte antworte nicht auf diese E-Mail!'); ?> 
+<?= __('Wenn Du ') . $senderNames . __(' per E-Mail  antworten willst, schreibe stattdessen an die Adresse: '); ?>
+
+<?= $senderUser->email ?>
+
  
 <?= __('Mit freundlichen Grüßen'); ?> 
 Gradido Community Server


### PR DESCRIPTION
## 🍰 Pullrequest
Because of problems with strato I have removed the reply-to transaction sender function in Gradido Transfer transaction commit E-Mails and update the text instead such that the Email Address from Sender of the Gradido Transaction is sended in E-Mail text. 
