### PR TITLE
feat: Verify Login in Admin Interface

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,7 +441,7 @@ jobs:
           report_name: Coverage Admin Interface
           type: lcov
           result_path: ./coverage/lcov.info
-          min_coverage: 50
+          min_coverage: 53
           token: ${{ github.token }}
 
   ##############################################################################

--- a/admin/src/graphql/verifyLogin.js
+++ b/admin/src/graphql/verifyLogin.js
@@ -5,6 +5,7 @@ export const verifyLogin = gql`
     verifyLogin {
       firstName
       lastName
+      isAdmin
       id
     }
   }

--- a/admin/src/main.js
+++ b/admin/src/main.js
@@ -75,7 +75,7 @@ Vue.use(Toasted, {
   },
 })
 
-addNavigationGuards(router, store)
+addNavigationGuards(router, store, apolloProvider.defaultClient)
 
 new Vue({
   moment,

--- a/admin/src/router/guards.js
+++ b/admin/src/router/guards.js
@@ -1,12 +1,28 @@
+import { verifyLogin } from '../graphql/verifyLogin'
 import CONFIG from '../config'
 
-const addNavigationGuards = (router, store) => {
+const addNavigationGuards = (router, store, apollo) => {
   // store token on `authenticate`
-  router.beforeEach((to, from, next) => {
+  router.beforeEach(async (to, from, next) => {
     if (to.path === '/authenticate' && to.query && to.query.token) {
-      // TODO verify user to get user data
       store.commit('token', to.query.token)
-      next({ path: '/' })
+      await apollo
+        .query({
+          query: verifyLogin,
+          fetchPolicy: 'network-only',
+        })
+        .then((result) => {
+          const moderator = result.data.verifyLogin
+          if (moderator.isAdmin) {
+            store.commit('moderator', moderator)
+            next({ path: '/' })
+          } else {
+            next({ path: '/not-found' })
+          }
+        })
+        .catch(() => {
+          next({ path: '/not-found' })
+        })
     } else {
       next()
     }
@@ -16,7 +32,9 @@ const addNavigationGuards = (router, store) => {
   router.beforeEach((to, from, next) => {
     if (
       !CONFIG.DEBUG_DISABLE_AUTH && // we did not disabled the auth module for debug purposes
-      !store.state.token && // we do not have a token
+      (!store.state.token || // we do not have a token
+        !store.state.moderator || // no moderator set in store
+        !store.state.moderator.isAdmin) && // user is no admin
       to.path !== '/not-found' && // we are not on `not-found`
       to.path !== '/logout' // we are not on `logout`
     ) {

--- a/admin/src/store/store.js
+++ b/admin/src/store/store.js
@@ -26,6 +26,7 @@ export const mutations = {
 export const actions = {
   logout: ({ commit, state }) => {
     commit('token', null)
+    commit('moderator', null)
     window.localStorage.clear()
   },
 }
@@ -38,7 +39,7 @@ const store = new Vuex.Store({
   ],
   state: {
     token: CONFIG.DEBUG_DISABLE_AUTH ? 'validToken' : null,
-    moderator: { name: 'Dertest Moderator', id: 0 },
+    moderator: null,
     openCreations: 0,
   },
   // Syncronous mutation of the state

--- a/admin/src/store/store.test.js
+++ b/admin/src/store/store.test.js
@@ -1,6 +1,6 @@
 import store, { mutations, actions } from './store'
 
-const { token, openCreationsPlus, openCreationsMinus, resetOpenCreations } = mutations
+const { token, openCreationsPlus, openCreationsMinus, resetOpenCreations, moderator } = mutations
 const { logout } = actions
 
 const CONFIG = {
@@ -40,6 +40,14 @@ describe('Vuex store', () => {
         expect(state.openCreations).toEqual(0)
       })
     })
+
+    describe('moderator', () => {
+      it('sets the moderator object in state', () => {
+        const state = { moderator: null }
+        moderator(state, { id: 1 })
+        expect(state.moderator).toEqual({ id: 1 })
+      })
+    })
   })
 
   describe('actions', () => {
@@ -55,6 +63,11 @@ describe('Vuex store', () => {
       it('deletes the token in store', () => {
         logout({ commit, state })
         expect(commit).toBeCalledWith('token', null)
+      })
+
+      it('deletes the moderator in store', () => {
+        logout({ commit, state })
+        expect(commit).toBeCalledWith('moderator', null)
       })
 
       it.skip('clears the window local storage', () => {

--- a/admin/src/store/store.test.js
+++ b/admin/src/store/store.test.js
@@ -3,8 +3,14 @@ import CONFIG from '../config'
 
 jest.mock('../config')
 
-const { token, openCreationsPlus, openCreationsMinus, resetOpenCreations, setOpenCreations } =
-  mutations
+const {
+  token,
+  openCreationsPlus,
+  openCreationsMinus,
+  resetOpenCreations,
+  setOpenCreations,
+  moderator,
+} = mutations
 const { logout } = actions
 
 CONFIG.DEBUG_DISABLE_AUTH = true


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
 * Calls `verifyLogin` on `/authenticate`
 * commits the response to the store, when user has admin rights
 * makes sure that moderator is present in store on every route

