### PR TITLE
fix: Flaky Dashboard Layout Test on Logout

### DIFF
--- a/frontend/src/views/Layout/DashboardLayout_gdd.spec.js
+++ b/frontend/src/views/Layout/DashboardLayout_gdd.spec.js
@@ -4,6 +4,8 @@ import DashboardLayoutGdd from './DashboardLayout_gdd'
 
 jest.useFakeTimers()
 
+jest.setTimeout(30000)
+
 const localVue = global.localVue
 
 const storeDispatchMock = jest.fn()


### PR DESCRIPTION
## 🍰 Pullrequest
The test if the logout query is called in the dashboard layout is flaky. I will rerun this PR a lot to see if it is still flaky.

**Successful consecutive runs executed: 12**

### Issues
- fixes #995 (hopefully)
