### PR TITLE
gradido proxy

### DIFF
--- a/deployment/bare_metal/nginx/sites-available/gradido_proxy.ssl.template
+++ b/deployment/bare_metal/nginx/sites-available/gradido_proxy.ssl.template
@@ -1,0 +1,38 @@
+server {
+    if ($host = $NGINX_PROXY_SERVER_NAME) {
+        return 301 https://$host$request_uri;
+    }
+
+    server_name $NGINX_PROXY_SERVER_NAME;
+    listen 80;
+    listen [::]:80;
+    return 404;
+}
+
+server {
+    server_name $NGINX_PROXY_SERVER_NAME;
+
+    listen [::]:443 ssl ipv6only=on;
+    listen 443 ssl;
+    ssl_certificate $NGINX_PROXY_SSL_CERTIFICATE;
+    ssl_certificate_key $NGINX_PROXY_SSL_CERTIFICATE_KEY;
+    include $NGINX_SSL_INCLUDE;
+    ssl_dhparam $NGINX_SSL_DHPARAM;
+
+    include /etc/nginx/common/protect.conf;
+    include /etc/nginx/common/protect_add_header.conf;
+	#include /etc/nginx/common/ssl.conf;
+
+    location / {
+		proxy_http_version 1.1;
+		proxy_set_header   Upgrade $http_upgrade;
+		proxy_set_header   Connection 'upgrade';
+		proxy_set_header   X-Forwarded-For $remote_addr;
+		proxy_set_header   X-Real-IP  $remote_addr;
+		proxy_set_header   Host $host;
+		
+		proxy_pass         $NGINX_SERVER_NAME;
+		proxy_redirect     off;
+	}
+    #access_log /var/log/nginx/access.log main;
+}

--- a/deployment/bare_metal/nginx/sites-available/gradido_proxy.template
+++ b/deployment/bare_metal/nginx/sites-available/gradido_proxy.template
@@ -1,0 +1,23 @@
+
+server {
+    server_name $NGINX_PROXY_SERVER_NAME;
+
+    listen 80;
+    listen [::]:80;
+    
+    include /etc/nginx/common/protect.conf;
+    include /etc/nginx/common/protect_add_header.conf;
+
+    location / {
+		proxy_http_version 1.1;
+		proxy_set_header   Upgrade $http_upgrade;
+		proxy_set_header   Connection 'upgrade';
+		proxy_set_header   X-Forwarded-For $remote_addr;
+		proxy_set_header   X-Real-IP  $remote_addr;
+		proxy_set_header   Host $host;
+		
+		proxy_pass         $NGINX_SERVER_NAME;
+		proxy_redirect     off;
+	}
+    #access_log /var/log/nginx/access.log main;
+}


### PR DESCRIPTION
## 🍰 Pullrequest
A nginx config template for a gradido domain proxy. 

Example: we have the domain gdd1.gradido.com as or main domain but our server will be shutdown sometime and we like easly switch over to or backup server without waiting that all dns server has get the update for the new domain. 
The solution: We use nginx as proxy and route the gdd1.gradido.com from dns to our final production server.
The final production server then proxy all calls to our current production server which get a second domain: gdd1-1fire.gradido.com.
If we swap to the backup server we need only update the nginx config on the final production server and don't need to wait on dns server updates.

If we copy over the ssl keys from production to the final production server, we can proxy from final production to current production and keep the config on current production. So all user can reach the production server nevertheless if there request go to current production ip or final production server ip.

