### PR TITLE
when creating the register page, everything in the form is set to blank

### DIFF
--- a/frontend/src/views/Pages/Register.vue
+++ b/frontend/src/views/Pages/Register.vue
@@ -205,13 +205,7 @@ export default {
           },
         })
         .then(() => {
-          this.form.email = ''
-          this.form.firstname = ''
-          this.form.lastname = ''
-          this.form.password.password = ''
-          this.form.password.passwordRepeat = ''
-          this.language = ''
-          this.$router.push('/thx/register')
+          this.$router.push('/thx/register')       
         })
         .catch((error) => {
           this.showError = true
@@ -241,6 +235,15 @@ export default {
     emailFilled() {
       return this.form.email !== ''
     },
+  },
+  created() {
+    this.messageError = ''
+    this.form.email = ''
+    this.form.firstname = ''
+    this.form.lastname = ''
+    this.form.password.password = ''
+    this.form.password.passwordRepeat = ''
+    this.language = ''
   },
 }
 </script>


### PR DESCRIPTION
## 🍰 Pullrequest
when creating the register page, everything in the form is set to blank. 
when the registration is completed, a forwarding to the thank you page is carried out directly. the form is set to "teaching" when the page is created. 

### Issues
- fixes #1000 
 
