### PR TITLE
630 frontend text improvemets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,7 +206,7 @@ jobs:
           report_name: Coverage Frontend
           type: lcov
           result_path: ./coverage/lcov.info
-          min_coverage: 46
+          min_coverage: 47
           token: ${{ github.token }}
   
   ##############################################################################

--- a/frontend/src/components/DecayInformation.vue
+++ b/frontend/src/components/DecayInformation.vue
@@ -28,7 +28,10 @@
                 </div>
               </div>
               <div>
-                <span>{{ $d($moment.unix(decay.decay_start), 'long') }} {{ $i18n.locale === 'de' ? 'Uhr' : '' }}</span>
+                <span>
+                  {{ $d($moment.unix(decay.decay_start), 'long') }}
+                  {{ $i18n.locale === 'de' ? 'Uhr' : '' }}
+                </span>
               </div>
             </div>
           </div>

--- a/frontend/src/components/DecayInformation.vue
+++ b/frontend/src/components/DecayInformation.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <span v-if="decaytyp === 'short'">
-      <small>{{ decay ? ' ' + decay.balance + ' ' + decayStartBlockTextShort : '' }}</small>
+      <small>{{ decay ? ' -' + decay.balance + ' ' + decayStartBlockTextShort : '' }}</small>
     </span>
 
     <div v-if="decaytyp === 'new'">
@@ -28,7 +28,7 @@
                 </div>
               </div>
               <div>
-                <span>{{ $d($moment.unix(decay.decay_start), 'long') }} Uhr</span>
+                <span>{{ $d($moment.unix(decay.decay_start), 'long') }} {{ $i18n.locale === 'de' ? 'Uhr' : '' }}</span>
               </div>
             </div>
           </div>

--- a/frontend/src/components/DecayInformation.vue
+++ b/frontend/src/components/DecayInformation.vue
@@ -8,11 +8,10 @@
       <b-list-group style="border: 0px">
         <b-list-group-item style="border: 0px; background-color: #f1f1f1">
           <div class="d-flex">
-            <div style="width: 40%" class="text-right pr-3 mr-2">
-              {{ $t('decay.calculation_decay') }}
+            <div style="width: 100%" class="text-center pb-3">
               <b-icon icon="droplet-half" height="12" class="mb-2" />
+              {{ $t('decay.calculation_decay') }}
             </div>
-            <div style="width: 60%"></div>
           </div>
 
           <div class="d-flex">

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -43,7 +43,7 @@
     "close": "schließen",
     "edit": "bearbeiten",
     "save": "speichern",
-    "receiver":"Empfänger",
+    "recipient":"Empfänger",
     "sender":"Absender",
     "username":"Username",
     "firstname":"Vorname",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -8,7 +8,7 @@
   "reset": "Passwort zurücksetzen",
   "imprint":"Impressum",
   "privacy_policy":"Datenschutzerklärung",
-  "members_area": "Mitgliedsbereich",
+  "members_area": "Mitgliederbereich",
   "whitepaper": "Whitepaper",
   "back":"Zurück",
   "send":"Senden",
@@ -59,14 +59,15 @@
     "change": "ändern",
     "change-password": "Passwort ändern",
     "amount":"Betrag",
-    "memo":"Nachricht für den Empfänger",
+    "memo":"Nachricht",
     "message":"Nachricht",
     "date":"Datum",
     "from":"von",
     "to":"bis",
+    "to1":"an",
     "at":"am",
     "time":"Zeit",
-    "send_now":"Jetzt versenden",
+    "send_now":"Jetzt senden",
     "scann_code":"<strong>QR Code Scanner</strong> - Scanne den QR Code deines Partners",
     "max_gdd_info":"Maximale anzahl GDD zum versenden erreicht!",
     "send_check":"Bestätige deine Zahlung. Prüfe bitte nochmal alle Daten!",
