### PR TITLE
close row-details automatically when switching to multiple creation page

### DIFF
--- a/admin/src/components/UserTable.vue
+++ b/admin/src/components/UserTable.vue
@@ -74,6 +74,7 @@
 
       <template #row-details="row">
         <row-details
+          v-if="type !== 'UserListSearch' && type !== 'UserListMassCreation'"
           :row="row"
           :type="type"
           :slotName="slotName"


### PR DESCRIPTION
## 🍰 Pullrequest
Wenn ich in der Nutzer Suche seite bin und für einen einzelnen Nutzer dei row details geöffnet habe .. und dann auf die mehrfachschöpfungsseite wechsel, schliest es die row-details autoamtisch. bzw. wird es weggeklemmt wenn der jeweilige page.type aktualiesert. 

bei der mehrfachschöpfung sollten alle row-details nicht zu öffnen sein .. und wenn offen .. sollen sie nicht angezeigt werden. 

### Issues
- fixes #1234 