### PR TITLE
fix open community server user account creation

### DIFF
--- a/community_server/src/Controller/ServerUsersController.php
+++ b/community_server/src/Controller/ServerUsersController.php
@@ -15,7 +15,8 @@ class ServerUsersController extends AppController
     public function initialize()
     {
         parent::initialize();
-        $this->Auth->allow(['add', 'edit']);
+        // uncomment in devmode to add new community server admin user, but don't!!! commit it
+        //$this->Auth->allow(['add', 'edit']);
         $this->Auth->deny('index');
     }
 


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
For develop I had made open the community server user account creation and had manually removed it in release builds on production. But it is to easy to forget it, so now it will default off and must be enabled in development to create server user for creation. 

### Issues
- fixes #1071
