### PR TITLE
Don't show the language-switch on the /register page.

### DIFF
--- a/frontend/src/views/Layout/AuthLayout_gdd.spec.js
+++ b/frontend/src/views/Layout/AuthLayout_gdd.spec.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import AuthLayoutGdd from './AuthLayout_gdd'
+import LanguageSwitch from '../../components/LanguageSwitch'
 
 const localVue = global.localVue
 
@@ -15,6 +16,7 @@ describe('AuthLayoutGdd', () => {
       meta: {
         hideFooter: false,
       },
+      path: '/',
     },
     $store: {
       state: {},
@@ -46,6 +48,21 @@ describe('AuthLayoutGdd', () => {
 
     it('has a footer inside the main content', () => {
       expect(wrapper.find('div.main-content').find('footer.footer').exists()).toBeTruthy()
+    })
+
+    it('has LanguageSwitch', () => {
+      expect(wrapper.findComponent(LanguageSwitch).exists()).toBeTruthy()
+    })
+
+    describe('check LanguageSwitch on register page', () => {
+      beforeEach(() => {
+        mocks.$route.path = '/register'
+        wrapper = Wrapper()
+      })
+
+      it('has not LanguageSwitch', () => {
+        expect(wrapper.findComponent(LanguageSwitch).exists()).toBeFalsy()
+      })
     })
   })
 })

--- a/frontend/src/views/Layout/AuthLayout_gdd.spec.js
+++ b/frontend/src/views/Layout/AuthLayout_gdd.spec.js
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils'
 import AuthLayoutGdd from './AuthLayout_gdd'
-import LanguageSwitch from '../../components/LanguageSwitch'
 
 const localVue = global.localVue
 
@@ -51,7 +50,7 @@ describe('AuthLayoutGdd', () => {
     })
 
     it('has LanguageSwitch', () => {
-      expect(wrapper.findComponent(LanguageSwitch).exists()).toBeTruthy()
+      expect(wrapper.findComponent({ name: 'LanguageSwitch' }).exists()).toBeTruthy()
     })
 
     describe('check LanguageSwitch on register page', () => {
@@ -61,7 +60,7 @@ describe('AuthLayoutGdd', () => {
       })
 
       it('has not LanguageSwitch', () => {
-        expect(wrapper.findComponent(LanguageSwitch).exists()).toBeFalsy()
+        expect(wrapper.findComponent({ name: 'LanguageSwitch' }).exists()).toBeFalsy()
       })
     })
   })

--- a/frontend/src/views/Layout/AuthLayout_gdd.vue
+++ b/frontend/src/views/Layout/AuthLayout_gdd.vue
@@ -2,7 +2,7 @@
   <div class="wrapper">
     <div class="main-content mt-4">
       <router-view></router-view>
-      <language-switch class="text-center mb-5 mt-5" />
+      <language-switch v-if="$route.path !== '/register'" class="text-center mb-5 mt-5" />
       <content-footer v-if="!$route.meta.hideFooter"></content-footer>
     </div>
   </div>


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
LanguageSwitch & LanguageSwitchSelect components doesn't update each other but both change the language of the website. So if LanguageSwitch is set to english the languageSwitchSelect stays on german and vise versa.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #1247 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] Don't show LanguageSwitch on the register page.
