### PR TITLE
Admin Logout redirectes to the wallet login page.

### DIFF
--- a/admin/.env.dist
+++ b/admin/.env.dist
@@ -1,3 +1,4 @@
 GRAPHQL_URI=http://localhost:4000/graphql
 WALLET_AUTH_URL=http://localhost/vue/authenticate?token=$1
+WALLET_URL=http://localhost/vue/login
 DEBUG_DISABLE_AUTH=false

--- a/admin/src/components/NavBar.spec.js
+++ b/admin/src/components/NavBar.spec.js
@@ -53,13 +53,17 @@ describe('NavBar', () => {
   })
 
   describe('logout', () => {
-    // const assignLocationSpy = jest.fn()
+    const windowLocationMock = jest.fn()
     beforeEach(async () => {
+      delete window.location
+      window.location = {
+        assign: windowLocationMock,
+      }
       await wrapper.findAll('a').at(6).trigger('click')
     })
 
     it('redirects to /logout', () => {
-      expect(routerPushMock).toBeCalledWith('/logout')
+      expect(windowLocationMock).toBeCalledWith('http://localhost/vue/login')
     })
 
     it('dispatches logout to store', () => {

--- a/admin/src/components/NavBar.vue
+++ b/admin/src/components/NavBar.vue
@@ -33,8 +33,8 @@ export default {
   name: 'navbar',
   methods: {
     logout() {
+      window.location = CONFIG.WALLET_URL
       this.$store.dispatch('logout')
-      this.$router.push('/logout')
     },
     wallet() {
       window.location = CONFIG.WALLET_AUTH_URL.replace('$1', this.$store.state.token)

--- a/admin/src/components/NavBar.vue
+++ b/admin/src/components/NavBar.vue
@@ -33,7 +33,8 @@ export default {
   name: 'navbar',
   methods: {
     logout() {
-      window.location = CONFIG.WALLET_URL
+      window.location.assign(CONFIG.WALLET_URL)
+      // window.location = CONFIG.WALLET_URL
       this.$store.dispatch('logout')
     },
     wallet() {

--- a/admin/src/config/index.js
+++ b/admin/src/config/index.js
@@ -20,6 +20,7 @@ const environment = {
 const endpoints = {
   GRAPHQL_URI: process.env.GRAPHQL_URI || 'http://localhost:4000/graphql',
   WALLET_AUTH_URL: process.env.WALLET_AUTH_URL || 'http://localhost/vue/authenticate?token=$1',
+  WALLET_URL: process.env.WALLET_URL || 'http://localhost/vue/login',
 }
 
 const debug = {


### PR DESCRIPTION
## 🍰 Pullrequest
When admin user logout they are send to a 404 not found, now redirects to the wallet-login page

### Issues
<!-- Which Issues does this fix, which are related?
- relates #XXX
-->
- fixes #1241

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] Admin Logout redirects to Wallet Login
