### PR TITLE
migration_0006_login_users_collation

### DIFF
--- a/backend/src/server/createServer.ts
+++ b/backend/src/server/createServer.ts
@@ -29,7 +29,7 @@ import { elopageWebhook } from '../webhook/elopage'
 // TODO implement
 // import queryComplexity, { simpleEstimator, fieldConfigEstimator } from "graphql-query-complexity";
 
-const DB_VERSION = '0005-admin_tables'
+const DB_VERSION = '0006-login_users_collation'
 
 const createServer = async (context: any = serverContext): Promise<any> => {
   // open mysql connection

--- a/database/entity/0001-init_db/User.ts
+++ b/database/entity/0001-init_db/User.ts
@@ -2,7 +2,7 @@ import { BaseEntity, Entity, PrimaryGeneratedColumn, Column, OneToOne } from 'ty
 import { Balance } from '../Balance'
 
 // Moriz: I do not like the idea of having two user tables
-@Entity('state_users')
+@Entity('state_users', { engine: 'InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' })
 export class User extends BaseEntity {
   @PrimaryGeneratedColumn('increment', { unsigned: true })
   id: number
@@ -16,16 +16,28 @@ export class User extends BaseEntity {
   @Column({ type: 'binary', length: 32, name: 'public_key' })
   pubkey: Buffer
 
-  @Column({ length: 255, nullable: true, default: null })
+  @Column({ length: 255, nullable: true, default: null, collation: 'utf8mb4_unicode_ci' })
   email: string
 
-  @Column({ name: 'first_name', length: 255, nullable: true, default: null })
+  @Column({
+    name: 'first_name',
+    length: 255,
+    nullable: true,
+    default: null,
+    collation: 'utf8mb4_unicode_ci',
+  })
   firstName: string
 
-  @Column({ name: 'last_name', length: 255, nullable: true, default: null })
+  @Column({
+    name: 'last_name',
+    length: 255,
+    nullable: true,
+    default: null,
+    collation: 'utf8mb4_unicode_ci',
+  })
   lastName: string
 
-  @Column({ length: 255, nullable: true, default: null })
+  @Column({ length: 255, nullable: true, default: null, collation: 'utf8mb4_unicode_ci' })
   username: string
 
   @Column()

--- a/database/entity/0002-add_settings/User.ts
+++ b/database/entity/0002-add_settings/User.ts
@@ -2,7 +2,7 @@ import { BaseEntity, Entity, PrimaryGeneratedColumn, Column, OneToMany } from 't
 import { UserSetting } from './UserSetting'
 
 // Moriz: I do not like the idea of having two user tables
-@Entity('state_users')
+@Entity('state_users', { engine: 'InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' })
 export class User extends BaseEntity {
   @PrimaryGeneratedColumn('increment', { unsigned: true })
   id: number
@@ -16,16 +16,28 @@ export class User extends BaseEntity {
   @Column({ type: 'binary', length: 32, name: 'public_key' })
   pubkey: Buffer
 
-  @Column({ length: 255, nullable: true, default: null })
+  @Column({ length: 255, nullable: true, default: null, collation: 'utf8mb4_unicode_ci' })
   email: string
 
-  @Column({ name: 'first_name', length: 255, nullable: true, default: null })
+  @Column({
+    name: 'first_name',
+    length: 255,
+    nullable: true,
+    default: null,
+    collation: 'utf8mb4_unicode_ci',
+  })
   firstName: string
 
-  @Column({ name: 'last_name', length: 255, nullable: true, default: null })
+  @Column({
+    name: 'last_name',
+    length: 255,
+    nullable: true,
+    default: null,
+    collation: 'utf8mb4_unicode_ci',
+  })
   lastName: string
 
-  @Column({ length: 255, nullable: true, default: null })
+  @Column({ length: 255, nullable: true, default: null, collation: 'utf8mb4_unicode_ci' })
   username: string
 
   @Column()

--- a/database/entity/0006-login_users_collation/LoginUser.ts
+++ b/database/entity/0006-login_users_collation/LoginUser.ts
@@ -1,0 +1,60 @@
+import { BaseEntity, Entity, PrimaryGeneratedColumn, Column, OneToOne } from 'typeorm'
+import { LoginUserBackup } from '../LoginUserBackup'
+
+// Moriz: I do not like the idea of having two user tables
+@Entity('login_users', { engine: 'InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' })
+export class LoginUser extends BaseEntity {
+  @PrimaryGeneratedColumn('increment', { unsigned: true })
+  id: number
+
+  @Column({ length: 191, unique: true, collation: 'utf8mb4_unicode_ci' })
+  email: string
+
+  @Column({ name: 'first_name', length: 150, collation: 'utf8mb4_unicode_ci' })
+  firstName: string
+
+  @Column({ name: 'last_name', length: 255, default: '', collation: 'utf8mb4_unicode_ci' })
+  lastName: string
+
+  @Column({ length: 255, default: '', collation: 'utf8mb4_unicode_ci' })
+  username: string
+
+  @Column({ default: '', collation: 'utf8mb4_unicode_ci' })
+  description: string
+
+  @Column({ type: 'bigint', default: 0, unsigned: true })
+  password: BigInt
+
+  @Column({ name: 'pubkey', type: 'binary', length: 32, default: null, nullable: true })
+  pubKey: Buffer
+
+  @Column({ name: 'privkey', type: 'binary', length: 80, default: null, nullable: true })
+  privKey: Buffer
+
+  @Column({ name: 'email_hash', type: 'binary', length: 32, default: null, nullable: true })
+  emailHash: Buffer
+
+  @Column({ name: 'created', default: () => 'CURRENT_TIMESTAMP' })
+  createdAt: Date
+
+  @Column({ name: 'email_checked', default: 0 })
+  emailChecked: boolean
+
+  @Column({ name: 'passphrase_shown', default: 0 })
+  passphraseShown: boolean
+
+  @Column({ length: 4, default: 'de', collation: 'utf8mb4_unicode_ci' })
+  language: string
+
+  @Column({ default: 0 })
+  disabled: boolean
+
+  @Column({ name: 'group_id', default: 0, unsigned: true })
+  groupId: number
+
+  @Column({ name: 'publisher_id', default: 0 })
+  publisherId: number
+
+  @OneToOne(() => LoginUserBackup, (loginUserBackup) => loginUserBackup.loginUser)
+  loginUserBackup: LoginUserBackup
+}

--- a/database/entity/LoginUser.ts
+++ b/database/entity/LoginUser.ts
@@ -1,1 +1,1 @@
-export { LoginUser } from './0003-login_server_tables/LoginUser'
+export { LoginUser } from './0006-login_users_collation/LoginUser'

--- a/database/migrations/0002-add_settings.ts
+++ b/database/migrations/0002-add_settings.ts
@@ -1,15 +1,9 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-/* FIRST MIGRATION
+/* MIGRATION TO ADD USER SETTINGS
  *
- * This migration is special since it takes into account that
- * the database can be setup already but also may not be.
- * Therefore you will find all `CREATE TABLE` statements with
- * a `IF NOT EXISTS`, all `INSERT` with an `IGNORE` and in the
- * downgrade function all `DROP TABLE` with a `IF EXISTS`.
- * This ensures compatibility for existing or non-existing
- * databases.
+ * This migration adds the table `user_setting` in order to store all sorts of user configuration data
  */
 
 export async function upgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {

--- a/database/migrations/0003-login_server_tables.ts
+++ b/database/migrations/0003-login_server_tables.ts
@@ -1,15 +1,11 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-/* FIRST MIGRATION
+/* MIGRATION TO CREATE THE LOGIN_SERVER TABLES
  *
- * This migration is special since it takes into account that
- * the database can be setup already but also may not be.
- * Therefore you will find all `CREATE TABLE` statements with
- * a `IF NOT EXISTS`, all `INSERT` with an `IGNORE` and in the
- * downgrade function all `DROP TABLE` with a `IF EXISTS`.
- * This ensures compatibility for existing or non-existing
- * databases.
+ * This migration creates the `login_server` tables in the `community_server` database (`gradido_community`).
+ * This is done to keep all data in the same place and is to be understood in conjunction with the next migration
+ * `0004-login_server_data` which will fill the tables with the existing data
  */
 
 export async function upgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {

--- a/database/migrations/0004-login_server_data.ts
+++ b/database/migrations/0004-login_server_data.ts
@@ -1,15 +1,15 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-/* FIRST MIGRATION
+/* MIGRATION TO COPY LOGIN_SERVER DATA
  *
- * This migration is special since it takes into account that
- * the database can be setup already but also may not be.
- * Therefore you will find all `CREATE TABLE` statements with
- * a `IF NOT EXISTS`, all `INSERT` with an `IGNORE` and in the
- * downgrade function all `DROP TABLE` with a `IF EXISTS`.
- * This ensures compatibility for existing or non-existing
- * databases.
+ * This migration copies all existing data from the `login_server` database (`gradido_login`)
+ * to the `community_server` database (`gradido_community`) in case the login_server database
+ * is present.
+ *
+ * NOTE: This will fail if the two databases are located on different servers.
+ *       Manual export and import of the database will be required then.
+ * NOTE: This migration does not delete the data when downgrading!
  */
 
 const LOGIN_SERVER_DB = 'gradido_login'

--- a/database/migrations/0005-admin_tables.ts
+++ b/database/migrations/0005-admin_tables.ts
@@ -1,12 +1,6 @@
 /* MIGRATION FOR ADMIN INTERFACE
  *
- * This migration is special since it takes into account that
- * the database can be setup already but also may not be.
- * Therefore you will find all `CREATE TABLE` statements with
- * a `IF NOT EXISTS`, all `INSERT` with an `IGNORE` and in the
- * downgrade function all `DROP TABLE` with a `IF EXISTS`.
- * This ensures compatibility for existing or non-existing
- * databases.
+ * This migration adds the table `login_pending_tasks_admin` to store pending creations
  */
 
 export async function upgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {

--- a/database/migrations/0006-login_users_collation.ts
+++ b/database/migrations/0006-login_users_collation.ts
@@ -1,0 +1,17 @@
+/* MIGRATION TO ALIGN COLLATIONS
+ *
+ * in oder to be able to compare `login_users` with `state_users`
+ * when the databases default is not `utf8mb4_unicode_ci`, we need
+ * to also explicitly define it in the table
+ *
+ */
+
+export async function upgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  await queryFn(
+    'ALTER TABLE `login_users` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;',
+  )
+}
+
+export async function downgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  await queryFn('ALTER TABLE `login_users` CONVERT TO CHARACTER SET utf8mb4;')
+}

--- a/database/migrations/0006-login_users_collation.ts
+++ b/database/migrations/0006-login_users_collation.ts
@@ -3,7 +3,6 @@
  * in oder to be able to compare `login_users` with `state_users`
  * when the databases default is not `utf8mb4_unicode_ci`, we need
  * to also explicitly define it in the table
- *
  */
 
 export async function upgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Besides some documentary refactoring this migrates the database to an explicit `DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci` which was set on `state_users` (and not modeled yet), but not on `login_users`. This resulted in both fields not being comparable if the database charset was not exactly the given charset and collation.

This PR:
- Migrates the Database to specify the charset and collation for both tables explicitly
- Migrates the entity models to reflect the database model more precisely
- Documents the purpose of all existing migrations in a proper manner

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
