### PR TITLE
disable auto-resend of not finished transactions on login-server restart

### DIFF
--- a/login_server/src/cpp/ServerConfig.cpp
+++ b/login_server/src/cpp/ServerConfig.cpp
@@ -57,6 +57,7 @@ namespace ServerConfig {
 	int         g_FakeLoginSleepTime = 820;
 	std::string g_versionString = "";
 	bool		g_disableEmail = false;
+	bool	    g_resendTransactionOnStart = false;
 	ServerSetupType g_ServerSetupType = SERVER_TYPE_PRODUCTION;
 	std::string g_devDefaultGroup = "";
 	std::string g_gRPCRelayServerFullURL;
@@ -259,23 +260,7 @@ namespace ServerConfig {
 			g_AllowUnsecureFlags = (AllowUnsecure)(g_AllowUnsecureFlags | UNSECURE_ALLOW_ALL_PASSWORDS);
 		}
 
-
-		g_gRPCRelayServerFullURL = cfg.getString("grpc.server", "");
-
-		// unsecure flags
-		//g_AllowUnsecureFlags
-		if (cfg.getInt("unsecure.allow_passwort_via_json_request", 0) == 1) {
-			g_AllowUnsecureFlags = (AllowUnsecure)(g_AllowUnsecureFlags | UNSECURE_PASSWORD_REQUESTS);
-		}
-		if (cfg.getInt("unsecure.allow_auto_sign_transactions", 0) == 1) {
-			g_AllowUnsecureFlags = (AllowUnsecure)(g_AllowUnsecureFlags | UNSECURE_AUTO_SIGN_TRANSACTIONS);
-		}
-		if (cfg.getInt("unsecure.allow_cors_all", 0) == 1) {
-			g_AllowUnsecureFlags = (AllowUnsecure)(g_AllowUnsecureFlags | UNSECURE_CORS_ALL);
-		}
-		if (cfg.getInt("unsecure.allow_all_passwords", 0) == 1) {
-			g_AllowUnsecureFlags = (AllowUnsecure)(g_AllowUnsecureFlags | UNSECURE_ALLOW_ALL_PASSWORDS);
-		}
+		g_resendTransactionOnStart = cfg.getBool("dev.resend_unfinished_transactions_on_start", false);
 
 		return true;
 	}

--- a/login_server/src/cpp/ServerConfig.cpp
+++ b/login_server/src/cpp/ServerConfig.cpp
@@ -57,7 +57,7 @@ namespace ServerConfig {
 	int         g_FakeLoginSleepTime = 820;
 	std::string g_versionString = "";
 	bool		g_disableEmail = false;
-	bool	    g_resendTransactionOnStart = false;
+	bool	    g_resendUnfinishedTransactionOnStart = false;
 	ServerSetupType g_ServerSetupType = SERVER_TYPE_PRODUCTION;
 	std::string g_devDefaultGroup = "";
 	std::string g_gRPCRelayServerFullURL;
@@ -260,7 +260,7 @@ namespace ServerConfig {
 			g_AllowUnsecureFlags = (AllowUnsecure)(g_AllowUnsecureFlags | UNSECURE_ALLOW_ALL_PASSWORDS);
 		}
 
-		g_resendTransactionOnStart = cfg.getBool("dev.resend_unfinished_transactions_on_start", false);
+		g_resendUnfinishedTransactionOnStart = cfg.getBool("dev.resend_unfinished_transactions_on_start", false);
 
 		return true;
 	}

--- a/login_server/src/cpp/ServerConfig.h
+++ b/login_server/src/cpp/ServerConfig.h
@@ -73,6 +73,7 @@ namespace ServerConfig {
 	extern int         g_FakeLoginSleepTime;
 	extern std::string g_versionString;
 	extern bool		   g_disableEmail;
+	extern bool		   g_resendTransactionOnStart;
 	extern ServerSetupType g_ServerSetupType;
 	extern std::string g_devDefaultGroup;
 	extern std::string g_gRPCRelayServerFullURL;

--- a/login_server/src/cpp/ServerConfig.h
+++ b/login_server/src/cpp/ServerConfig.h
@@ -73,7 +73,7 @@ namespace ServerConfig {
 	extern int         g_FakeLoginSleepTime;
 	extern std::string g_versionString;
 	extern bool		   g_disableEmail;
-	extern bool		   g_resendTransactionOnStart;
+	extern bool		   g_resendUnfinishedTransactionOnStart;
 	extern ServerSetupType g_ServerSetupType;
 	extern std::string g_devDefaultGroup;
 	extern std::string g_gRPCRelayServerFullURL;

--- a/login_server/src/cpp/model/gradido/Transaction.cpp
+++ b/login_server/src/cpp/model/gradido/Transaction.cpp
@@ -204,7 +204,7 @@ namespace model {
 				}
 			}
 			// try not finished but signed transactions again
-			if (!finished) {
+			if (!finished && ServerConfig::g_resendTransactionOnStart) {
 				transaction->ifEnoughSignsProceed(nullptr);
 			}
 

--- a/login_server/src/cpp/model/gradido/Transaction.cpp
+++ b/login_server/src/cpp/model/gradido/Transaction.cpp
@@ -204,7 +204,7 @@ namespace model {
 				}
 			}
 			// try not finished but signed transactions again
-			if (!finished && ServerConfig::g_resendTransactionOnStart) {
+			if (!finished && ServerConfig::g_resendUnfinishedTransactionOnStart) {
 				transaction->ifEnoughSignsProceed(nullptr);
 			}
 


### PR DESCRIPTION
## 🍰 Pullrequest
### Problem
Login-Server try to resend not finished transaction on restart again.
The reason from the start was that no transactions get's lost by server crash. 
But in production this lead to creation transaction which are invalid because the user has already get enough Gradidos,
resend every time if login-server is startet new. And therefore send again the error message confusing the creator.

### Solution
Make it optional with additional option in config with default false.

### Additional
Removed double code which seems to resulting from some merge or rebase in past