### PR TITLE
fix: Double Redirect After Logout with Expired JWT

### DIFF
--- a/frontend/src/views/Layout/DashboardLayout_gdd.spec.js
+++ b/frontend/src/views/Layout/DashboardLayout_gdd.spec.js
@@ -32,6 +32,9 @@ describe('DashboardLayoutGdd', () => {
     },
     $router: {
       push: routerPushMock,
+      currentRoute: {
+        path: '/overview',
+      },
     },
     $toasted: {
       error: toasterMock,
@@ -143,21 +146,23 @@ describe('DashboardLayoutGdd', () => {
         it('redirects to login page', () => {
           expect(routerPushMock).toBeCalledWith('/login')
         })
+      })
 
-        describe('logout fails', () => {
-          beforeEach(() => {
-            apolloMock.mockRejectedValue({
-              message: 'error',
-            })
+      describe('logout fails', () => {
+        beforeEach(async () => {
+          apolloMock.mockRejectedValue({
+            message: 'error',
           })
+          await wrapper.findComponent({ name: 'sidebar' }).vm.$emit('logout')
+          await flushPromises()
+        })
 
-          it('dispatches logout to store', () => {
-            expect(storeDispatchMock).toBeCalledWith('logout')
-          })
+        it('dispatches logout to store', () => {
+          expect(storeDispatchMock).toBeCalledWith('logout')
+        })
 
-          it('redirects to login page', () => {
-            expect(routerPushMock).toBeCalledWith('/login')
-          })
+        it('redirects to login page', () => {
+          expect(routerPushMock).toBeCalledWith('/login')
         })
       })
 

--- a/frontend/src/views/Layout/DashboardLayout_gdd.vue
+++ b/frontend/src/views/Layout/DashboardLayout_gdd.vue
@@ -101,7 +101,7 @@ export default {
         .catch(() => {
           this.$sidebar.displaySidebar(false)
           this.$store.dispatch('logout')
-          this.$router.push('/login')
+          if (this.$router.currentRoute.path !== '/login') this.$router.push('/login')
         })
     },
     async updateTransactions(pagination) {


### PR DESCRIPTION
## 🍰 Pullrequest
Logout requires authentication. If the Jwt is expired, an error is thrown in the backend. This triggers a redirect to login. The catch block in the logout call triggers the same redirect, which causes a vue error. Now this redirect is only triggered when we are not already on the login page. 
