### PR TITLE
1230 details für wiederholte email bestaetigen versenden

### DIFF
--- a/admin/src/components/ConfirmRegisterMailFormular.spec.js
+++ b/admin/src/components/ConfirmRegisterMailFormular.spec.js
@@ -19,6 +19,7 @@ const mocks = {
 }
 
 const propsData = {
+  checked: false,
   email: 'bob@baumeister.de',
   dateLastSend: '',
 }

--- a/admin/src/components/ConfirmRegisterMailFormular.vue
+++ b/admin/src/components/ConfirmRegisterMailFormular.vue
@@ -1,23 +1,20 @@
 <template>
   <div class="component-confirm-register-mail">
     <div class="shadow p-3 mb-5 bg-white rounded">
-     
-      <div v-if="checked">
-        Die E-Mail wurde am  {{ dateLastSend  }} bestätigt.
-      </div>
-       <div v-else  >
+      <div v-if="checked">Die E-Mail wurde am {{ dateLastSend }} bestätigt.</div>
+      <div v-else>
         {{ $t('unregister_mail.text', { date: dateLastSend, mail: email }) }}
-     
-      <!-- Using components -->
-      <b-input-group :prepend="$t('unregister_mail.info')" class="mt-3">
-        <b-form-input readonly :value="email"></b-form-input>
-        <b-input-group-append>
-          <b-button variant="outline-success" class="test-button" @click="sendRegisterMail">
-            {{ $t('unregister_mail.button') }}
-          </b-button>
-        </b-input-group-append>
-      </b-input-group>
-       </div>
+
+        <!-- Using components -->
+        <b-input-group :prepend="$t('unregister_mail.info')" class="mt-3">
+          <b-form-input readonly :value="email"></b-form-input>
+          <b-input-group-append>
+            <b-button variant="outline-success" class="test-button" @click="sendRegisterMail">
+              {{ $t('unregister_mail.button') }}
+            </b-button>
+          </b-input-group-append>
+        </b-input-group>
+      </div>
     </div>
   </div>
 </template>

--- a/admin/src/components/ConfirmRegisterMailFormular.vue
+++ b/admin/src/components/ConfirmRegisterMailFormular.vue
@@ -25,7 +25,7 @@ export default {
   name: 'ConfirmRegisterMail',
   props: {
     checked: {
-      type: String,
+      type: Boolean,
     },
     email: {
       type: String,

--- a/admin/src/components/ConfirmRegisterMailFormular.vue
+++ b/admin/src/components/ConfirmRegisterMailFormular.vue
@@ -1,10 +1,13 @@
 <template>
   <div class="component-confirm-register-mail">
     <div class="shadow p-3 mb-5 bg-white rounded">
-      <div class="h5">
-        {{ $t('unregister_mail.text', { date: dateLastSend, mail: email }) }}
+     
+      <div v-if="checked">
+        Die E-Mail wurde am  {{ dateLastSend  }} bestätigt.
       </div>
-
+       <div v-else  >
+        {{ $t('unregister_mail.text', { date: dateLastSend, mail: email }) }}
+     
       <!-- Using components -->
       <b-input-group :prepend="$t('unregister_mail.info')" class="mt-3">
         <b-form-input readonly :value="email"></b-form-input>
@@ -14,6 +17,7 @@
           </b-button>
         </b-input-group-append>
       </b-input-group>
+       </div>
     </div>
   </div>
 </template>
@@ -23,6 +27,9 @@ import { sendActivationEmail } from '../graphql/sendActivationEmail'
 export default {
   name: 'ConfirmRegisterMail',
   props: {
+    checked: {
+      type: String,
+    },
     email: {
       type: String,
     },

--- a/admin/src/components/ConfirmRegisterMailFormular.vue
+++ b/admin/src/components/ConfirmRegisterMailFormular.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="component-confirm-register-mail">
     <div class="shadow p-3 mb-5 bg-white rounded">
-      <div v-if="checked">Die E-Mail wurde am {{ dateLastSend }} bestätigt.</div>
+      <div v-if="checked">{{ $t('unregister_mail.text_true', { date: dateLastSend }) }}</div>
       <div v-else>
-        {{ $t('unregister_mail.text', { date: dateLastSend, mail: email }) }}
+        {{ $t('unregister_mail.text_false', { date: dateLastSend, mail: email }) }}
 
         <!-- Using components -->
         <b-input-group :prepend="$t('unregister_mail.info')" class="mt-3">

--- a/admin/src/components/UserTable.vue
+++ b/admin/src/components/UserTable.vue
@@ -107,6 +107,7 @@
           </template>
           <template #show-register-mail>
             <confirm-register-mail-formular
+              :checked="row.item.emailChecked"
               :email="row.item.email"
               :dateLastSend="$moment().subtract(1, 'month').format('dddd, DD.MMMM.YYYY HH:mm'),"
             />

--- a/admin/src/locales/de.json
+++ b/admin/src/locales/de.json
@@ -59,7 +59,8 @@
     "error": "Fehler beim Senden des Bestätigungs-Links an den Benutzer: {message}",
     "info": "Email bestätigen, wiederholt senden an:",
     "success": "Erfolgreiches Senden des Bestätigungs-Links an die E-Mail des Nutzers! ({email})",
-    "text": " Die letzte Email wurde am <b>{date} Uhr</b> an das Mitglied ({mail}) gesendet."
+    "text_false": " Die letzte Email wurde am {date} Uhr an das Mitglied ({mail}) gesendet.",
+    "text_true": " Die Email wurde am {date} Uhr bestätigt."
   },
   "user_search": "Nutzer-Suche"
 }

--- a/admin/src/locales/en.json
+++ b/admin/src/locales/en.json
@@ -59,7 +59,8 @@
     "error": "Error sending the confirmation link to the user: {message}",
     "info": "Confirm email, send repeatedly to:",
     "success": "Successfully send the confirmation link to the user's email! ({email})",
-    "text": " The last email was sent to the member ({mail}) on <b>{date} clock</b>."
+    "text_false": "The last email was sent to the member ({mail}) on {date} clock.",
+    "text_true": "The email was confirmed on {date} clock."
   },
   "user_search": "User search"
 }


### PR DESCRIPTION
## 🍰 Pullrequest
1. Wenn eine E-Mail bestätigt ist dann wir d nur der Text und Datum der bestätigung angezeigt. 
2. Wenn nicht bestätigt ist, wird das formular angezeigt mit dem erneuten absenden einer mail funktion zum bestätignen der email. 


### Issues
- fixes #1230 

![FireShot Capture 893 - Gradido Admin Interface - localhost](https://user-images.githubusercontent.com/1324583/148530439-3cfc2ab4-62a0-4946-9e6c-485b29ce73bc.png)

![FireShot Capture 896 - Gradido Admin Interface - localhost](https://user-images.githubusercontent.com/1324583/148531272-30aceb61-7c26-4642-bab8-0857d418df4e.png)


![FireShot Capture 895 - Gradido Admin Interface - localhost](https://user-images.githubusercontent.com/1324583/148530448-a82645e1-be6c-4839-a9d4-5f5ea0d2dc79.png)

