### PR TITLE
fix: Whitespace in Password Shows Validation Error

### DIFF
--- a/frontend/src/validation-rules.js
+++ b/frontend/src/validation-rules.js
@@ -114,14 +114,14 @@ export const loadAllRules = (i18nCallback) => {
 
   extend('atLeastOneSpecialCharater', {
     validate(value) {
-      return !!value.match(/[^a-zA-Z0-9]/)
+      return !!value.match(/[^a-zA-Z0-9 \t\n\r]/)
     },
     message: (_, values) => i18nCallback.t('site.signup.special-char', values),
   })
 
   extend('noWhitespaceCharacters', {
     validate(value) {
-      return !!value.match(/[^ \t\n\r]/)
+      return !value.match(/[ \t\n\r]+/)
     },
     message: (_, values) => i18nCallback.t('site.signup.no-whitespace', values),
   })

--- a/frontend/src/views/Pages/UserProfile/UserCard_FormUserPasswort.spec.js
+++ b/frontend/src/views/Pages/UserProfile/UserCard_FormUserPasswort.spec.js
@@ -105,13 +105,20 @@ describe('UserCard_FormUserPasswort', () => {
       describe('validation', () => {
         it('displays all password requirements', () => {
           const feedbackArray = wrapper.findAll('div.invalid-feedback').at(1).findAll('span')
-          expect(feedbackArray).toHaveLength(7)
+          expect(feedbackArray).toHaveLength(6)
           expect(feedbackArray.at(0).text()).toBe('validations.messages.required')
           expect(feedbackArray.at(1).text()).toBe('site.signup.lowercase')
           expect(feedbackArray.at(2).text()).toBe('site.signup.uppercase')
           expect(feedbackArray.at(3).text()).toBe('site.signup.one_number')
           expect(feedbackArray.at(4).text()).toBe('site.signup.minimum')
           expect(feedbackArray.at(5).text()).toBe('site.signup.special-char')
+        })
+
+        it('displays no whitespace error when a space character is entered', async () => {
+          await wrapper.findAll('input').at(1).setValue(' ')
+          await flushPromises()
+          const feedbackArray = wrapper.findAll('div.invalid-feedback').at(1).findAll('span')
+          expect(feedbackArray).toHaveLength(7)
           expect(feedbackArray.at(6).text()).toBe('site.signup.no-whitespace')
         })
 


### PR DESCRIPTION
## 🍰 Pullrequest
When white space is entered in any set password field, a validation error is shown correctly.
