### PR TITLE
fix: Render Localized Balance in NavBar

### DIFF
--- a/frontend/src/components/Menu/Navbar.spec.js
+++ b/frontend/src/components/Menu/Navbar.spec.js
@@ -7,6 +7,7 @@ const propsData = {
   balance: 1234,
   visible: false,
   elopageUri: 'https://elopage.com',
+  pending: false,
 }
 
 const mocks = {
@@ -20,6 +21,7 @@ const mocks = {
       isAdmin: true,
     },
   },
+  $n: jest.fn((n) => n),
 }
 
 describe('Navbar', () => {

--- a/frontend/src/components/Menu/Navbar.vue
+++ b/frontend/src/components/Menu/Navbar.vue
@@ -10,7 +10,7 @@
       </div>
 
       <b-navbar-nav class="ml-auto" is-nav>
-        <b-nav-item>{{ balance }} GDD</b-nav-item>
+        <b-nav-item>{{ pending ? '—' : $n(balance, 'decimal') }} GDD</b-nav-item>
         <b-nav-item to="/profile" right class="d-none d-sm-none d-md-none d-lg-flex shadow-lg">
           <small>
             {{ $store.state.firstName }} {{ $store.state.lastName }},
@@ -86,6 +86,10 @@ export default {
     elopageUri: {
       type: String,
       required: false,
+    },
+    pending: {
+      type: Boolean,
+      required: true,
     },
   },
   data() {

--- a/frontend/src/views/Layout/DashboardLayout_gdd.vue
+++ b/frontend/src/views/Layout/DashboardLayout_gdd.vue
@@ -4,6 +4,7 @@
       class="main-navbar"
       :balance="balance"
       :visible="visible"
+      :pending="pending"
       :elopageUri="elopageUri"
       @set-visible="setVisible"
       @admin="admin"


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
The balance in the navigation bar is localized and always with 2 digits.