### PR TITLE
bugfix: change to new frontend passwort reset

### DIFF
--- a/login_server/src/cpp/HTTPInterface/PageRequestMessagedHandler.cpp
+++ b/login_server/src/cpp/HTTPInterface/PageRequestMessagedHandler.cpp
@@ -84,3 +84,11 @@ std::string PageRequestMessagedHandler::getBaseUrl()
 	}
 	return "https://" + mHost + mLoginServerPath; 
 }
+
+std::string PageRequestMessagedHandler::getHost()
+{
+	if (ServerConfig::g_ServerSetupType == ServerConfig::SERVER_TYPE_TEST) {
+		return "http://" + mHost;
+	}
+	return "https://" + mHost;
+}

--- a/login_server/src/cpp/HTTPInterface/PageRequestMessagedHandler.h
+++ b/login_server/src/cpp/HTTPInterface/PageRequestMessagedHandler.h
@@ -29,6 +29,7 @@ protected:
 
 	unsigned long long getLastGetAsU64(const std::string& uri);
 	std::string getBaseUrl();
+	std::string getHost();
 
 	Profiler mTimeProfiler;
 	std::string mHost;

--- a/login_server/src/cpsp/Login.cpsp
+++ b/login_server/src/cpsp/Login.cpsp
@@ -299,7 +299,7 @@
 		  </a>
 	    </div>
 		<div class="reset-pwd-link">
-			<a href="<%= getBaseUrl() %>/resetPassword"><%= langCatalog->gettext("Passwort vergessen") %></a>
+			<a href="<%= getHost() %>/vue/password"><%= langCatalog->gettext("Passwort vergessen") %></a>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
## 🍰 Pullrequest
Vom Support habe ich die Meldung bekommen das die Passwort zurücksetzen Funktion im altend frontend nicht mehr funktioniert.
Eine Analyse hat ergeben, das dies durch mein Bugfix am 15.07 ans Licht gekommen ist.
Sie hat davor nur durch einen unbeabsichtigten Side-Effect funktioniert. 

Ich hatte damals dummerweise versucht den Passwort reset und das Email aktivieren ohne redirects umzusetzen,
was das ganze sehr kompliziert und fehleranfällig gemacht hat. 
Daher sehe ich jetzt davon ab das zu fixen, bzw. zu refactoren und lege stattdessen den "Paswort vergessen" Link vom alten Frontend auf die entsprechende Seite vom neuen Frontend. 

Ja Ulf, ich gebe endlich zu das ich beim Login-Server einige Konzeptionsfehler gemacht habe, was ihn in bestimmten Bereichen fehleranfällig gemacht hat. Ich hätte von Anfang an mit einem js-frontend arbeiten sollen wie ich es eigentlich vorhatte. Und gleich den Kurs wechseln sollen, nachdem Bernd zugegeben hat das ich js doch im Frontend verwenden kann. 
Ich habe versucht das ganze User-Interface ohne js und anfangs mit möglichst wenigen redirects abzubilden. 
Das war ein Fehler, dafür ist js tatsächlich besser geeignet. 
Wir sollten allerdings jetzt auch nicht den Fehler machen alles mit js abbilden zu wollen. Das wird vermutlich genauso nach hinten losgehen. 

