### PR TITLE
Login fix crash

### DIFF
--- a/community_server/src/Model/Table/TransactionsTable.php
+++ b/community_server/src/Model/Table/TransactionsTable.php
@@ -168,7 +168,11 @@ class TransactionsTable extends Table
         if($decay_start_transaction->count()) {
             $decay_start_transaction_id = $decay_start_transaction->first()->id;
         }
-        $decay_start_time = $stateBalancesTable->getDecayStartDateCached()->getTimestamp();
+        $decay_start_date = $stateBalancesTable->getDecayStartDateCached();
+        $decay_start_time = 0;
+        if($decay_start_date) {
+            $decay_start_time = $decay_start_date->getTimestamp();
+        }
         
         foreach($stateUserTransactions as $i => $su_transaction)
         {
@@ -206,7 +210,7 @@ class TransactionsTable extends Table
                           'decay_start' => $calculated_decay['start_date'],
                           'decay_end' => $calculated_decay['end_date']
                       ]; 
-                      if($prev->transaction_id < $decay_start_transaction_id && 
+                      if($decay_start_time && $prev->transaction_id < $decay_start_transaction_id && 
                          $current->transaction_id > $decay_start_transaction_id) {
                          $final_transaction['decay']['decay_start_block'] = $decay_start_time;
                       }

--- a/login_server/src/cpp/SingletonManager/PendingTasksManager.cpp
+++ b/login_server/src/cpp/SingletonManager/PendingTasksManager.cpp
@@ -162,10 +162,13 @@ std::vector<Poco::AutoPtr<model::gradido::Transaction>> PendingTasksManager::get
 	// TODO: don't use cast here, because can lead to errors
 	Poco::ScopedLock<Poco::Mutex> _lock(mWorkMutex);
 	std::vector<Poco::AutoPtr<model::gradido::Transaction>> transactions_to_sign;
+<<<<<<< HEAD
 
 	if (user->getModel()->getRole() != model::table::ROLE_ADMIN) {
 		return transactions_to_sign;
 	}
+=======
+>>>>>>> Remove dynamic cast because it lead to errors again and agin (Poco::AutoPtr don't work correct with that)
 
 	for (auto map_it = mPendingGradidoTransactions.begin(); map_it != mPendingGradidoTransactions.end(); map_it++)
 	{

--- a/login_server/src/cpp/SingletonManager/PendingTasksManager.cpp
+++ b/login_server/src/cpp/SingletonManager/PendingTasksManager.cpp
@@ -15,10 +15,10 @@ PendingTasksManager::~PendingTasksManager()
 	Poco::ScopedLock<Poco::Mutex> _lock(mWorkMutex);
 	mCheckForFinishedTimer.stop();
 
-	for (auto it = mPendingTasks.begin(); it != mPendingTasks.end(); it++) {
+	for (auto it = mPendingGradidoTransactions.begin(); it != mPendingGradidoTransactions.end(); it++) {
 		delete it->second;
 	}
-	mPendingTasks.clear();
+	mPendingGradidoTransactions.clear();
 }
 
 PendingTasksManager* PendingTasksManager::getInstance()
@@ -37,31 +37,32 @@ int PendingTasksManager::load()
 	return 0;
 }
 
-int PendingTasksManager::addTask(Poco::AutoPtr<controller::PendingTask> task)
+
+int PendingTasksManager::addTask(Poco::AutoPtr<model::gradido::Transaction> gradidoTransactionTask)
 {
-	if (task.isNull() || !task->getModel()) {
+	if (gradidoTransactionTask.isNull() || !gradidoTransactionTask->getModel()) {
 		return -1;
 	}
-	
-	auto model = task->getModel();
-	Poco::ScopedLock<Poco::Mutex> _lock(mWorkMutex);
-	auto pending_task_list = getTaskListForUser(model->getUserId());
-	pending_task_list->push_back(task);
-	return 0;
 
+	auto model = gradidoTransactionTask->getModel();
+	Poco::ScopedLock<Poco::Mutex> _lock(mWorkMutex);
+	auto pending_task_list = getGradidoTransactionsForUser(model->getUserId());
+	pending_task_list->push_back(gradidoTransactionTask);
+	return 0;
 }
 
-bool PendingTasksManager::removeTask(Poco::AutoPtr<controller::PendingTask> task)
+
+bool PendingTasksManager::removeTask(Poco::AutoPtr<model::gradido::Transaction> gradidoTransactionTask)
 {
-	if (task.isNull() || !task->getModel()) {
+	if (gradidoTransactionTask.isNull() || !gradidoTransactionTask->getModel()) {
 		return false;
 	}
-	auto model = task->getModel();
+	auto model = gradidoTransactionTask->getModel();
 	Poco::ScopedLock<Poco::Mutex> _lock(mWorkMutex);
-	auto pending_task_list = getTaskListForUser(model->getUserId());
+	auto pending_task_list = getGradidoTransactionsForUser(model->getUserId());
 	bool removed = false;
 	for (auto it = pending_task_list->begin(); it != pending_task_list->end(); it++) {
-		if (task.get() == it->get()) {
+		if (gradidoTransactionTask.get() == it->get()) {
 			pending_task_list->erase(it);
 			removed = true;
 			break;
@@ -71,41 +72,42 @@ bool PendingTasksManager::removeTask(Poco::AutoPtr<controller::PendingTask> task
 	return removed;
 }
 
-PendingTasksManager::PendingTaskList* PendingTasksManager::getTaskListForUser(int userId)
+
+PendingTasksManager::PendingGradidoTaskList* PendingTasksManager::getGradidoTransactionsForUser(int userId)
 {
 	Poco::ScopedLock<Poco::Mutex> _lock(mWorkMutex);
-	auto it = mPendingTasks.find(userId);
-	if (it == mPendingTasks.end()) {
-		auto pending_list = new PendingTaskList;
-		mPendingTasks.insert(std::pair<int, PendingTaskList*>(userId, pending_list));
+	auto it = mPendingGradidoTransactions.find(userId);
+	if (it == mPendingGradidoTransactions.end()) {
+		auto pending_list = new PendingGradidoTaskList;
+		mPendingGradidoTransactions.insert(std::pair<int, PendingGradidoTaskList*>(userId, pending_list));
 		return pending_list;
 	}
 	else {
 		return it->second;
 	}
-
 }
-const PendingTasksManager::PendingTaskList* PendingTasksManager::getTaskListForUser(int userId) const
+
+
+const PendingTasksManager::PendingGradidoTaskList* PendingTasksManager::getGradidoTransactionsForUser(int userId) const
 {
 	Poco::ScopedLock<Poco::Mutex> _lock(mWorkMutex);
-	auto it = mPendingTasks.find(userId);
-	if (it != mPendingTasks.end()) {
+	auto it = mPendingGradidoTransactions.find(userId);
+	if (it != mPendingGradidoTransactions.end()) {
 		return it->second;
 	}
 	return nullptr;
 }
 
-bool PendingTasksManager::hasPendingTask(Poco::AutoPtr<controller::User> user, model::table::TaskType type)
+bool PendingTasksManager::hasPendingGradidoTransaction(Poco::AutoPtr<controller::User> user, model::table::TaskType type)
 {
 	auto model = user->getModel();
 	int user_id = model->getID();
 	Poco::ScopedLock<Poco::Mutex> _lock(mWorkMutex);
-	auto it = mPendingTasks.find(user_id);
-	if (it != mPendingTasks.end()) {
+	auto it = mPendingGradidoTransactions.find(user_id);
+	if (it != mPendingGradidoTransactions.end()) {
 		auto task_list = it->second;
-		for (auto task = task_list->begin(); task != task_list->end(); it++) {
-			auto task_model = (*task)->getModel();
-			if (type == task_model->getTaskType()) {
+		for (auto taskIt = task_list->begin(); taskIt != task_list->end(); taskIt++) {
+			if ((*taskIt)->getModel()->getTaskType() == type) {
 				return true;
 			}
 		}
@@ -114,20 +116,21 @@ bool PendingTasksManager::hasPendingTask(Poco::AutoPtr<controller::User> user, m
 
 }
 
-std::vector<Poco::AutoPtr<controller::PendingTask>> PendingTasksManager::getPendingTasks(Poco::AutoPtr<controller::User> user, model::table::TaskType type)
+
+std::vector<Poco::AutoPtr<model::gradido::Transaction>> PendingTasksManager::getPendingGradidoTransactions(Poco::AutoPtr<controller::User> user, model::table::TaskType type)
 {
 	auto model = user->getModel();
 	int user_id = model->getID();
 	Poco::ScopedLock<Poco::Mutex> _lock(mWorkMutex);
-	std::vector<Poco::AutoPtr<controller::PendingTask>> results;
+	std::vector<Poco::AutoPtr<model::gradido::Transaction>> results;
 
-	auto it = mPendingTasks.find(user_id);
-	if (it != mPendingTasks.end()) {
+	auto it = mPendingGradidoTransactions.find(user_id);
+	if (it != mPendingGradidoTransactions.end()) {
 		auto task_list = it->second;
 		results.reserve(task_list->size());
 		for (auto taskIt = task_list->begin(); taskIt != task_list->end(); taskIt++) {
 			auto task_model = (*taskIt)->getModel();
-			if (type == task_model->getTaskType()) {
+			if (task_model->getTaskType() == type) {
 				results.push_back(*taskIt);
 			}
 		}
@@ -135,48 +138,42 @@ std::vector<Poco::AutoPtr<controller::PendingTask>> PendingTasksManager::getPend
 	return results;
 }
 
-std::vector<Poco::AutoPtr<controller::PendingTask>>  PendingTasksManager::getTransactionsUserMustSign(Poco::AutoPtr<controller::User> user)
+std::vector<Poco::AutoPtr<model::gradido::Transaction>>  PendingTasksManager::getTransactionsUserMustSign(Poco::AutoPtr<controller::User> user)
 {
 	// TODO: don't use cast here, because can lead to errors
 	Poco::ScopedLock<Poco::Mutex> _lock(mWorkMutex);
-	std::vector<Poco::AutoPtr<controller::PendingTask>> transactions_to_sign;
+	std::vector<Poco::AutoPtr<model::gradido::Transaction>> transactions_to_sign;
 
-	for (auto map_it = mPendingTasks.begin(); map_it != mPendingTasks.end(); map_it++) 
+	for (auto map_it = mPendingGradidoTransactions.begin(); map_it != mPendingGradidoTransactions.end(); map_it++)
 	{
 		auto list = map_it->second;
 		for (auto list_it = list->begin(); list_it != list->end(); list_it++) 
 		{
-			if ((*list_it)->getModel()->isGradidoTransaction()) {
-				auto transaction = dynamic_cast<model::gradido::Transaction*>(list_it->get());
-				if (transaction->mustSign(user)) {
-					transactions_to_sign.push_back(*list_it);
-				}
+			if((*list_it)->mustSign(user)) {
+				transactions_to_sign.push_back(*list_it);
 			}
 		}
 	}
 	return transactions_to_sign;
 }
 
-std::vector<Poco::AutoPtr<controller::PendingTask>> PendingTasksManager::getTransactionSomeoneMustSign(Poco::AutoPtr<controller::User> user)
+std::vector<Poco::AutoPtr<model::gradido::Transaction>> PendingTasksManager::getTransactionSomeoneMustSign(Poco::AutoPtr<controller::User> user)
 {
 	// TODO: don't use cast here, because can lead to errors
 	Poco::ScopedLock<Poco::Mutex> _lock(mWorkMutex);
-	std::vector<Poco::AutoPtr<controller::PendingTask>> transactions_to_sign;
+	std::vector<Poco::AutoPtr<model::gradido::Transaction>> transactions_to_sign;
 
 	if (user->getModel()->getRole() != model::table::ROLE_ADMIN) {
 		return transactions_to_sign;
 	}
 
-	for (auto map_it = mPendingTasks.begin(); map_it != mPendingTasks.end(); map_it++)
+	for (auto map_it = mPendingGradidoTransactions.begin(); map_it != mPendingGradidoTransactions.end(); map_it++)
 	{
 		auto list = map_it->second;
 		for (auto list_it = list->begin(); list_it != list->end(); list_it++)
 		{
-			if ((*list_it)->getModel()->isGradidoTransaction()) {
-				auto transaction = dynamic_cast<model::gradido::Transaction*>(list_it->get());
-				if (transaction->needSomeoneToSign(user)) {
-					transactions_to_sign.push_back(*list_it);
-				}
+			if ((*list_it)->needSomeoneToSign(user)) {
+				transactions_to_sign.push_back(*list_it);
 			}
 		}
 	}
@@ -189,26 +186,24 @@ void PendingTasksManager::checkForFinishedTasks(Poco::Timer& timer)
 	Poco::ScopedLock<Poco::Mutex> _lock(mWorkMutex);
 	try {
 
-		for (auto map_it = mPendingTasks.begin(); map_it != mPendingTasks.end(); map_it++)
+		for (auto map_it = mPendingGradidoTransactions.begin(); map_it != mPendingGradidoTransactions.end(); map_it++)
 		{
 			auto list = map_it->second;
 			for (auto list_it = list->begin(); list_it != list->end(); list_it++)
 			{
-				if ((*list_it)->getModel()->isGradidoTransaction()) {
-					auto transaction = dynamic_cast<model::gradido::Transaction*>(list_it->get());
-					auto json = transaction->getModel()->getResultJson();
-					bool removeIt = false;
-					if (!json.isNull()) {
-						auto state = json->get("state");
-						if (!state.isEmpty() && state.toString() == "success") {
-							removeIt = true;
-						}
+				auto transaction = *list_it;
+				auto json = transaction->getModel()->getResultJson();
+				bool removeIt = false;
+				if (!json.isNull()) {
+					auto state = json->get("state");
+					if (!state.isEmpty() && state.toString() == "success") {
+						removeIt = true;
 					}
-					if (removeIt) {
-						transaction->deleteFromDB();
-						list_it = list->erase(list_it);
-						if (!list->size() || list_it == list->end()) break;
-					}
+				}
+				if (removeIt) {
+					transaction->deleteFromDB();
+					list_it = list->erase(list_it);
+					if (!list->size() || list_it == list->end()) break;
 				}
 			}
 		}
@@ -224,10 +219,11 @@ void PendingTasksManager::checkForFinishedTasks(Poco::Timer& timer)
 	}
 }
 
-Poco::AutoPtr<controller::PendingTask> PendingTasksManager::getPendingTask(int pendingTaskId)
+
+Poco::AutoPtr<model::gradido::Transaction> PendingTasksManager::getPendingGradidoTransaction(int pendingTaskId)
 {
 	Poco::ScopedLock<Poco::Mutex> _lock(mWorkMutex);
-	for (auto map_it = mPendingTasks.begin(); map_it != mPendingTasks.end(); map_it++)
+	for (auto map_it = mPendingGradidoTransactions.begin(); map_it != mPendingGradidoTransactions.end(); map_it++)
 	{
 		auto list = map_it->second;
 		for (auto list_it = list->begin(); list_it != list->end(); list_it++)

--- a/login_server/src/cpp/SingletonManager/PendingTasksManager.h
+++ b/login_server/src/cpp/SingletonManager/PendingTasksManager.h
@@ -13,9 +13,10 @@
 #ifndef GRADIDO_LOGIN_SERVER_SINGLETON_MANAGER_PENDING_TASKS_MANAGER
 #define GRADIDO_LOGIN_SERVER_SINGLETON_MANAGER_PENDING_TASKS_MANAGER
 
-#include "../controller/PendingTask.h"
-#include "../controller/User.h"
-#include "../model/gradido/Transaction.h"
+#include "controller/PendingTask.h"
+#include "model/gradido/Transaction.h"
+#include "controller/User.h"
+#include "model/gradido/Transaction.h"
 
 class UserUpdateGroupPage;
 
@@ -24,6 +25,7 @@ class PendingTasksManager: protected UniLib::lib::MultithreadContainer
 	friend UserUpdateGroupPage;
 public:
 	typedef std::list<Poco::AutoPtr<controller::PendingTask>>  PendingTaskList;
+	typedef std::list<Poco::AutoPtr<model::gradido::Transaction>> PendingGradidoTaskList;
 
 	~PendingTasksManager();
 
@@ -34,8 +36,9 @@ public:
 
 	//! \return -1 task is zero
 	//! \return 0 if added
-	int addTask(Poco::AutoPtr<controller::PendingTask> task);
-	bool removeTask(Poco::AutoPtr<controller::PendingTask> task);
+	int addTask(Poco::AutoPtr<model::gradido::Transaction> gradidoTransactionTask);
+
+	bool removeTask(Poco::AutoPtr<model::gradido::Transaction> gradidoTransactionTask);
 
 	//! check if tasks can be removed
 	void checkForFinishedTasks(Poco::Timer& timer);
@@ -43,12 +46,12 @@ public:
 	//! by calling this, important is to call lock to prevent vanishing the list while working with it,
 	//! and unlock afterwards
 	//! \return list or nullptr if no list for user exist
-	const PendingTaskList* getTaskListForUser(int userId) const;
-	bool hasPendingTask(Poco::AutoPtr<controller::User> user, model::table::TaskType type);
-	std::vector<Poco::AutoPtr<controller::PendingTask>> getPendingTasks(Poco::AutoPtr<controller::User> user, model::table::TaskType type);
-	Poco::AutoPtr<controller::PendingTask> getPendingTask(int pendingTaskId);
-	std::vector<Poco::AutoPtr<controller::PendingTask>> getTransactionsUserMustSign(Poco::AutoPtr<controller::User> user);
-	std::vector<Poco::AutoPtr<controller::PendingTask>> getTransactionSomeoneMustSign(Poco::AutoPtr<controller::User> user);
+	const PendingGradidoTaskList* getGradidoTransactionsForUser(int userId) const;
+	bool hasPendingGradidoTransaction(Poco::AutoPtr<controller::User> user, model::table::TaskType type);
+	std::vector<Poco::AutoPtr<model::gradido::Transaction>> getPendingGradidoTransactions(Poco::AutoPtr<controller::User> user, model::table::TaskType type);
+	Poco::AutoPtr<model::gradido::Transaction> getPendingGradidoTransaction(int pendingTaskId);
+	std::vector<Poco::AutoPtr<model::gradido::Transaction>> getTransactionsUserMustSign(Poco::AutoPtr<controller::User> user);
+	std::vector<Poco::AutoPtr<model::gradido::Transaction>> getTransactionSomeoneMustSign(Poco::AutoPtr<controller::User> user);
 
 
 protected:
@@ -58,8 +61,10 @@ protected:
 	
 	
 	std::map<int, PendingTaskList*> mPendingTasks;
+	std::map<int, PendingGradidoTaskList*> mPendingGradidoTransactions;
 	//! \return list for user, creating new list and map entry if not exist
 	PendingTaskList* getTaskListForUser(int userId);
+	PendingGradidoTaskList* getGradidoTransactionsForUser(int userId);
 };
 
 

--- a/login_server/src/cpp/controller/EmailVerificationCode.cpp
+++ b/login_server/src/cpp/controller/EmailVerificationCode.cpp
@@ -70,10 +70,13 @@ namespace controller {
 
 	Poco::AutoPtr<EmailVerificationCode> EmailVerificationCode::loadOrCreate(int user_id, model::table::EmailOptInType type)
 	{
-		model::table::EmailOptIn db;
+		auto db = new model::table::EmailOptIn();
 		std::vector<std::string> fields = { "user_id", "email_opt_in_type_id" };
 		std::vector<int> field_values = { user_id, (int)type };
-		auto results = db.loadFromDB<int, model::table::EmailOptInTuple>(fields, field_values);
+		auto results = db->loadFromDB<int, model::table::EmailOptInTuple>(fields, field_values);
+		db->release();
+		db = nullptr;
+
 		if (results.size() > 0) {
 			return Poco::AutoPtr<EmailVerificationCode>(new EmailVerificationCode(new model::table::EmailOptIn(results[0])));
 		}

--- a/login_server/src/cpp/controller/User.cpp
+++ b/login_server/src/cpp/controller/User.cpp
@@ -136,7 +136,7 @@ namespace controller {
 	{
 		auto db = new model::table::User();
 		if (0 == db->loadFromDB("id", user_id)) {
-			delete db;
+			db->release();
 			return nullptr;
 		}
 		auto user = new User(db);

--- a/login_server/src/cpp/model/gradido/Transaction.cpp
+++ b/login_server/src/cpp/model/gradido/Transaction.cpp
@@ -360,8 +360,8 @@ namespace model {
 				//transaction_send_task->scheduleTask(transaction_send_task);
 				auto pt = PendingTasksManager::getInstance();
 
-				pt->removeTask(Poco::AutoPtr<Transaction>(this, true));
-				deleteFromDB();
+				// pt->removeTask(Poco::AutoPtr<Transaction>(this, true));
+				// deleteFromDB();
 				return 1 == runSendTransaction();
 				//return true;
 			}

--- a/login_server/src/cpp/model/table/AppAccessToken.h
+++ b/login_server/src/cpp/model/table/AppAccessToken.h
@@ -16,7 +16,7 @@ namespace model {
 			AppAccessToken(int user_id, const Poco::UInt64& code);
 			AppAccessToken(const AppAccessCodeTuple& tuple);
 			AppAccessToken();
-			~AppAccessToken();
+			
 
 			// generic db operations
 			const char* getTableName() const { return "app_access_tokens"; }
@@ -32,6 +32,8 @@ namespace model {
 			size_t update();
 
 		protected:
+			~AppAccessToken();
+
 			Poco::Data::Statement _loadFromDB(Poco::Data::Session session, const std::string& fieldName);
 			Poco::Data::Statement _loadIdFromDB(Poco::Data::Session session);
 			Poco::Data::Statement _insertIntoDB(Poco::Data::Session session);

--- a/login_server/src/cpp/model/table/ElopageBuy.h
+++ b/login_server/src/cpp/model/table/ElopageBuy.h
@@ -31,14 +31,15 @@ namespace model {
 		{
 		public:
 			ElopageBuy(const Poco::Net::NameValueCollection& elopage_webhook_requestData);
-			~ElopageBuy();
-
+			
 			// generic db operations
 			const char* getTableName() const { return "elopage_buys"; }
 			
 			std::string toString();
 			
 		protected:
+			~ElopageBuy();
+
 			Poco::Data::Statement _loadIdFromDB(Poco::Data::Session session);
 			Poco::Data::Statement _loadFromDB(Poco::Data::Session session, const std::string& fieldName);
 			Poco::Data::Statement _insertIntoDB(Poco::Data::Session session);

--- a/login_server/src/cpp/model/table/EmailOptIn.h
+++ b/login_server/src/cpp/model/table/EmailOptIn.h
@@ -26,7 +26,7 @@ namespace model {
 			EmailOptIn(const Poco::UInt64& code, EmailOptInType type);
 			EmailOptIn(const EmailOptInTuple& tuple);
 			EmailOptIn();
-			~EmailOptIn();
+			
 
 			// generic db operations
 			const char* getTableName() const { return "email_opt_in"; }
@@ -46,6 +46,8 @@ namespace model {
 			static const char* typeToString(EmailOptInType type);
 			static EmailOptInType stringToType(const std::string& typeString); 
 		protected:
+			~EmailOptIn();
+
 			Poco::Data::Statement _loadFromDB(Poco::Data::Session session, const std::string& fieldName);
 			Poco::Data::Statement _loadIdFromDB(Poco::Data::Session session);
 			Poco::Data::Statement _loadMultipleFromDB(Poco::Data::Session session, const std::string& fieldName);

--- a/login_server/src/cpp/model/table/Group.h
+++ b/login_server/src/cpp/model/table/Group.h
@@ -15,8 +15,7 @@ namespace model {
 			Group();
 			Group(const std::string& alias, const std::string& name, const std::string& url, const std::string& host, const std::string& home, const std::string& description);
 			Group(GroupTuple userTuple);
-			~Group();
-
+			
 			// generic db operations
 			const char* getTableName() const { return "groups"; }
 			std::string toString();
@@ -35,6 +34,8 @@ namespace model {
 			inline void setHome(const std::string& home) { UNIQUE_LOCK; mHome = home; }
 
 		protected:
+			~Group();
+
 			Poco::Data::Statement _loadFromDB(Poco::Data::Session session, const std::string& fieldName);
 			Poco::Data::Statement _loadAllFromDB(Poco::Data::Session session);
 			Poco::Data::Statement _loadMultipleFromDB(Poco::Data::Session session, const std::string& fieldName);

--- a/login_server/src/cpp/model/table/ModelBase.h
+++ b/login_server/src/cpp/model/table/ModelBase.h
@@ -32,7 +32,7 @@ namespace model {
 		public:
 			ModelBase(int id) :mID(id), mReferenceCount(1) {}
 			ModelBase() : mID(0), mReferenceCount(1) {}
-			virtual ~ModelBase();
+			
 
 			virtual const char* getTableName() const = 0;
 			//! called from within of some catch to give more information for debugging, don't lock mutex!
@@ -90,6 +90,8 @@ namespace model {
 			void duplicate();
 			void release();
 		protected:
+			virtual ~ModelBase();
+
 			virtual Poco::Data::Statement _loadIdFromDB(Poco::Data::Session session) = 0;
 			virtual Poco::Data::Statement _loadFromDB(Poco::Data::Session session, const std::string& fieldName) = 0;
 			virtual Poco::Data::Statement _loadFromDB(Poco::Data::Session session, const std::vector<std::string>& fieldNames, MysqlConditionType conditionType = MYSQL_CONDITION_AND);
@@ -104,6 +106,9 @@ namespace model {
 			int mReferenceCount;	
 
 			mutable std::shared_mutex mSharedMutex;
+
+		private:
+			
 
 		};
 

--- a/login_server/src/cpp/model/table/PendingTask.h
+++ b/login_server/src/cpp/model/table/PendingTask.h
@@ -28,7 +28,6 @@ namespace model {
 			PendingTask(int userId, std::string serializedProtoRequest, TaskType type);
 			PendingTask(const PendingTaskTuple& tuple);
 
-			~PendingTask();
 
 			// generic db operations
 			const char* getTableName() const { return "pending_tasks"; }
@@ -65,6 +64,8 @@ namespace model {
 
 			static const char* typeToString(TaskType type);
 		protected:
+			~PendingTask();
+
 			Poco::Data::Statement _loadFromDB(Poco::Data::Session session, const std::string& fieldName);
 			Poco::Data::Statement _loadAllFromDB(Poco::Data::Session session);
 			Poco::Data::Statement _loadIdFromDB(Poco::Data::Session session);

--- a/login_server/src/cpp/model/table/User.h
+++ b/login_server/src/cpp/model/table/User.h
@@ -38,7 +38,7 @@ namespace model {
 			User();
 			User(UserTuple tuple);
 			User(const std::string& email, const std::string& first_name, const std::string& last_name, int group_id, Poco::UInt64 passwordHashed = 0, std::string languageKey = "de");
-			~User();
+			
 
 			// generic db operations
 			const char* getTableName() const { return "users"; }
@@ -97,6 +97,7 @@ namespace model {
 			Poco::JSON::Object getJson();			
 
 		protected:
+			~User();
 
 			Poco::Data::Statement _loadFromDB(Poco::Data::Session session, const std::string& fieldName);
 			Poco::Data::Statement _loadIdFromDB(Poco::Data::Session session);

--- a/login_server/src/cpp/model/table/UserBackup.h
+++ b/login_server/src/cpp/model/table/UserBackup.h
@@ -15,8 +15,7 @@ namespace model {
 			UserBackup(int user_id, const std::string& passphrase, ServerConfig::Mnemonic_Types type);
 			UserBackup(const UserBackupsTuple& tuple);
 			UserBackup();
-			~UserBackup();
-
+			
 			// generic db operations
 			const char* getTableName() const { return "user_backups"; }
 			std::string toString();
@@ -29,6 +28,7 @@ namespace model {
 
 
 		protected:
+			~UserBackup();
 
 			//! \brief call from constructor if mMnemonicType -1
 			//! 

--- a/login_server/src/cpp/model/table/UserRole.h
+++ b/login_server/src/cpp/model/table/UserRole.h
@@ -23,7 +23,6 @@ namespace model {
 			UserRole(int user_id, RoleType type);
 			UserRole(const UserRolesTuple& tuple);
 			UserRole();
-			~UserRole();
 
 			// generic db operations
 			const char* getTableName() const { return "user_roles"; }
@@ -35,7 +34,9 @@ namespace model {
 			inline void setUserId(int user_Id) { mUserId = user_Id; }
 
 			static const char* typeToString(RoleType type);
-			protected:
+		protected:
+			~UserRole();
+
 			Poco::Data::Statement _loadFromDB(Poco::Data::Session session, const std::string& fieldName);
 			Poco::Data::Statement _loadIdFromDB(Poco::Data::Session session);
 			Poco::Data::Statement _loadMultipleFromDB(Poco::Data::Session session, const std::string& fieldName);

--- a/login_server/src/cpsp/CheckTransaction.cpsp
+++ b/login_server/src/cpsp/CheckTransaction.cpsp
@@ -200,8 +200,6 @@ enum PageState {
 		}
 	}
 	
-	std::clog << "state: " << std::to_string(state) << std::endl;
-
 %><%@ include file="include/header_navi_chr.cpsp" %>
 <%= getErrorsHtml() %>
 <div class="col-md-10 equel-grid mb-3">

--- a/login_server/src/cpsp/CheckTransaction.cpsp
+++ b/login_server/src/cpsp/CheckTransaction.cpsp
@@ -134,7 +134,7 @@ enum PageState {
 	std::vector<Poco::AutoPtr<model::gradido::Transaction>> transactions_to_sign;
 	bool transaction_removeable = false;
 	int transaction_to_sign_index = 0;
-	if(!transaction.isNull()) 
+	if(transaction.isNull()) 
 	{
 		if(transactions_user_must_sign.size() > skip_count) {
 			transactions_to_sign = transactions_user_must_sign;
@@ -143,7 +143,7 @@ enum PageState {
 			transactions_to_sign = transactions_someone_must_sign;
 			transaction_to_sign_index = skip_count - transactions_user_must_sign.size();
 		}
-		
+
 		if(transactions_to_sign.size() > transaction_to_sign_index) 
 		{
 			transaction = transactions_to_sign[transaction_to_sign_index];
@@ -200,7 +200,7 @@ enum PageState {
 		}
 	}
 	
-	
+	std::clog << "state: " << std::to_string(state) << std::endl;
 
 %><%@ include file="include/header_navi_chr.cpsp" %>
 <%= getErrorsHtml() %>
@@ -267,18 +267,19 @@ enum PageState {
 				  </div>
 				</div>
 		     <% } else if(PAGE_TRANSACTION_GROUP_ADD_MEMBER == state) { 
-				auto groupMemberUpdateTransaction = transaction_body->getGroupMemberUpdate();
-				auto groups = controller::Group::load(groupMemberUpdateTransaction->getTargetGroupAlias());
-				Poco::AutoPtr<model::table::Group> group_model;
-				Poco::AutoPtr<controller::User> user;
-				if(groups.size() == 1 && !groups[0].isNull()) group_model = groups[0]->getModel();
-				auto user_id = transaction->getModel()->getUserId();
-				if(user_id == user_model->getID()) {
-					user = account_user;
-				} else {
-					user = controller::User::sload(user_id);
-				}
-			 %>
+					auto groupMemberUpdateTransaction = transaction_body->getGroupMemberUpdate();
+					auto groups = controller::Group::load(groupMemberUpdateTransaction->getTargetGroupAlias());
+					Poco::AutoPtr<model::table::Group> group_model;
+					Poco::AutoPtr<controller::User> user;
+					if(groups.size() == 1 && !groups[0].isNull()) group_model = groups[0]->getModel();
+					auto user_id = transaction->getModel()->getUserId();
+					if(user_id == user_model->getID()) {
+						user = account_user;
+					} else {
+						user = controller::User::sload(user_id);
+					}
+
+			 	%>
 			 <p><%= gettext("Benutzer zu einer Gruppe hinzufügen") %></p>
 			 <div class="content-table">
 				<p><% if(!user.isNull()) { %>

--- a/login_server/src/cpsp/CheckTransaction.cpsp
+++ b/login_server/src/cpsp/CheckTransaction.cpsp
@@ -46,10 +46,7 @@ enum PageState {
 	
 	PageState state = PAGE_NO_TRANSACTIONS;
 	
-	
-	
-	Poco::AutoPtr<controller::PendingTask> pending_task;
-	model::gradido::Transaction* transaction = nullptr;
+	Poco::AutoPtr<model::gradido::Transaction> transaction;
 	Poco::AutoPtr<model::gradido::TransactionBody> transaction_body;
 	
 	if(!form.empty()) 
@@ -64,10 +61,9 @@ enum PageState {
 		if(DataTypeConverter::NUMBER_PARSE_OKAY == DataTypeConverter::strToInt(pending_task_id_string, pending_task_id)) 
 		{
 			// load transaction from pending task manager
-			pending_task = pt->getPendingTask(pending_task_id);
-			if(!pending_task.isNull() && pending_task->getModel()->isGradidoTransaction()) 
+			transaction = pt->getPendingGradidoTransaction(pending_task_id);
+			if(!transaction.isNull()) 
 			{
-				transaction = dynamic_cast<model::gradido::Transaction*>(pending_task.get());
 				if(transaction->hasSigned(account_user)) {
 					transaction = nullptr;
 				} else {				
@@ -78,10 +74,11 @@ enum PageState {
 				{
 					//mSession->finalizeTransaction(false, true);
 					// 
-					if(transaction && transaction->getModel()->getUserId() == user_model->getID()) 
+					if(!transaction.isNull() && transaction->getModel()->getUserId() == user_model->getID()) 
 					{
-						pt->removeTask(pending_task);
-						transaction->deleteFromDB();
+						if(pt->removeTask(transaction)) {
+							transaction->deleteFromDB();
+						}
 						transaction = nullptr;
 					}
 				} 
@@ -110,7 +107,7 @@ enum PageState {
 					}
 					if(!hasErrors) {
 						//mSession->finalizeTransaction(true, false);
-						if(transaction && transaction->sign(account_user)) {
+						if(!transaction.isNull() && transaction->sign(account_user)) {
 							transaction = nullptr;
 						}
 					}
@@ -129,15 +126,15 @@ enum PageState {
 	}
 	
 	auto transactions_user_must_sign = pt->getTransactionsUserMustSign(account_user);
-	std::vector<Poco::AutoPtr<controller::PendingTask>> transactions_someone_must_sign;
+	std::vector<Poco::AutoPtr<model::gradido::Transaction>> transactions_someone_must_sign;
 	// TODO: work with community server roles
 	if(user_model->getRole() == model::table::ROLE_ADMIN) {
 	  transactions_someone_must_sign = pt->getTransactionSomeoneMustSign(account_user);	
 	}
-	std::vector<Poco::AutoPtr<controller::PendingTask>>  transactions_to_sign;
+	std::vector<Poco::AutoPtr<model::gradido::Transaction>> transactions_to_sign;
 	bool transaction_removeable = false;
 	int transaction_to_sign_index = 0;
-	if(!transaction) 
+	if(!transaction.isNull()) 
 	{
 		if(transactions_user_must_sign.size() > skip_count) {
 			transactions_to_sign = transactions_user_must_sign;
@@ -149,7 +146,7 @@ enum PageState {
 		
 		if(transactions_to_sign.size() > transaction_to_sign_index) 
 		{
-			transaction = dynamic_cast<model::gradido::Transaction*>(transactions_to_sign[transaction_to_sign_index].get());
+			transaction = transactions_to_sign[transaction_to_sign_index];
 			transaction_body = transaction->getTransactionBody();
 			// user can only delete there own transactions
 			// TODO: Auto timeout for community transactions
@@ -181,7 +178,7 @@ enum PageState {
 	{
 		enableLogout = false;
 	}
-	if(PAGE_NO_TRANSACTIONS == state && transaction && !transaction_body.isNull()) 
+	if(PAGE_NO_TRANSACTIONS == state && !transaction.isNull() && !transaction_body.isNull()) 
 	{
 		auto transactionType = transaction_body->getType();
 		memo = transaction_body->getMemo();
@@ -326,7 +323,7 @@ enum PageState {
 				  </div>
 				</div>
 				<form>
-					<% if(transaction) { %>
+					<% if(!transaction.isNull()) { %>
 						<input type="hidden" name="pending-task-id" value="<%= transaction->getModel()->getID() %>">
 					<% } %>
 					<input type="hidden" name="skip-count" value="<%= skip_count %>">

--- a/login_server/src/cpsp/UserUpdateGroup.cpsp
+++ b/login_server/src/cpsp/UserUpdateGroup.cpsp
@@ -73,15 +73,14 @@ enum PageState {
 			
 			
 			pt->lock("userUpdateGroup Page");
-			auto has_pending_group_add_member_task = pt->hasPendingTask(user, model::table::TASK_TYPE_GROUP_ADD_MEMBER);
+			auto has_pending_group_add_member_task = pt->hasPendingGradidoTransaction(user, model::table::TASK_TYPE_GROUP_ADD_MEMBER);
 			auto referer_was_checkTransaction = refererString.find("checkTransactions") != std::string::npos;
 			if(has_pending_group_add_member_task) {
 				state = PAGE_STATE_REQUEST_IS_RUNNING;
-				std::vector<Poco::AutoPtr<controller::PendingTask>> tasks = pt->getPendingTasks(user, model::table::TASK_TYPE_GROUP_ADD_MEMBER);
+				auto tasks = pt->getPendingGradidoTransactions(user, model::table::TASK_TYPE_GROUP_ADD_MEMBER);
 				// should be only one
-				Poco::AutoPtr<model::gradido::Transaction> transaction = tasks[0].cast<model::gradido::Transaction>();
+				auto transaction = tasks[0];
 				if(transaction->getSignCount() == 0) {
-					
 					pt->unlock();
 					response.redirect(getBaseUrl() + "/checkTransactions");
 					return;


### PR DESCRIPTION
## 🍰 Pullrequest
Fix bugs which let the login-server crash

- Change Pending Task structure from using virtual objects to combine different classes with the base class into on map, to using only direct the model::gradido::Transaction class. With that change, it isn't neccessary anymore to make dynamic casts of pointers which seems to lead to bugs with the Poco::AutoPtr. The Hedera Transactions are not longer needed so it is relative easy.
- Move all Destructors from mode::table classes from public to protected to prevent misuse of the table classes ignoring the reference counting (needed for Poco::AutoPtr)

### Issues
- depends on / includes  #640