@@ -113,7 +114,7 @@
     "password": {
       "title": "Passwort zurücksetzen",
       "subtitle": "Wenn du dein Passwort vergessen hast, kannst du es hier zurücksetzen.",
-      "reset_now": "Jetzt zurücksetzen"
+      "send_now": "Jetzt senden"
     },
     "thx": {
       "title": "Danke!",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -35,7 +35,8 @@
     "seconds":"Sekunden",
     "received":"empfangen",
     "sent":"gesendet",
-    "created":"geschöpft"
+    "created":"geschöpft",
+    "fromCommunity":"Aus der Community"
   }, 
   "form": {
     "cancel": "Abbrechen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -43,7 +43,7 @@
     "close":"Close",
     "edit": "Edit",
     "save": "save",
-    "receiver":"Receiver",
+    "recipient":"Recipient",
     "sender":"Sender",
     "username":"Username",
     "firstname":"Firstname",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -43,11 +43,7 @@
     "close":"Close",
     "edit": "Edit",
     "save": "save",
-<<<<<<< HEAD
     "recipient":"Recipient",
-=======
-    "receiver":"Recipient",
->>>>>>> 86e253ac0495b36b1ce3a07eeb9d35dae9abced2
     "sender":"Sender",
     "username":"Username",
     "firstname":"Firstname",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -8,7 +8,7 @@
   "reset": "Reset password",
   "imprint":"Legal notice",
   "privacy_policy":"Privacy policy",
-  "members_area": "Member´s area",
+  "members_area": "Member's area",
   "whitepaper": "Whitepaper",
   "back":"Back",
   "send":"Send",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -8,7 +8,7 @@
   "reset": "Reset password",
   "imprint":"Legal notice",
   "privacy_policy":"Privacy policy",
-  "members_area": "Member's area",
+  "members_area": "Members area",
   "whitepaper": "Whitepaper",
   "back":"Back",
   "send":"Send",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -8,7 +8,7 @@
   "reset": "Reset password",
   "imprint":"Legal notice",
   "privacy_policy":"Privacy policy",
-  "members_area": "Members area",
+  "members_area": "Member´s area",
   "whitepaper": "Whitepaper",
   "back":"Back",
   "send":"Send",
@@ -35,7 +35,8 @@
     "seconds": "Seconds",
     "received":"received",
     "sent":"sent",
-    "created":"created"
+    "created":"reated",
+    "fromCommunity":"From the community"
   },
   "form": {
     "cancel":"Cancel",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -59,11 +59,12 @@
     "change": "change",
     "change-password": "Change password",
     "amount":"Amount",
-    "memo":"Message for the recipient",
+    "memo":"Message",
     "message":"Message",
     "date":"Date",
     "from":"from",
     "to":"to",
+    "to1":"to",
     "at":"at",
     "time":"Time",
     "send_now":"Send now",
@@ -113,7 +114,7 @@
     "password": {
       "title": "Reset password",
       "subtitle": "If you have forgotten your password, you can reset it here.",
-      "reset_now": "Reset now"
+      "send_now": "Send now"
     },
     "thx": {
       "title": "Thank you!",

--- a/frontend/src/views/Pages/AccountOverview/GddSend/TransactionConfirmation.vue
+++ b/frontend/src/views/Pages/AccountOverview/GddSend/TransactionConfirmation.vue
@@ -6,7 +6,7 @@
         <b-list-group>
           <b-list-group-item class="d-flex justify-content-between align-items-center">
             {{ email }}
-            <b-badge variant="primary" pill>{{ $t('form.receiver') }}</b-badge>
+            <b-badge variant="primary" pill>{{ $t('form.recipient') }}</b-badge>
           </b-list-group-item>
           <b-list-group-item class="d-flex justify-content-between align-items-center">
             {{ $n(amount, 'decimal') }} GDD

--- a/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.spec.js
+++ b/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.spec.js
@@ -144,9 +144,7 @@ describe('GddSend', () => {
         })
 
         it('has the text "form.cancel"', () => {
-          expect(wrapper.find('button[type="reset"]').find('svg').attributes('aria-label')).toBe(
-            'trash',
-          )
+          expect(wrapper.find('button[type="reset"]').text()).toBe('form.reset')
         })
 
         it('clears all fields on click', async () => {

--- a/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.spec.js
+++ b/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.spec.js
@@ -50,7 +50,7 @@ describe('GddSend', () => {
         })
 
         it('has a label form.receiver', () => {
-          expect(wrapper.find('label.input-1').text()).toBe('form.receiver')
+          expect(wrapper.find('label.input-1').text()).toBe('form.recipient')
         })
 
         it('has a placeholder "E-Mail"', () => {
@@ -121,8 +121,8 @@ describe('GddSend', () => {
           )
         })
 
-        it('has a label form.memo', () => {
-          expect(wrapper.find('label.input-3').text()).toBe('form.memo')
+        it('has a label form.message', () => {
+          expect(wrapper.find('label.input-3').text()).toBe('form.message')
         })
 
         it('flushes an error message when memo is less than 5 characters', async () => {

--- a/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.spec.js
+++ b/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.spec.js
@@ -144,7 +144,7 @@ describe('GddSend', () => {
         })
 
         it('has the text "form.cancel"', () => {
-          expect(wrapper.find('button[type="reset"]').text()).toBe('form.reset')
+          expect(wrapper.find('button[type="reset"]').find('svg').attributes('aria-label')).toBe('trash')
         })
 
         it('clears all fields on click', async () => {

--- a/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.spec.js
+++ b/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.spec.js
@@ -144,7 +144,9 @@ describe('GddSend', () => {
         })
 
         it('has the text "form.cancel"', () => {
-          expect(wrapper.find('button[type="reset"]').find('svg').attributes('aria-label')).toBe('trash')
+          expect(wrapper.find('button[type="reset"]').find('svg').attributes('aria-label')).toBe(
+            'trash',
+          )
         })
 
         it('clears all fields on click', async () => {

--- a/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.vue
+++ b/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.vue
@@ -43,7 +43,7 @@
                     class="pl-3"
                   ></b-form-input>
                 </b-input-group>
-                <b-col v-if="errors" class="text-right p-3 p-sm-1">
+                <b-col v-if="errors">
                   <span v-for="error in errors" :key="error" class="errors">{{ error }}</span>
                 </b-col>
               </validation-provider>
@@ -78,7 +78,7 @@
                     class="pl-3"
                   ></b-form-input>
                 </b-input-group>
-                <b-col v-if="errors" class="col-12 text-right p-3 p-sm-1">
+                <b-col v-if="errors">
                   <span v-for="error in errors" class="errors" :key="error">{{ error }}</span>
                 </b-col>
               </validation-provider>
@@ -106,7 +106,7 @@
                     class="pl-3"
                   ></b-form-textarea>
                 </b-input-group>
-                <b-col v-if="errors" class="text-right p-3 p-sm-1">
+                <b-col v-if="errors">
                   <span v-for="error in errors" class="errors" :key="error">{{ error }}</span>
                 </b-col>
               </validation-provider>
@@ -116,7 +116,7 @@
             <b-row>
               <b-col>
                 <b-button type="reset" variant="secondary" @click="onReset">
-                  {{ $t('form.reset') }}
+                  <b-icon icon="trash" class="mb-2" />
                 </b-button>
               </b-col>
               <b-col class="text-right">

--- a/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.vue
+++ b/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.vue
@@ -116,7 +116,7 @@
             <b-row>
               <b-col>
                 <b-button type="reset" variant="secondary" @click="onReset">
-                  <b-icon icon="trash" class="mb-2" />
+                  {{ $t('form.reset') }}
                 </b-button>
               </b-col>
               <b-col class="text-right">

--- a/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.vue
+++ b/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.vue
@@ -21,11 +21,7 @@
                 }"
                 v-slot="{ errors }"
               >
-                <b-row>
-                  <b-col v-if="errors" class="text-right p-3 p-sm-1">
-                    <span v-for="error in errors" :key="error" class="errors">{{ error }}</span>
-                  </b-col>
-                </b-row>
+             
                 <label class="input-1" for="input-1">{{ $t('form.receiver') }}</label>
                 <b-input-group
                   id="input-group-1"
@@ -48,6 +44,9 @@
                     class="pl-3"
                   ></b-form-input>
                 </b-input-group>
+                  <b-col v-if="errors" class="text-right p-3 p-sm-1">
+                    <span v-for="error in errors" :key="error" class="errors">{{ error }}</span>
+                  </b-col>
               </validation-provider>
             </div>
 
@@ -61,12 +60,7 @@
                   gddSendAmount: [0.01, balance],
                 }"
                 v-slot="{ errors, valid }"
-              >
-                <b-row>
-                  <b-col v-if="errors" class="col-12 text-right p-3 p-sm-1">
-                    <span v-for="error in errors" class="errors" :key="error">{{ error }}</span>
-                  </b-col>
-                </b-row>
+              >              
                 <label class="input-2" for="input-2">{{ $t('form.amount') }}</label>
                 <b-input-group id="input-group-2" class="border border-default" size="lg">
                   <b-input-group-prepend class="p-2 d-none d-md-block">
@@ -85,6 +79,9 @@
                     class="pl-3"
                   ></b-form-input>
                 </b-input-group>
+                 <b-col v-if="errors" class="col-12 text-right p-3 p-sm-1">
+                    <span v-for="error in errors" class="errors" :key="error">{{ error }}</span>
+                  </b-col>
               </validation-provider>
             </div>
 
@@ -95,15 +92,10 @@
                   min: 5,
                   max: 150,
                 }"
-                :name="$t('form.memo')"
+                :name="$t('form.message')"
                 v-slot="{ errors }"
-              >
-                <b-row>
-                  <b-col v-if="errors" class="text-right p-3 p-sm-1">
-                    <span v-for="error in errors" class="errors" :key="error">{{ error }}</span>
-                  </b-col>
-                </b-row>
-                <label class="input-3" for="input-3">{{ $t('form.memo') }}</label>
+              >              
+                <label class="input-3" for="input-3">{{ $t('form.message') }}</label>
                 <b-input-group id="input-group-3" class="border border-default">
                   <b-input-group-prepend class="d-none d-md-block">
                     <b-icon icon="chat-right-text" class="display-4 m-3 mt-4"></b-icon>
@@ -115,6 +107,9 @@
                     class="pl-3"
                   ></b-form-textarea>
                 </b-input-group>
+                 <b-col v-if="errors" class="text-right p-3 p-sm-1">
+                    <span v-for="error in errors" class="errors" :key="error">{{ error }}</span>
+                  </b-col>
               </validation-provider>
             </div>
 

--- a/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.vue
+++ b/frontend/src/views/Pages/AccountOverview/GddSend/TransactionForm.vue
@@ -21,8 +21,7 @@
                 }"
                 v-slot="{ errors }"
               >
-             
-                <label class="input-1" for="input-1">{{ $t('form.receiver') }}</label>
+                <label class="input-1" for="input-1">{{ $t('form.recipient') }}</label>
                 <b-input-group
                   id="input-group-1"
                   class="border border-default"
@@ -44,9 +43,9 @@
                     class="pl-3"
                   ></b-form-input>
                 </b-input-group>
-                  <b-col v-if="errors" class="text-right p-3 p-sm-1">
-                    <span v-for="error in errors" :key="error" class="errors">{{ error }}</span>
-                  </b-col>
+                <b-col v-if="errors" class="text-right p-3 p-sm-1">
+                  <span v-for="error in errors" :key="error" class="errors">{{ error }}</span>
+                </b-col>
               </validation-provider>
             </div>
 
@@ -60,7 +59,7 @@
                   gddSendAmount: [0.01, balance],
                 }"
                 v-slot="{ errors, valid }"
-              >              
+              >
                 <label class="input-2" for="input-2">{{ $t('form.amount') }}</label>
                 <b-input-group id="input-group-2" class="border border-default" size="lg">
                   <b-input-group-prepend class="p-2 d-none d-md-block">
@@ -79,9 +78,9 @@
                     class="pl-3"
                   ></b-form-input>
                 </b-input-group>
-                 <b-col v-if="errors" class="col-12 text-right p-3 p-sm-1">
-                    <span v-for="error in errors" class="errors" :key="error">{{ error }}</span>
-                  </b-col>
+                <b-col v-if="errors" class="col-12 text-right p-3 p-sm-1">
+                  <span v-for="error in errors" class="errors" :key="error">{{ error }}</span>
+                </b-col>
               </validation-provider>
             </div>
 
@@ -94,7 +93,7 @@
                 }"
                 :name="$t('form.message')"
                 v-slot="{ errors }"
-              >              
+              >
                 <label class="input-3" for="input-3">{{ $t('form.message') }}</label>
                 <b-input-group id="input-group-3" class="border border-default">
                   <b-input-group-prepend class="d-none d-md-block">
@@ -107,9 +106,9 @@
                     class="pl-3"
                   ></b-form-textarea>
                 </b-input-group>
-                 <b-col v-if="errors" class="text-right p-3 p-sm-1">
-                    <span v-for="error in errors" class="errors" :key="error">{{ error }}</span>
-                  </b-col>
+                <b-col v-if="errors" class="text-right p-3 p-sm-1">
+                  <span v-for="error in errors" class="errors" :key="error">{{ error }}</span>
+                </b-col>
               </validation-provider>
             </div>
 

--- a/frontend/src/views/Pages/AccountOverview/GddTransactionList.spec.js
+++ b/frontend/src/views/Pages/AccountOverview/GddTransactionList.spec.js
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils'
 import GddTransactionList from './GddTransactionList'
-import flushPromises from 'flush-promises'
 
 const localVue = global.localVue
 
@@ -85,7 +84,6 @@ describe('GddTransactionList', () => {
           ],
           transactionCount: 12,
         })
-        await flushPromises()
       })
 
       it('renders 4 transactions', () => {

--- a/frontend/src/views/Pages/AccountOverview/GddTransactionList.spec.js
+++ b/frontend/src/views/Pages/AccountOverview/GddTransactionList.spec.js
@@ -118,7 +118,7 @@ describe('GddTransactionList', () => {
           expect(transaction.findAll('div').at(0).text()).toContain('Bob der Baumeister')
         })
 
-        it('shows the memo of the receiver', () => {
+        it('shows the message of the transaction', () => {
           expect(transaction.findAll('div').at(5).text()).toContain('Alles Gute zum Geburtstag')
         })
 
@@ -180,11 +180,11 @@ describe('GddTransactionList', () => {
           expect(transaction.findAll('div').at(2).text()).toContain('+ 314.98')
         })
 
-        it('shows the name of the receiver', () => {
+        it('shows the name of the recipient', () => {
           expect(transaction.findAll('div').at(0).text()).toContain('Jan Ulrich')
         })
 
-        it('shows the memo of the receiver', () => {
+        it('shows the message of the transaction', () => {
           expect(transaction.findAll('div').at(5).text()).toContain('Für das Fahrrad!')
         })
 

--- a/frontend/src/views/Pages/AccountOverview/GddTransactionList.spec.js
+++ b/frontend/src/views/Pages/AccountOverview/GddTransactionList.spec.js
@@ -55,7 +55,7 @@ describe('GddTransactionList', () => {
           transactions: [
             {
               balance: '19.93',
-              date: '2021-05-25T17:38:13+00:00',
+              date: 'Tue May 25 2021',
               memo: 'Alles Gute zum Geburtstag',
               name: 'Bob der Baumeister',
               transaction_id: 29,
@@ -64,7 +64,7 @@ describe('GddTransactionList', () => {
             },
             {
               balance: '1000',
-              date: '2021-04-29T15:34:49+00:00',
+              date: '2021-04-29',
               memo: 'Gut das du da bist!',
               name: 'Gradido Akademie',
               transaction_id: 3,
@@ -72,7 +72,7 @@ describe('GddTransactionList', () => {
             },
             {
               balance: '314.98',
-              date: '2021-04-29T17:26:40+00:00',
+              date: '2021-04-29',
               memo: 'Für das Fahrrad!',
               name: 'Jan Ulrich',
               transaction_id: 8,
@@ -123,9 +123,7 @@ describe('GddTransactionList', () => {
         })
 
         it('shows the date of the transaction', () => {
-          expect(transaction.findAll('div').at(8).text()).toContain(
-            'Tue May 25 2021 19:38:13 GMT+0200',
-          )
+          expect(transaction.findAll('div').at(8).text()).toContain('Tue May 25 2021')
         })
 
         it('shows the decay calculation', () => {
@@ -191,9 +189,7 @@ describe('GddTransactionList', () => {
         })
 
         it('shows the date of the transaction', () => {
-          expect(transaction.findAll('div').at(8).text()).toContain(
-            'Thu Apr 29 2021 19:26:40 GMT+0200',
-          )
+          expect(transaction.findAll('div').at(8).text()).toContain('Thu Apr 29 2021')
         })
 
         it('shows the decay calculation', () => {

--- a/frontend/src/views/Pages/AccountOverview/GddTransactionList.spec.js
+++ b/frontend/src/views/Pages/AccountOverview/GddTransactionList.spec.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import GddTransactionList from './GddTransactionList'
+import flushPromises from 'flush-promises'
 
 const localVue = global.localVue
 
@@ -18,6 +19,9 @@ describe('GddTransactionList', () => {
     $n: jest.fn((n) => n),
     $t: jest.fn((t) => t),
     $d: jest.fn((d) => d),
+    $i18n: {
+      locale: () => 'en',
+    },
   }
 
   const Wrapper = () => {
@@ -81,6 +85,7 @@ describe('GddTransactionList', () => {
           ],
           transactionCount: 12,
         })
+        await flushPromises()
       })
 
       it('renders 4 transactions', () => {

--- a/frontend/src/views/Pages/AccountOverview/GddTransactionList.spec.js
+++ b/frontend/src/views/Pages/AccountOverview/GddTransactionList.spec.js
@@ -19,7 +19,7 @@ describe('GddTransactionList', () => {
     $t: jest.fn((t) => t),
     $d: jest.fn((d) => d),
     $i18n: {
-      locale: () => 'en',
+      locale: () => 'de',
     },
   }
 
@@ -60,6 +60,7 @@ describe('GddTransactionList', () => {
               name: 'Bob der Baumeister',
               transaction_id: 29,
               type: 'send',
+              decay: { balance: '0.5' },
             },
             {
               balance: '1000',
@@ -76,6 +77,7 @@ describe('GddTransactionList', () => {
               name: 'Jan Ulrich',
               transaction_id: 8,
               type: 'receive',
+              decay: { balance: '1.5' },
             },
             {
               balance: '1.07',
@@ -113,11 +115,21 @@ describe('GddTransactionList', () => {
         })
 
         it('shows the name of the receiver', () => {
-          expect(transaction.findAll('div').at(3).text()).toContain('Bob der Baumeister')
+          expect(transaction.findAll('div').at(0).text()).toContain('Bob der Baumeister')
+        })
+
+        it('shows the memo of the receiver', () => {
+          expect(transaction.findAll('div').at(5).text()).toContain('Alles Gute zum Geburtstag')
         })
 
         it('shows the date of the transaction', () => {
-          expect(transaction.findAll('div').at(3).text()).toContain('Tue May 25 2021')
+          expect(transaction.findAll('div').at(8).text()).toContain(
+            'Tue May 25 2021 19:38:13 GMT+0200',
+          )
+        })
+
+        it('shows the decay calculation', () => {
+          expect(transaction.findAll('div').at(9).text()).toContain('-0.5')
         })
       })
 
@@ -167,19 +179,25 @@ describe('GddTransactionList', () => {
         })
 
         it('shows the amount of transaction', () => {
-          expect(transaction.findAll('div').at(2).text()).toContain('314.98')
-        })
-
-        it('has a plus operator', () => {
-          expect(transaction.findAll('div').at(2).text()).toContain('+')
+          expect(transaction.findAll('div').at(2).text()).toContain('+ 314.98')
         })
 
         it('shows the name of the receiver', () => {
-          expect(transaction.findAll('div').at(3).text()).toContain('Jan Ulrich')
+          expect(transaction.findAll('div').at(0).text()).toContain('Jan Ulrich')
+        })
+
+        it('shows the memo of the receiver', () => {
+          expect(transaction.findAll('div').at(5).text()).toContain('Für das Fahrrad!')
         })
 
         it('shows the date of the transaction', () => {
-          expect(transaction.findAll('div').at(3).text()).toContain('Thu Apr 29 2021')
+          expect(transaction.findAll('div').at(8).text()).toContain(
+            'Thu Apr 29 2021 19:26:40 GMT+0200',
+          )
+        })
+
+        it('shows the decay calculation', () => {
+          expect(transaction.findAll('div').at(9).text()).toContain('-1.5')
         })
       })
 

--- a/frontend/src/views/Pages/AccountOverview/GddTransactionList.spec.js
+++ b/frontend/src/views/Pages/AccountOverview/GddTransactionList.spec.js
@@ -55,7 +55,7 @@ describe('GddTransactionList', () => {
           transactions: [
             {
               balance: '19.93',
-              date: 'Tue May 25 2021',
+              date: '2021-05-25T17:38:13+00:00',
               memo: 'Alles Gute zum Geburtstag',
               name: 'Bob der Baumeister',
               transaction_id: 29,
@@ -64,7 +64,7 @@ describe('GddTransactionList', () => {
             },
             {
               balance: '1000',
-              date: '2021-04-29',
+              date: '2021-04-29T15:34:49+00:00',
               memo: 'Gut das du da bist!',
               name: 'Gradido Akademie',
               transaction_id: 3,
@@ -72,7 +72,7 @@ describe('GddTransactionList', () => {
             },
             {
               balance: '314.98',
-              date: '2021-04-29',
+              date: '2021-04-29T17:26:40+00:00',
               memo: 'Für das Fahrrad!',
               name: 'Jan Ulrich',
               transaction_id: 8,

--- a/frontend/src/views/Pages/AccountOverview/GddTransactionList.vue
+++ b/frontend/src/views/Pages/AccountOverview/GddTransactionList.vue
@@ -19,10 +19,11 @@
             <small v-if="type === 'decay'">{{ $n(balance, 'decimal') }}</small>
 
             <span v-else>{{ $n(balance, 'decimal') }}</span>
-  <div><small >
-                  {{ $t('form.message') }}
-                </small>
-             </div>
+            <div>
+              <small >
+                {{ $t('form.message') }}
+              </small>
+            </div>
             <div v-if="decay">
               <br />
               <b-icon v-if="type != 'decay'" icon="droplet-half" height="15" class="mb-3" />
@@ -61,14 +62,6 @@
                 <div style="width: 60%">
                   {{ name }}
                   <b-avatar class="mr-3"></b-avatar>
-                </div>
-              </div>
-              <div class="d-flex">
-                <div style="width: 40%" class="text-right pr-3 mr-2">
-                   {{$t('form.message')}}  
-                </div>
-                <div style="width: 60%">
-                  {{ memo }}
                 </div>
               </div>
             </b-list-group-item>

--- a/frontend/src/views/Pages/AccountOverview/GddTransactionList.vue
+++ b/frontend/src/views/Pages/AccountOverview/GddTransactionList.vue
@@ -9,18 +9,18 @@
         <!-- ROW Start -->
         <div class="d-flex gdd-transaction-list-item" v-b-toggle="'a' + date + ''">
           <!-- ICON -->
-          <div style="width: 8%">
+          <div class="tap1" style="width: 8%">
             <b-icon :icon="getProperties(type).icon" :class="getProperties(type).class" />
           </div>
           <!-- Text Links -->
-          <div class="font1_2em pr-2 text-right" style="width: 32%">
+          <div class="font1_2em pr-2 text-right tap2" style="width: 32%">
             <span>{{ getProperties(type).operator }}</span>
-          
+
             <small v-if="type === 'decay'">{{ $n(balance, 'decimal') }}</small>
 
             <span v-else>{{ $n(balance, 'decimal') }}</span>
             <div>
-              <small >
+              <small>
                 {{ $t('form.message') }}
               </small>
             </div>
@@ -30,20 +30,23 @@
             </div>
           </div>
           <!-- Text Rechts -->
-          <div class="font1_2em text-left pl-2" style="width: 55%">
+          <div class="font1_2em text-left pl-2 tap3" style="width: 55%">
             {{ name ? name : '' }}
-             <div><small >
-                  {{ memo }}
-                </small>
-             </div>
+            <div>
+              <small>
+                {{ memo }}
+              </small>
+            </div>
             <span v-if="type === 'decay'">
               <small>{{ $t('decay.decay_since_last_transaction') }}</small>
             </span>
-            <div v-if="date" class="text-sm">{{ $d($moment(date), 'long') }} {{ $i18n.locale === 'de' ? 'Uhr' : '' }}</div>
+            <div v-if="date" class="text-sm">
+              {{ $d($moment(date), 'long') }} {{ $i18n.locale === 'de' ? 'Uhr' : '' }}
+            </div>
             <decay-information v-if="decay" decaytyp="short" :decay="decay" />
           </div>
           <!-- Collaps Toggle Button -->
-          <div v-if="type != 'decay'" class="text-right" style="width: 5%">
+          <div v-if="type != 'decay'" class="text-right tap4" style="width: 5%">
             <b-button class="btn-sm">
               <b>i</b>
             </b-button>
@@ -57,7 +60,6 @@
               <div class="d-flex">
                 <div style="width: 40%" class="text-right pr-3 mr-2">
                   {{ type === 'receive' ? $t('form.from') : $t('form.to1') }}:
-                    
                 </div>
                 <div style="width: 60%">
                   {{ name }}

--- a/frontend/src/views/Pages/AccountOverview/GddTransactionList.vue
+++ b/frontend/src/views/Pages/AccountOverview/GddTransactionList.vue
@@ -15,10 +15,14 @@
           <!-- Text Links -->
           <div class="font1_2em pr-2 text-right" style="width: 32%">
             <span>{{ getProperties(type).operator }}</span>
+          
             <small v-if="type === 'decay'">{{ $n(balance, 'decimal') }}</small>
 
             <span v-else>{{ $n(balance, 'decimal') }}</span>
-
+  <div><small >
+                  {{ $t('form.message') }}
+                </small>
+             </div>
             <div v-if="decay">
               <br />
               <b-icon v-if="type != 'decay'" icon="droplet-half" height="15" class="mb-3" />
@@ -27,10 +31,14 @@
           <!-- Text Rechts -->
           <div class="font1_2em text-left pl-2" style="width: 55%">
             {{ name ? name : '' }}
+             <div><small >
+                  {{ memo }}
+                </small>
+             </div>
             <span v-if="type === 'decay'">
               <small>{{ $t('decay.decay_since_last_transaction') }}</small>
             </span>
-            <div v-if="date" class="text-sm">{{ $d($moment(date), 'long') }}</div>
+            <div v-if="date" class="text-sm">{{ $d($moment(date), 'long') }} {{ $i18n.locale === 'de' ? 'Uhr' : '' }}</div>
             <decay-information v-if="decay" decaytyp="short" :decay="decay" />
           </div>
           <!-- Collaps Toggle Button -->
@@ -47,7 +55,8 @@
             <b-list-group-item style="border: 0px; background-color: #f1f1f1">
               <div class="d-flex">
                 <div style="width: 40%" class="text-right pr-3 mr-2">
-                  {{ type === 'receive' ? 'von:' : 'an:' }}
+                  {{ type === 'receive' ? $t('form.from') : $t('form.to1') }}:
+                    
                 </div>
                 <div style="width: 60%">
                   {{ name }}
@@ -56,7 +65,7 @@
               </div>
               <div class="d-flex">
                 <div style="width: 40%" class="text-right pr-3 mr-2">
-                  {{ type === 'receive' ? 'Nachricht:' : 'Nachricht:' }}
+                   {{$t('form.message')}}  
                 </div>
                 <div style="width: 60%">
                   {{ memo }}

--- a/frontend/src/views/Pages/AccountOverview/GddTransactionList.vue
+++ b/frontend/src/views/Pages/AccountOverview/GddTransactionList.vue
@@ -9,19 +9,19 @@
         <!-- ROW Start -->
         <div class="d-flex gdd-transaction-list-item" v-b-toggle="'a' + date + ''">
           <!-- ICON -->
-          <div class="tap1" style="width: 8%">
+          <div style="width: 8%">
             <b-icon :icon="getProperties(type).icon" :class="getProperties(type).class" />
           </div>
           <!-- Text Links -->
-          <div class="font1_2em pr-2 text-right tap2" style="width: 32%">
+          <div class="font1_2em pr-2 text-right" style="width: 32%">
             <span>{{ getProperties(type).operator }}</span>
 
             <small v-if="type === 'decay'">{{ $n(balance, 'decimal') }}</small>
 
             <span v-else>{{ $n(balance, 'decimal') }}</span>
-            <div>
+            <div v-if="type !== 'decay' && type !== 'creation'">
               <small>
-                {{ $t('form.message') }}
+                {{ $t('form.memo') }}
               </small>
             </div>
             <div v-if="decay">
@@ -30,8 +30,8 @@
             </div>
           </div>
           <!-- Text Rechts -->
-          <div class="font1_2em text-left pl-2 tap3" style="width: 55%">
-            {{ name ? name : '' }}
+          <div class="font1_2em text-left pl-2" style="width: 55%">
+            <div>{{ name ? name : '' }}</div>
             <div>
               <small>
                 {{ memo }}
@@ -46,7 +46,7 @@
             <decay-information v-if="decay" decaytyp="short" :decay="decay" />
           </div>
           <!-- Collaps Toggle Button -->
-          <div v-if="type != 'decay'" class="text-right tap4" style="width: 5%">
+          <div v-if="type != 'decay'" class="text-right" style="width: 5%">
             <b-button class="btn-sm">
               <b>i</b>
             </b-button>
@@ -55,24 +55,11 @@
         <!-- ROW End -->
         <!-- Collaps Start -->
         <b-collapse v-if="type != 'decay'" :id="'a' + date + ''">
-          <b-list-group v-if="type === 'receive' || type === 'send'">
-            <b-list-group-item style="border: 0px; background-color: #f1f1f1">
-              <div class="d-flex">
-                <div style="width: 40%" class="text-right pr-3 mr-2">
-                  {{ type === 'receive' ? $t('form.from') : $t('form.to1') }}:
-                </div>
-                <div style="width: 60%">
-                  {{ name }}
-                  <b-avatar class="mr-3"></b-avatar>
-                </div>
-              </div>
-            </b-list-group-item>
-          </b-list-group>
           <b-list-group v-if="type === 'creation'">
             <b-list-group-item style="border: 0px">
               <div class="d-flex">
-                <div style="width: 40%" class="text-right pr-3 mr-2">Schöpfung</div>
-                <div style="width: 60%">Aus der Community</div>
+                <div style="width: 40%" class="text-right pr-3 mr-2">{{ $t('decay.created') }}</div>
+                <div style="width: 60%">{{ $t('decay.fromCommunity') }}</div>
               </div>
             </b-list-group-item>
           </b-list-group>

--- a/frontend/src/views/Pages/ForgotPassword.vue
+++ b/frontend/src/views/Pages/ForgotPassword.vue
@@ -22,7 +22,7 @@
                   <input-email v-model="form.email"></input-email>
                   <div class="text-center">
                     <b-button type="submit" variant="primary">
-                      {{ $t('site.password.reset_now') }}
+                      {{ $t('site.password.send_now') }}
                     </b-button>
                   </div>
                 </b-form>


### PR DESCRIPTION
## 🍰 Pullrequest
frontend text improvemets
 
- forgotPassword: Change text of button from Send now to  Jetzt senden
- Email field in send GDD form must be called: Recipient
- Only Message, Nachricht as label for the memo field of the send Gdd form
- Transaction list, von, an and Nachricht is not localized. Uhr must be removed
- Minus sign before the decay value in the detail view of a transaction.
- memo text of transaction should always be shown
- Content menu english: Members area (remove ')


PLUS ... I could not leave it ... 
is only changed the html

  
![FireShot Capture 018 - Gradido Account - localhost](https://user-images.githubusercontent.com/1324583/126032943-27dd579e-e1e0-4a1c-b013-4901f0b109b3.png)


### Issues
-  #630 
- #597 
- #591 

