### PR TITLE
[WIP] 804 elopage registration

### DIFF
--- a/frontend/src/components/SidebarPlugin/SideBar.spec.js
+++ b/frontend/src/components/SidebarPlugin/SideBar.spec.js
@@ -18,6 +18,10 @@ describe('SideBar', () => {
     $store: {
       state: {
         email: 'test@example.org',
+        publisherId: 123,
+        firstName: 'test',
+        lastName: 'example',
+        hasElopage: false,
       },
       commit: jest.fn(),
     },
@@ -80,12 +84,16 @@ describe('SideBar', () => {
     describe('static menu items', () => {
       describe("member's area", () => {
         it('has a link to the elopage', () => {
-          expect(wrapper.findAll('li').at(0).text()).toBe('members_area')
+          expect(wrapper.findAll('li').at(0).text()).toContain('members_area')
         })
 
-        it('links to the elopage', () => {
+        it('has a badge', () => {
+          expect(wrapper.findAll('li').at(0).text()).toContain('!')
+        })
+
+        it('links to the elopage registration', () => {
           expect(wrapper.findAll('li').at(0).find('a').attributes('href')).toBe(
-            'https://elopage.com/s/gradido/sign_in?locale=en',
+            'https://elopage.com/s/gradido/basic-de/payment?locale=en&prid=111&pid=123&firstName=test&lastName=example&email=test@example.org',
           )
         })
 
@@ -94,10 +102,26 @@ describe('SideBar', () => {
             mocks.$i18n.locale = 'de'
           })
 
-          it('links to the German elopage when locale is set to de', () => {
+          it('links to the German elopage registration when locale is set to de', () => {
+            expect(wrapper.findAll('li').at(0).find('a').attributes('href')).toBe(
+              'https://elopage.com/s/gradido/basic-de/payment?locale=de&prid=111&pid=123&firstName=test&lastName=example&email=test@example.org',
+            )
+          })
+        })
+
+        describe('with hasElopage is true', () => {
+          beforeEach(() => {
+            mocks.$store.state.hasElopage = true
+          })
+
+          it('links to the elopage member area', () => {
             expect(wrapper.findAll('li').at(0).find('a').attributes('href')).toBe(
               'https://elopage.com/s/gradido/sign_in?locale=de',
             )
+          })
+
+          it('has no badge', () => {
+            expect(wrapper.findAll('li').at(0).text()).not.toContain('!')
           })
         })
       })

--- a/frontend/src/components/SidebarPlugin/SideBar.vue
+++ b/frontend/src/components/SidebarPlugin/SideBar.vue
@@ -47,12 +47,9 @@
         <hr class="my-2" />
         <ul class="navbar-nav ml-3">
           <li class="nav-item">
-            <a
-              :href="`https://elopage.com/s/gradido/sign_in?locale=${$i18n.locale}`"
-              class="nav-link"
-              target="_blank"
-            >
-              {{ $t('members_area') }}
+            <a :href="getElopageLink()" class="nav-link" target="_blank">
+              {{ $t('members_area') }}&nbsp;
+              <b-badge v-if="!this.$store.state.hasElopage" pill variant="danger">!</b-badge>
             </a>
           </li>
         </ul>
@@ -113,6 +110,11 @@ export default {
     },
     logout() {
       this.$emit('logout')
+    },
+    getElopageLink() {
+      return this.$store.state.hasElopage
+        ? `https://elopage.com/s/gradido/sign_in?locale=${this.$i18n.locale}&email=${this.$store.state.email}`
+        : `https://elopage.com/s/gradido/basic-de/payment?locale=de&prid=111&pid=${this.$store.state.publisherId}&firstName=${this.$store.state.firstName}&lastName=${this.$store.state.lastName}&email=${this.$store.state.email}`
     },
   },
 }

--- a/frontend/src/components/SidebarPlugin/SideBar.vue
+++ b/frontend/src/components/SidebarPlugin/SideBar.vue
@@ -113,8 +113,8 @@ export default {
     },
     getElopageLink() {
       return this.$store.state.hasElopage
-        ? `https://elopage.com/s/gradido/sign_in?locale=${this.$i18n.locale}&email=${this.$store.state.email}`
-        : `https://elopage.com/s/gradido/basic-de/payment?locale=de&prid=111&pid=${this.$store.state.publisherId}&firstName=${this.$store.state.firstName}&lastName=${this.$store.state.lastName}&email=${this.$store.state.email}`
+        ? `https://elopage.com/s/gradido/sign_in?locale=${this.$i18n.locale}`
+        : `https://elopage.com/s/gradido/basic-de/payment?locale=${this.$i18n.locale}&prid=111&pid=${this.$store.state.publisherId}&firstName=${this.$store.state.firstName}&lastName=${this.$store.state.lastName}&email=${this.$store.state.email}`
     },
   },
 }

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -38,6 +38,9 @@ export const mutations = {
   coinanimation: (state, coinanimation) => {
     state.coinanimation = coinanimation
   },
+  hasElopage: (state, hasElopage) => {
+    state.hasElopage = hasElopage
+  },
 }
 
 export const actions = {
@@ -50,6 +53,7 @@ export const actions = {
     commit('description', data.description)
     commit('coinanimation', data.coinanimation)
     commit('newsletterState', data.klickTipp.newsletterState)
+    commit('hasElopage', data.hasElopage)
   },
   logout: ({ commit, state }) => {
     commit('token', null)
@@ -60,6 +64,7 @@ export const actions = {
     commit('description', '')
     commit('coinanimation', true)
     commit('newsletterState', null)
+    commit('hasElopage', false)
     localStorage.clear()
   },
 }
@@ -81,6 +86,7 @@ export const store = new Vuex.Store({
     coinanimation: true,
     newsletterState: null,
     community: null,
+    hasElopage: false,
   },
   getters: {},
   // Syncronous mutation of the state

--- a/frontend/src/store/store.test.js
+++ b/frontend/src/store/store.test.js
@@ -12,6 +12,7 @@ const {
   newsletterState,
   publisherId,
   community,
+  hasElopage,
 } = mutations
 const { login, logout } = actions
 
@@ -114,6 +115,14 @@ describe('Vuex store', () => {
         })
       })
     })
+
+    describe('hasElopage', () => {
+      it('sets the state of hasElopage', () => {
+        const state = { hasElopage: false }
+        hasElopage(state, true)
+        expect(state.hasElopage).toBeTruthy()
+      })
+    })
   })
 
   describe('actions', () => {
@@ -131,11 +140,12 @@ describe('Vuex store', () => {
         klickTipp: {
           newsletterState: true,
         },
+        hasElopage: false,
       }
 
-      it('calls eight commits', () => {
+      it('calls nine commits', () => {
         login({ commit, state }, commitedData)
-        expect(commit).toHaveBeenCalledTimes(8)
+        expect(commit).toHaveBeenCalledTimes(9)
       })
 
       it('commits email', () => {
@@ -177,15 +187,20 @@ describe('Vuex store', () => {
         login({ commit, state }, commitedData)
         expect(commit).toHaveBeenNthCalledWith(8, 'newsletterState', true)
       })
+
+      it('commits hasElopage', () => {
+        login({ commit, state }, commitedData)
+        expect(commit).toHaveBeenNthCalledWith(9, 'hasElopage', false)
+      })
     })
 
     describe('logout', () => {
       const commit = jest.fn()
       const state = {}
 
-      it('calls eight commits', () => {
+      it('calls nine commits', () => {
         logout({ commit, state })
-        expect(commit).toHaveBeenCalledTimes(8)
+        expect(commit).toHaveBeenCalledTimes(9)
       })
 
       it('commits token', () => {
@@ -226,6 +241,11 @@ describe('Vuex store', () => {
       it('commits newsletterState', () => {
         logout({ commit, state })
         expect(commit).toHaveBeenNthCalledWith(8, 'newsletterState', null)
+      })
+
+      it('commits hasElopage', () => {
+        logout({ commit, state })
+        expect(commit).toHaveBeenNthCalledWith(9, 'hasElopage', false)
       })
 
       // how to get this working?


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
On the members area we have now a link to the registration on the Gradido Elopage when the User has not registered now,
else he gets a link to the sign_in page.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes #804 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [ ] When User login gets a flag if his email is registered on the gdt server #949 
- [x] If yes button "Member Area" sends us to the Elopage Account 
- [x] if not button "..." has a visual queu (Red exclamation button) and sends us to the Elopage Registration "https://elopage.com/s/gradido/basic-de/payment?locale=de&prid=111&pid=&firstName=&lastName=&email="
