### PR TITLE
Community-Server Test with new db migration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -422,11 +422,6 @@ jobs:
                  --health-interval=5s
                  --health-timeout=5s
                  --health-retries=3
-      database:
-        image: gradido/database:production_up
-        env:
-           NODE_ENV: "production"
-           DB_HOST: mariadb
     steps:
       - name: get mariadb container id
         run: echo "::set-output name=id::$(docker container ls | grep mariadb | awk '{ print $1 }')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -423,11 +423,17 @@ jobs:
                  --health-timeout=5s
                  --health-retries=3
     steps:
+      - name: get mariadb container id
+        run: echo "::set-output name=id::$(docker container ls | grep mariadb | awk '{ print $1 }')"
+        id: mariadb_container
       - name: get automatic created network
         run: echo "::set-output name=id::$(docker network ls | grep github_network | awk '{ print $1 }')"
         id: network
       - name: Start database migration
         run: docker run --network ${{ steps.network.outputs.id }} --name=database -d gradido/database:production_up --env NODE_ENV=production --env DB_HOST=mariadb --target production_up
+      - name: get database migration container id
+        run: echo "::set-output name=id::$(docker container ls | grep database | awk '{ print $1 }')"
+        id: database_container
       - name: Start Login-Server
         run: docker run --network ${{ steps.network.outputs.id }} --name=login-server -d gradido/login_server:with-config
       - name: get login-server container id
@@ -448,6 +454,13 @@ jobs:
           path: /tmp
       - name: Load Docker Image
         run: docker load < /tmp/community_server.tar
+      # for debugging login-server
+      - name: check login-server
+        run: docker logs ${{ steps.login_server_container.outputs.id }}
+      - name: check mariadb
+        run: docker logs ${{ steps.mariadb_container.outputs.id }}
+      - name: check migration
+        run: docker logs ${{ steps.database_container.outputs.id }}
       ##########################################################################
       # UNIT TESTS BACKEND COMMUNITY-SERVER  #######################################
       ##########################################################################

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -423,9 +423,6 @@ jobs:
                  --health-timeout=5s
                  --health-retries=3
     steps:
-      - name: get mariadb container id
-        run: echo "::set-output name=id::$(docker container ls | grep mariadb | awk '{ print $1 }')"
-        id: mariadb_container
       - name: get automatic created network
         run: echo "::set-output name=id::$(docker network ls | grep github_network | awk '{ print $1 }')"
         id: network

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -417,7 +417,6 @@ jobs:
         env:
            MARIADB_ALLOW_EMPTY_PASSWORD: 1
            MARIADB_USER: root
-           MARIADB_DATABASE: gradido_community_test
         options: --health-cmd="mysqladmin ping"
                  --health-interval=5s
                  --health-timeout=5s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -413,7 +413,7 @@ jobs:
     needs: [build_test_community_server]
     services: 
       mariadb:
-        image: mariadb/server:10.5
+        image: gradido/mariadb:test
         env:
            MARIADB_ALLOW_EMPTY_PASSWORD: 1
            MARIADB_USER: root
@@ -424,16 +424,9 @@ jobs:
                  --health-retries=3
       database:
         image: gradido/database:production_up
-        build:
-          context: ./database
-          target: production_up
-        depends_on:
-          - mariadb
-        networks:
-          - internal-net
-        environment:
-          - NODE_ENV="production"
-          - DB_HOST=mariadb
+        env:
+           NODE_ENV: "production"
+           DB_HOST: mariadb
     steps:
       - name: get mariadb container id
         run: echo "::set-output name=id::$(docker container ls | grep mariadb | awk '{ print $1 }')"
@@ -441,6 +434,8 @@ jobs:
       - name: get automatic created network
         run: echo "::set-output name=id::$(docker network ls | grep github_network | awk '{ print $1 }')"
         id: network
+      - name: Start database migration
+        run: docker run --network ${{ steps.network.outputs.id }} --name=database -d gradido/database:production_up --env NODE_ENV=production --env DB_HOST=mariadb --target production_up
       - name: Start Login-Server
         run: docker run --network ${{ steps.network.outputs.id }} --name=login-server -d gradido/login_server:with-config
       - name: get login-server container id

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -413,22 +413,31 @@ jobs:
     needs: [build_test_community_server]
     services: 
       mariadb:
-        image: gradido/mariadb:test
+        image: mariadb/server:10.5
         env:
            MARIADB_ALLOW_EMPTY_PASSWORD: 1
            MARIADB_USER: root
-       # ports: 
-        #  - 3306:3306
+           MARIADB_DATABASE: gradido_community_test
         options: --health-cmd="mysqladmin ping"
                  --health-interval=5s
                  --health-timeout=5s
                  --health-retries=3
+      database:
+        image: gradido/database:production_up
+        build:
+          context: ./database
+          target: production_up
+        depends_on:
+          - mariadb
+        networks:
+          - internal-net
+        environment:
+          - NODE_ENV="production"
+          - DB_HOST=mariadb
     steps:
       - name: get mariadb container id
         run: echo "::set-output name=id::$(docker container ls | grep mariadb | awk '{ print $1 }')"
         id: mariadb_container
-      - name: show networks
-        run: echo "$(docker network ls)"
       - name: get automatic created network
         run: echo "::set-output name=id::$(docker network ls | grep github_network | awk '{ print $1 }')"
         id: network
@@ -452,12 +461,6 @@ jobs:
           path: /tmp
       - name: Load Docker Image
         run: docker load < /tmp/community_server.tar
-        
-      # for debugging login-server
-      - name: check login-server
-        run: docker logs ${{ steps.login_server_container.outputs.id }}
-      - name: check mariadb
-        run: docker logs ${{ steps.mariadb_container.outputs.id }}
       ##########################################################################
       # UNIT TESTS BACKEND COMMUNITY-SERVER  #######################################
       ##########################################################################

--- a/database/src/prepare.ts
+++ b/database/src/prepare.ts
@@ -25,6 +25,12 @@ export default async (): Promise<void> => {
       DEFAULT CHARACTER SET utf8mb4
       DEFAULT COLLATE utf8mb4_unicode_ci;`)
 
+  // Create Database `gradido_community_test` for tests
+  await con.query(`
+    CREATE DATABASE IF NOT EXISTS ${CONFIG.DB_DATABASE}_test 
+      DEFAULT CHARACTER SET utf8mb4
+      DEFAULT COLLATE utf8mb4_unicode_ci;`)
+
   // Check if old migration table is present, delete if needed
   const [rows] = await con.query(`SHOW TABLES FROM \`${CONFIG.DB_DATABASE}\` LIKE 'migrations';`)
   if ((<RowDataPacket>rows).length > 0) {


### PR DESCRIPTION
## 🍰 Pullrequest
The community-server needs for testing in github workflow a db.
Until now a mariadb docker container was used, exported for testing gradido/mariadb:test
After the community-server sql files was removed from this config it don't longer work, after updating this container. 
So now we must use this new db migration container. 
Without this update, after the next change in community-server db tests will fail. 
Like in #831 

- removed some debugging stuff from github workflow