### PR TITLE
database_reachable_in_testmode

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -76,6 +76,13 @@ services:
       - ./community_server/config/php-fpm/php-ini-overrides.ini:/etc/php/7.4/fpm/conf.d/99-overrides.ini
       - ./community_server/src:/var/www/cakephp/src
 
+  #########################################################
+  ## MARIADB ##############################################
+  #########################################################
+  mariadb:
+    networks: 
+      - internal-net
+      - external-net
       
   #########################################################
   ## NGINX ################################################


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

allow maria db to be reachable from outside the docker environment in the test environment.

This will allow you to connect to the database with the tool of your choice. E.g. VSCodium:

![image](https://user-images.githubusercontent.com/1238238/130353134-26b8fbd5-a640-4aa9-9611-39a9dc60487b.png)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None