### PR TITLE
feat: Global Catch of Publisher ID to Store

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -50,6 +50,11 @@ Vue.config.productionTip = false
 loadAllRules(i18n)
 
 router.beforeEach((to, from, next) => {
+  const publisherId = to.query.pid
+  if (publisherId) {
+    store.commit('publisherId', publisherId)
+    to.query.pid = undefined
+  }
   if (to.meta.requiresAuth && !store.state.token) {
     next({ path: '/login' })
   } else {

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -29,6 +29,9 @@ export const mutations = {
   newsletterState: (state, newsletterState) => {
     state.newsletterState = newsletterState
   },
+  publisherId: (state, publisherId) => {
+    state.publisherId = publisherId
+  },
 }
 
 export const actions = {

--- a/frontend/src/store/store.test.js
+++ b/frontend/src/store/store.test.js
@@ -9,6 +9,7 @@ const {
   lastName,
   description,
   newsletterState,
+  publisherId,
 } = mutations
 const { login, logout } = actions
 
@@ -75,6 +76,14 @@ describe('Vuex store', () => {
         const state = { newsletterState: null }
         newsletterState(state, true)
         expect(state.newsletterState).toEqual(true)
+      })
+    })
+
+    describe('publisherId', () => {
+      it('sets the state of publisherId', () => {
+        const state = {}
+        publisherId(state, 42)
+        expect(state.publisherId).toEqual(42)
       })
     })
   })


### PR DESCRIPTION
## 🍰 Pullrequest
 * checks all routes for the presence of `pid` in the query
 * commits the pid to the store.
 * store does not delete pid on logout

### Issues
- fixes #941 

