### PR TITLE
fix: Test Default Publisher ID in Sidebar Menu

### DIFF
--- a/frontend/src/components/SidebarPlugin/SideBar.spec.js
+++ b/frontend/src/components/SidebarPlugin/SideBar.spec.js
@@ -124,6 +124,23 @@ describe('SideBar', () => {
             expect(wrapper.findAll('li').at(0).text()).not.toContain('!')
           })
         })
+
+        describe("member's area with default publisher ID", () => {
+          beforeEach(() => {
+            mocks.$store.state.publisherId = null
+            mocks.$store.state.hasElopage = true
+          })
+
+          it('links to the elopage member area with default publisher ID', () => {
+            expect(wrapper.findAll('li').at(0).find('a').attributes('href')).toBe(
+              'https://elopage.com/s/gradido/sign_in?locale=de',
+            )
+          })
+
+          it('has no badge', () => {
+            expect(wrapper.findAll('li').at(0).text()).not.toContain('!')
+          })
+        })
       })
 
       describe('logout', () => {

--- a/frontend/src/components/SidebarPlugin/SideBar.spec.js
+++ b/frontend/src/components/SidebarPlugin/SideBar.spec.js
@@ -125,20 +125,20 @@ describe('SideBar', () => {
           })
         })
 
-        describe("member's area with default publisher ID", () => {
+        describe("member's area with default publisher ID  and no elopage", () => {
           beforeEach(() => {
             mocks.$store.state.publisherId = null
-            mocks.$store.state.hasElopage = true
+            mocks.$store.state.hasElopage = false
           })
 
           it('links to the elopage member area with default publisher ID', () => {
             expect(wrapper.findAll('li').at(0).find('a').attributes('href')).toBe(
-              'https://elopage.com/s/gradido/sign_in?locale=de',
+              'https://elopage.com/s/gradido/basic-de/payment?locale=de&prid=111&pid=2896&firstName=test&lastName=example&email=test@example.org',
             )
           })
 
-          it('has no badge', () => {
-            expect(wrapper.findAll('li').at(0).text()).not.toContain('!')
+          it('has a badge', () => {
+            expect(wrapper.findAll('li').at(0).text()).toContain('!')
           })
         })
       })


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest

Test behavior of Sidebar Menu with the default publisher ID and no elopage