### PR TITLE
login_call_getUserInfos

### DIFF
--- a/backend/src/graphql/resolver/TransactionResolver.ts
+++ b/backend/src/graphql/resolver/TransactionResolver.ts
@@ -33,6 +33,7 @@ import { calculateDecay, calculateDecayWithInterval } from '../../util/decay'
 import { TransactionTypeId } from '../enum/TransactionTypeId'
 import { TransactionType } from '../enum/TransactionType'
 import { hasUserAmount, isHexPublicKey } from '../../util/validate'
+import { LoginUserRepository } from '../../typeorm/repository/LoginUser'
 
 /*
 # Test
@@ -451,15 +452,15 @@ async function addUserTransaction(
   })
 }
 
-async function getPublicKey(email: string, sessionId: number): Promise<string | undefined> {
-  const result = await apiPost(CONFIG.LOGIN_API_URL + 'getUserInfos', {
-    session_id: sessionId,
-    email,
-    ask: ['user.pubkeyhex'],
-  })
-  if (result.success) {
-    return result.data.userData.pubkeyhex
+async function getPublicKey(email: string): Promise<string | null> {
+  const loginUserRepository = getCustomRepository(LoginUserRepository)
+  const loginUser = await loginUserRepository.findOne({ email: email })
+  // User not found
+  if (!loginUser) {
+    return null
   }
+
+  return loginUser.pubKey.toString('hex')
 }
 
 @Resolver()
@@ -517,7 +518,7 @@ export class TransactionResolver {
 
     // validate recipient user
     // TODO: the detour over the public key is unnecessary
-    const recipiantPublicKey = await getPublicKey(email, context.sessionId)
+    const recipiantPublicKey = await getPublicKey(email)
     if (!recipiantPublicKey) {
       throw new Error('recipiant not known')
     }


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

replace implementation of `getPublicKey` to no longer require the sessionId. Furthermore the call now no longer calls `getUserInfos` on the `login_server` but just queries the database itself

This is actually not an implementation of `getUserInfos` since we do not need that, but just the publicKey part

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
