### PR TITLE
fix: Override Existing Token in Response Header

### DIFF
--- a/backend/src/server/plugins.ts
+++ b/backend/src/server/plugins.ts
@@ -8,7 +8,11 @@ const plugins = [
         willSendResponse(requestContext: any) {
           const { setHeaders = [] } = requestContext.context
           setHeaders.forEach(({ key, value }: { [key: string]: string }) => {
-            requestContext.response.http.headers.append(key, value)
+            if (requestContext.response.http.headers.get(key)) {
+              requestContext.response.http.headers.set(key, value)
+            } else {
+              requestContext.response.http.headers.append(key, value)
+            }
           })
           return requestContext
         },


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
Use `set` instead of `append` when a key already exists in response header.

### Issues
- fixes #1254
