### PR TITLE
fix display error with creation

### DIFF
--- a/community_server/src/Model/Table/TransactionsTable.php
+++ b/community_server/src/Model/Table/TransactionsTable.php
@@ -236,13 +236,12 @@ class TransactionsTable extends Table
            
             if($su_transaction->transaction_type_id == 1) { // creation
                 $creation = $transaction->transaction_creation;
-                $balance = $stateBalancesTable->calculateDecay($creation->amount, $creation->target_date, $transaction->received);
                 
                 $final_transaction['name'] = 'Gradido Akademie';
                 $final_transaction['type'] = 'creation';
                 $final_transaction['target_date'] = $creation->target_date;
-                $final_transaction['creation_amount'] = $creation->amount;
-                $final_transaction['balance'] = $balance;
+                //$final_transaction['creation_amount'] = $creation->amount;
+                $final_transaction['balance'] = $creation->amount;
                 
             } else if($su_transaction->transaction_type_id == 2) { // transfer or send coins
                 $sendCoins = $transaction->transaction_send_coin;

--- a/community_server/tests/TestCase/Controller/AppRequestControllerTest.php
+++ b/community_server/tests/TestCase/Controller/AppRequestControllerTest.php
@@ -168,7 +168,6 @@ class AppRequestControllerTest extends TestCase
 			"name": "Gradido Akademie",
 			"type": "creation",
 			"target_date": "2021-01-01T00:00:00+00:00",
-			"creation_amount": 10000000,
 			"balance": 10000000
 		},
 		{


### PR DESCRIPTION
## 🍰 Pullrequest
Currently the creation transaction will be shown with delay between targe_date and received, but we've decided to use the recevied as start date for decay the same as by transfer transactions. 

I had already updated the code, but i've forgott that for the api call the decay will be calculated seperatly. 
I have now remove this line. 

### Issues
- fixes #644

