### PR TITLE
Login-Server bug fix, allow names with 2 characters also

### DIFF
--- a/login_server/src/cpp/SingletonManager/SessionManager.cpp
+++ b/login_server/src/cpp/SingletonManager/SessionManager.cpp
@@ -43,7 +43,7 @@ bool SessionManager::init()
 	for (i = 0; i < VALIDATE_MAX; i++) {
 		switch (i) {
 		//case VALIDATE_NAME: mValidations[i] = new Poco::RegularExpression("/^[a-zA-Z_ -]{3,}$/"); break;
-		case VALIDATE_NAME: mValidations[i] = new Poco::RegularExpression("^[^<>&;]{3,}$"); break;
+		case VALIDATE_NAME: mValidations[i] = new Poco::RegularExpression("^[^<>&;]{2,}$"); break;
 		case VALIDATE_USERNAME: mValidations[i] = new Poco::RegularExpression("^[a-zA-Z][a-zA-Z0-9_-]*$"); break;
 		case VALIDATE_EMAIL: mValidations[i] = new Poco::RegularExpression("^[a-zA-Z0-9.!#$%&?*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$"); break;
 		case VALIDATE_PASSWORD: mValidations[i] = new Poco::RegularExpression("^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[@$!%*?&+-_])[A-Za-z0-9@$!%*?&+-_]{8,}$"); break;


### PR DESCRIPTION
## 🍰 Pullrequest
Until now first- and last names need to have at least 3 characters. 
But now someone has tried to registered with "Jo" as his first name. 
So I changed the rule for names validation to have at least 2 characters. 

