### PR TITLE
Moved reverse of the getPendingCreations to the AdminResolver instead…

### DIFF
--- a/admin/src/components/UserTable.vue
+++ b/admin/src/components/UserTable.vue
@@ -237,7 +237,7 @@ export default {
           },
         })
         .then(() => {
-          this.$emit('remove-confirm-result', item, 'remove')
+          this.$emit('remove-confirm-result', item, 'confirmed')
         })
         .catch((error) => {
           this.$toasted.error(error.message)

--- a/admin/src/graphql/createPendingCreation.js
+++ b/admin/src/graphql/createPendingCreation.js
@@ -3,7 +3,7 @@ import gql from 'graphql-tag'
 export const createPendingCreation = gql`
   mutation (
     $email: String!
-    $amount: Int!
+    $amount: Float!
     $memo: String!
     $creationDate: String!
     $moderator: Int!

--- a/admin/src/graphql/updatePendingCreation.js
+++ b/admin/src/graphql/updatePendingCreation.js
@@ -4,7 +4,7 @@ export const updatePendingCreation = gql`
   mutation (
     $id: Int!
     $email: String!
-    $amount: Int!
+    $amount: Float!
     $memo: String!
     $creationDate: String!
     $moderator: Int!

--- a/admin/src/pages/CreationConfirm.spec.js
+++ b/admin/src/pages/CreationConfirm.spec.js
@@ -194,14 +194,13 @@ describe('CreationConfirm', () => {
 
     describe('delete creation delete with error', () => {
       beforeEach(async () => {
-        apolloMutateMock.mockRejectedValue({ message: 'Ouchhh!' })
         await wrapper
           .findComponent({ name: 'UserTable' })
           .vm.$emit('remove-confirm-result', { id: 1 }, 'confirm')
       })
 
       it('toasts an error message', () => {
-        expect(toastedErrorMock).not.toBeCalledWith('Ouchhh!')
+        expect(toastedErrorMock).toBeCalledWith('Case confirm is not supported')
       })
     })
 

--- a/admin/src/pages/CreationConfirm.spec.js
+++ b/admin/src/pages/CreationConfirm.spec.js
@@ -81,7 +81,7 @@ describe('CreationConfirm', () => {
       })
     })
 
-    describe('confirm creation delete with success', () => {
+    describe('delete creation delete with success', () => {
       beforeEach(async () => {
         apolloQueryMock.mockResolvedValue({
           data: {
@@ -130,7 +130,7 @@ describe('CreationConfirm', () => {
       })
     })
 
-    describe('confirm creation delete with error', () => {
+    describe('delete creation delete with error', () => {
       beforeEach(async () => {
         apolloMutateMock.mockRejectedValue({ message: 'Ouchhh!' })
         await wrapper
@@ -140,6 +140,68 @@ describe('CreationConfirm', () => {
 
       it('toasts an error message', () => {
         expect(toastedErrorMock).toBeCalledWith('Ouchhh!')
+      })
+    })
+
+    describe('confirm creation delete with success', () => {
+      beforeEach(async () => {
+        apolloQueryMock.mockResolvedValue({
+          data: {
+            getPendingCreations: [
+              {
+                id: 1,
+                firstName: 'Bibi',
+                lastName: 'Bloxberg',
+                email: 'bibi@bloxberg.de',
+                amount: 500,
+                memo: 'Danke für alles',
+                date: new Date(),
+                moderator: 0,
+              },
+              {
+                id: 2,
+                firstName: 'Räuber',
+                lastName: 'Hotzenplotz',
+                email: 'raeuber@hotzenplotz.de',
+                amount: 1000000,
+                memo: 'Gut Ergatert',
+                date: new Date(),
+                moderator: 0,
+              },
+            ],
+          },
+        })
+        await wrapper
+          .findComponent({ name: 'UserTable' })
+          .vm.$emit('remove-confirm-result', { id: 1 }, 'confirmed')
+      })
+
+      it('calls the deletePendingCreation mutation', () => {
+        expect(apolloMutateMock).not.toBeCalledWith({
+          mutation: deletePendingCreation,
+          variables: { id: 1 },
+        })
+      })
+
+      it('commits openCreationsMinus to store', () => {
+        expect(storeCommitMock).toBeCalledWith('openCreationsMinus', 1)
+      })
+
+      it('toasts a success message', () => {
+        expect(toastedSuccessMock).toBeCalledWith('Pending Creation has been deleted')
+      })
+    })
+
+    describe('delete creation delete with error', () => {
+      beforeEach(async () => {
+        apolloMutateMock.mockRejectedValue({ message: 'Ouchhh!' })
+        await wrapper
+          .findComponent({ name: 'UserTable' })
+          .vm.$emit('remove-confirm-result', { id: 1 }, 'confirm')
+      })
+
+      it('toasts an error message', () => {
+        expect(toastedErrorMock).not.toBeCalledWith('Ouchhh!')
       })
     })
 

--- a/admin/src/pages/CreationConfirm.vue
+++ b/admin/src/pages/CreationConfirm.vue
@@ -53,27 +53,32 @@ export default {
     removeConfirmResult(e, event) {
       let index = 0
       const findArr = this.confirmResult.find((arr) => arr.id === e.id)
-      if (event === 'remove') {
-        this.$apollo
-          .mutate({
-            mutation: deletePendingCreation,
-            variables: {
-              id: findArr.id,
-            },
-          })
-          .then((result) => {
-            index = this.confirmResult.indexOf(findArr)
-            this.confirmResult.splice(index, 1)
-            this.$store.commit('openCreationsMinus', 1)
-            this.$toasted.success('Pending Creation has been deleted')
-          })
-          .catch((error) => {
-            this.$toasted.error(error.message)
-          })
-      } else {
-        this.confirmResult.splice(index, 1)
-        this.$store.commit('openCreationsMinus', 1)
-        this.$toasted.success('Pending Creation has been deleted')
+      switch (event) {
+        case 'remove':
+          this.$apollo
+            .mutate({
+              mutation: deletePendingCreation,
+              variables: {
+                id: findArr.id,
+              },
+            })
+            .then((result) => {
+              index = this.confirmResult.indexOf(findArr)
+              this.confirmResult.splice(index, 1)
+              this.$store.commit('openCreationsMinus', 1)
+              this.$toasted.success('Pending Creation has been deleted')
+            })
+            .catch((error) => {
+              this.$toasted.error(error.message)
+            })
+          break
+        case 'confirmed':
+          this.confirmResult.splice(index, 1)
+          this.$store.commit('openCreationsMinus', 1)
+          this.$toasted.success('Pending Creation has been deleted')
+          break
+        default:
+          this.$toasted.error('Case ' + event + ' is not supported')
       }
     },
     getPendingCreations() {

--- a/admin/src/pages/CreationConfirm.vue
+++ b/admin/src/pages/CreationConfirm.vue
@@ -80,7 +80,7 @@ export default {
         })
         .then((result) => {
           this.$store.commit('resetOpenCreations')
-          this.confirmResult = result.data.getPendingCreations.reverse()
+          this.confirmResult = result.data.getPendingCreations
           this.$store.commit('setOpenCreations', result.data.getPendingCreations.length)
         })
         .catch((error) => {

--- a/admin/src/pages/CreationConfirm.vue
+++ b/admin/src/pages/CreationConfirm.vue
@@ -51,9 +51,9 @@ export default {
   },
   methods: {
     removeConfirmResult(e, event) {
+      let index = 0
+      const findArr = this.confirmResult.find((arr) => arr.id === e.id)
       if (event === 'remove') {
-        let index = 0
-        const findArr = this.confirmResult.find((arr) => arr.id === e.id)
         this.$apollo
           .mutate({
             mutation: deletePendingCreation,
@@ -70,6 +70,10 @@ export default {
           .catch((error) => {
             this.$toasted.error(error.message)
           })
+      } else {
+        this.confirmResult.splice(index, 1)
+        this.$store.commit('openCreationsMinus', 1)
+        this.$toasted.success('Pending Creation has been deleted')
       }
     },
     getPendingCreations() {

--- a/backend/src/graphql/arg/CreatePendingCreationArgs.ts
+++ b/backend/src/graphql/arg/CreatePendingCreationArgs.ts
@@ -1,11 +1,11 @@
-import { ArgsType, Field, Int } from 'type-graphql'
+import { ArgsType, Field, Float, Int } from 'type-graphql'
 
 @ArgsType()
 export default class CreatePendingCreationArgs {
   @Field(() => String)
   email: string
 
-  @Field(() => Int)
+  @Field(() => Float)
   amount: number
 
   @Field(() => String)

--- a/backend/src/graphql/arg/UpdatePendingCreationArgs.ts
+++ b/backend/src/graphql/arg/UpdatePendingCreationArgs.ts
@@ -1,4 +1,4 @@
-import { ArgsType, Field, Int } from 'type-graphql'
+import { ArgsType, Field, Float, Int } from 'type-graphql'
 
 @ArgsType()
 export default class CreatePendingCreationArgs {
@@ -8,7 +8,7 @@ export default class CreatePendingCreationArgs {
   @Field(() => String)
   email: string
 
-  @Field(() => Int)
+  @Field(() => Float)
   amount: number
 
   @Field(() => String)

--- a/backend/src/graphql/resolver/AdminResolver.ts
+++ b/backend/src/graphql/resolver/AdminResolver.ts
@@ -132,7 +132,7 @@ export class AdminResolver {
         return newPendingCreation
       }),
     )
-    return pendingCreationsPromise
+    return pendingCreationsPromise.reverse()
   }
 
   @Mutation(() => Boolean)


### PR DESCRIPTION
… to do it in the CreationConfirm page.

<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- #1165 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] Remove 10000 of Frontend & Admin
- [X] Move array.reverse to backend
- [x] Use floats instead of integer 
- [x] Remove GraphQL error
