### PR TITLE
Withdrew space at the end of an locale definition.

### DIFF
--- a/admin/src/locales/de.json
+++ b/admin/src/locales/de.json
@@ -2,7 +2,7 @@
   "bookmark": "bookmark",
   "confirmed": "bestätigt",
   "creation_form": {
-    "creation_for": "Schöpfung für ",
+    "creation_for": "Schöpfung für",
     "enter_text": "Text eintragen",
     "form": "Schöpfungsformular",
     "min_characters": "Mindestens 10 Zeichen eingeben",

--- a/admin/src/locales/en.json
+++ b/admin/src/locales/en.json
@@ -2,7 +2,7 @@
   "bookmark": "Remember",
   "confirmed": "confirmed",
   "creation_form": {
-    "creation_for": "Creation for ",
+    "creation_for": "Creation for",
     "enter_text": "Enter text",
     "form": "Creation form",
     "min_characters": "Enter at least 10 characters",


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
As an admin when creating a pending creation we have a default text in the middle of this text were 2 spaces.
This fixes it.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #1242 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] Withdraw spaces at the end of locale definitions
