### PR TITLE
fix: Do Not Pass Userdata Description to Server

### DIFF
--- a/frontend/src/apis/loginAPI.js
+++ b/frontend/src/apis/loginAPI.js
@@ -93,7 +93,7 @@ const loginAPI = {
       update: {
         'User.first_name': data.firstName,
         'User.last_name': data.lastName,
-        //'User.description': data.description,
+        // 'User.description': data.description,
       },
     }
     return apiPost(CONFIG.LOGIN_API_URL + 'updateUserInfos', payload)

--- a/frontend/src/apis/loginAPI.js
+++ b/frontend/src/apis/loginAPI.js
@@ -93,7 +93,7 @@ const loginAPI = {
       update: {
         'User.first_name': data.firstName,
         'User.last_name': data.lastName,
-        'User.description': data.description,
+        //'User.description': data.description,
       },
     }
     return apiPost(CONFIG.LOGIN_API_URL + 'updateUserInfos', payload)


### PR DESCRIPTION
## 🍰 Pullrequest
The server does not accept an empty description for the user profile. As we do not use description so far, it is always empty. This means, that the user profile cannot be updated.

### Issues
- relates #616

### Todo
- [ ] Allow empty description on the server
