### PR TITLE
fix_database_migrations

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -22,9 +22,10 @@ const DB_VERSION = '0001-init_db'
 async function main() {
   // check for correct database version
   const con = await connection()
-  const [rows] = await con.query(`SELECT fileName FROM migrations ORDER BY version DESC LIMIT 1;`)
+  const [rows] = await con.query(`SELECT * FROM migrations ORDER BY version DESC LIMIT 1;`)
   if (
     (<RowDataPacket>rows).length === 0 ||
+    !(<RowDataPacket>rows)[0].fileName ||
     (<RowDataPacket>rows)[0].fileName.indexOf(DB_VERSION) === -1
   ) {
     throw new Error(`Wrong database version - the backend requires '${DB_VERSION}'`)

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -58,6 +58,7 @@ services:
       # This makes sure the docker container has its own node modules.
       # Therefore it is possible to have a different node version on the host machine
       - database_node_modules:/app/node_modules
+      - database_build:/app/build
       # bind the local folder to the docker to allow live reload
       - ./database:/app
 
@@ -149,4 +150,5 @@ volumes:
   frontend_node_modules:
   backend_node_modules:
   database_node_modules:
+  database_build:
   login_build_ubuntu_3.1:


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

This PR fixes two problems which came to light after running the database tool on an external environment (alex):
- if the old migration table is present selecting `fileName` will result in an SQL error
- when building in development environment the docker container contains the built files, but files are read from local harddrive where the build folder is not present. We mount a drive for the build folder in development mode. This happens since we always use the built variant of the database project since the table contains the filename - which then varies between js & ts (it is unclear how this will affect development on this tool, but in most cases one will use a clean database and use the `yarn dev_up/down/reset` commands which will use the `.ts` file endings - therefore its negligible for now)

Both fixes are essential to have the database migration tool run out of the box.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
