### PR TITLE
feat: Redirect to Login when JWT has expired

### DIFF
--- a/backend/src/jwt/decode.ts
+++ b/backend/src/jwt/decode.ts
@@ -5,7 +5,7 @@ import jwt from 'jsonwebtoken'
 import CONFIG from '../config/'
 
 export default (token: string): any => {
-  if (!token) return null
+  if (!token) return new Error('401 Unauthorized')
   let sessionId = null
   try {
     const decoded = jwt.verify(token, CONFIG.JWT_SECRET)
@@ -15,6 +15,6 @@ export default (token: string): any => {
       sessionId,
     }
   } catch (err) {
-    return null
+    throw new Error('403.13 - Client certificate revoked')
   }
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -36,7 +36,8 @@
   "error": {
     "change-password": "Fehler beim Ändern des Passworts",
     "error": "Fehler",
-    "no-account": "Leider konnten wir keinen Account finden mit diesen Daten!"
+    "no-account": "Leider konnten wir keinen Account finden mit diesen Daten!",
+    "session-expired": "Sitzung abgelaufen!"
   },
   "form": {
     "amount": "Betrag",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -36,7 +36,8 @@
   "error": {
     "change-password": "Error while changing password",
     "error": "Error",
-    "no-account": "Unfortunately we could not find an account to the given data!"
+    "no-account": "Unfortunately we could not find an account to the given data!",
+    "session-expired": "The session expired"
   },
   "form": {
     "amount": "Amount",

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -21,6 +21,12 @@ const authLink = new ApolloLink((operation, forward) => {
     },
   })
   return forward(operation).map((response) => {
+    if (response.errors && response.errors[0].message === '403.13 - Client certificate revoked') {
+      response.errors[0].message = i18n.t('error.session-expired')
+      store.dispatch('logout', null)
+      if (router.currentRoute.path !== '/login') router.push('/login')
+      return response
+    }
     const newToken = operation.getContext().response.headers.get('token')
     if (newToken) store.commit('token', newToken)
     return response


### PR DESCRIPTION
## 🍰 Pullrequest
Server raises error with message: `'403.13 - Client certificate revoked'` when JWT has expired.
Frontend checks each response for this error. When it is present, redirect to login. The message is translated and toasted by the apollo call.

### Issues
- fixes #827 
