### PR TITLE
Remove discord link for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->
+
 <!--
 Please take a look at the issue templates at https://github.com/gradido/gradido/issues/new/choose
 before submitting a new issue. Following one of the issue templates will ensure maintainers can route your request efficiently.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,7 @@ about: Create a report to help us improve
 labels: bug
 title: 🐛 [Bug] 
 ---
+<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->
 
 ## 🐛 Bugreport
 <!-- Describe your issue in detail. Include screenshots if needed. Give us as much information as possible. Use a clear and concise description of what the bug is.-->

--- a/.github/ISSUE_TEMPLATE/devops_ticket.md
+++ b/.github/ISSUE_TEMPLATE/devops_ticket.md
@@ -1,9 +1,10 @@
 ---
 name: 💥 DevOps ticket
-about: Help us manage our deployed App.
+about: Help us manage our deployed Software.
 labels: devops
 title: 💥 [DevOps]
 ---
+<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->
 
 ## 💥 DevOps ticket
 <!-- Describe your issue in detail. Include screenshots if needed. Give us as much information as possible. Use a clear and concise description of what the problem is.-->

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -4,9 +4,10 @@ about: Define a big development Step
 labels: epic
 title: 🌟 [EPIC] 
 ---
+<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->
+
 <!-- THIS ISSUE-TYPE IS NOT FOR YOU! -->
-<!-- Proceed only if you know what you are doing - go chat with Team Gradido -->
-<!-- Visit the Gradido Discord: https://discord.gg/kA3zBAKQDC -->
+<!-- Proceed only if you know what you are doing - have a chat with Project's Team first -->
 
 ## 🌟 EPIC
 <!-- Describe your Epic in detail. Include screenshots and drawings -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,6 +4,7 @@ about: Suggest an idea for this project
 labels: feature
 title: 🚀 [Feature] 
 ---
+<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->
 
 ## 🚀 Feature
 <!-- Give a short summary of the Feature. Use Screenshots if you want. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,11 +1,13 @@
 ---
 name: 💬 Question
-about: If you need help understanding Gradido.
+about: If you need help understanding our Software.
 labels: question
 title: 💬 [Question] 
 ---
-<!-- Chat with Team Gradido -->
-<!-- If you need an answer right away, visit the Gradido Discord: https://discord.gg/kA3zBAKQDC -->
+<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->
+
+<!-- Question the project's team -->
+<!-- If you need an answer right away, consider to take other means of communication with the project's team -->
 
 ## 💬 Question
 <!-- Describe your Question in detail. Include screenshots and drawings if needed. -->

--- a/.github/ISSUE_TEMPLATE/refactor_ticket.md
+++ b/.github/ISSUE_TEMPLATE/refactor_ticket.md
@@ -4,6 +4,7 @@ about: Help us improve our code by refactoring it.
 labels: refactor
 title: 🔧 [Refactor]
 ---
+<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->
 
 ## 🔧 Refactor ticket
 <!-- Describe your issue in detail. Include screenshots if needed. Give us as much information as possible. Use a clear and concise description of what the problem is.-->

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -4,9 +4,10 @@ about: Define a Release
 labels: release
 title: 🏅 [RELEASE] 
 ---
+<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->
+
 <!-- THIS ISSUE-TYPE IS NOT FOR YOU! -->
-<!-- Proceed only if you know what you are doing - go chat with Team Gradido -->
-<!-- Visit the Gradido Discord: https://discord.gg/kA3zBAKQDC -->
+<!-- Proceed only if you know what you are doing - have a chat with Project's Team first -->
 
 ## 🏅 RELEASE
 <!-- Describe your Release in detail. Include screenshots and drawings -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->
+
 ## 🍰 Pullrequest
 <!-- Describe the Pullrequest. Use Screenshots if possible. -->
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

- remove discord links from templates
- make the templates project agnostic
- link to the new repo https://github.com/ulfgebhardt/issue-templates to have it compatible
- rename refactor tickets into .. ticket

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
