### PR TITLE
defined fields for Transactionlist in UserSearch in Adminarea, add Lo…

### DIFF
--- a/admin/src/components/CreationTransactionListFormular.spec.js
+++ b/admin/src/components/CreationTransactionListFormular.spec.js
@@ -15,7 +15,7 @@ const apolloQueryMock = jest.fn().mockResolvedValue({
           decayDuration: 0,
           memo: 'Testing',
           transactionId: 1,
-          name: 'Bibi',
+          name: 'Gradido Akademie',
           email: 'bibi@bloxberg.de',
           date: new Date(),
           decay: {
@@ -34,7 +34,7 @@ const apolloQueryMock = jest.fn().mockResolvedValue({
           decayDuration: 0,
           memo: 'Testing 2',
           transactionId: 2,
-          name: 'Bibi',
+          name: 'Gradido Akademie',
           email: 'bibi@bloxberg.de',
           date: new Date(),
           decay: {
@@ -53,6 +53,16 @@ const apolloQueryMock = jest.fn().mockResolvedValue({
 const toastedErrorMock = jest.fn()
 
 const mocks = {
+  $moment: jest.fn(() => {
+    return {
+      format: jest.fn((m) => m),
+      subtract: jest.fn(() => {
+        return {
+          format: jest.fn((m) => m),
+        }
+      }),
+    }
+  }),
   $t: jest.fn((t) => t),
   $apollo: {
     query: apolloQueryMock,
@@ -64,6 +74,7 @@ const mocks = {
 
 const propsData = {
   userId: 1,
+  fields: ['date', 'balance', 'name', 'memo', 'decay'],
 }
 
 describe('CreationTransactionListFormular', () => {
@@ -92,7 +103,9 @@ describe('CreationTransactionListFormular', () => {
       )
     })
 
-    it('has two values for the transaction', () => {
+    it('has two values for the transaction', async () => {
+      await wrapper.vm.$nextTick()
+      console.log(wrapper.html())
       expect(wrapper.find('tbody').findAll('tr').length).toBe(2)
     })
 

--- a/admin/src/components/CreationTransactionListFormular.spec.js
+++ b/admin/src/components/CreationTransactionListFormular.spec.js
@@ -103,9 +103,7 @@ describe('CreationTransactionListFormular', () => {
       )
     })
 
-    it('has two values for the transaction', async () => {
-      await wrapper.vm.$nextTick()
-      console.log(wrapper.html())
+    it('has two values for the transaction', () => {
       expect(wrapper.find('tbody').findAll('tr').length).toBe(2)
     })
 

--- a/admin/src/components/CreationTransactionListFormular.spec.js
+++ b/admin/src/components/CreationTransactionListFormular.spec.js
@@ -53,16 +53,7 @@ const apolloQueryMock = jest.fn().mockResolvedValue({
 const toastedErrorMock = jest.fn()
 
 const mocks = {
-  $moment: jest.fn(() => {
-    return {
-      format: jest.fn((m) => m),
-      subtract: jest.fn(() => {
-        return {
-          format: jest.fn((m) => m),
-        }
-      }),
-    }
-  }),
+  $d: jest.fn((t) => t),
   $t: jest.fn((t) => t),
   $apollo: {
     query: apolloQueryMock,

--- a/admin/src/components/CreationTransactionListFormular.vue
+++ b/admin/src/components/CreationTransactionListFormular.vue
@@ -53,9 +53,7 @@ export default {
           },
         })
         .then((result) => {
-          console.log(result)
           this.items = result.data.transactionList.transactions.filter((t) => t.type === 'creation')
-          console.log( this.items)
         })
         .catch((error) => {
           this.$toasted.error(error.message)

--- a/admin/src/components/CreationTransactionListFormular.vue
+++ b/admin/src/components/CreationTransactionListFormular.vue
@@ -18,7 +18,7 @@ export default {
           key: 'date',
           label: this.$t('transactionlist.date'),
           formatter: (value, key, item) => {
-            return this.$moment(value).format(this.$t('transactionlist.formatter'))
+            return this.$d(new Date(value))
           },
         },
         {

--- a/admin/src/components/CreationTransactionListFormular.vue
+++ b/admin/src/components/CreationTransactionListFormular.vue
@@ -21,8 +21,8 @@ export default {
             return this.$moment(value).format(this.$t('transactionlist.formatter'))
           },
         },
-        { key: 'name', label: this.$t('transactionlist.community') },
         { key: 'balance', label: this.$t('transactionlist.amount') },
+        { key: 'name', label: this.$t('transactionlist.community') },
         { key: 'memo', label: this.$t('transactionlist.memo') },
         {
           key: 'decay',

--- a/admin/src/components/CreationTransactionListFormular.vue
+++ b/admin/src/components/CreationTransactionListFormular.vue
@@ -53,7 +53,9 @@ export default {
           },
         })
         .then((result) => {
+          console.log(result)
           this.items = result.data.transactionList.transactions.filter((t) => t.type === 'creation')
+          console.log( this.items)
         })
         .catch((error) => {
           this.$toasted.error(error.message)

--- a/admin/src/components/CreationTransactionListFormular.vue
+++ b/admin/src/components/CreationTransactionListFormular.vue
@@ -21,7 +21,13 @@ export default {
             return this.$moment(value).format(this.$t('transactionlist.formatter'))
           },
         },
-        { key: 'balance', label: this.$t('transactionlist.amount') },
+        {
+          key: 'balance',
+          label: this.$t('transactionlist.amount'),
+          formatter: (value, key, item) => {
+            return `${value} GDD`
+          },
+        },
         { key: 'name', label: this.$t('transactionlist.community') },
         { key: 'memo', label: this.$t('transactionlist.memo') },
         {

--- a/admin/src/components/CreationTransactionListFormular.vue
+++ b/admin/src/components/CreationTransactionListFormular.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="component-creation-transaction-list">
     {{ $t('transactionlist.title') }}
-    <b-table striped hover :items="items"></b-table>
+    <b-table striped hover :fields="fields" :items="items"></b-table>
   </div>
 </template>
 <script>
@@ -13,6 +13,29 @@ export default {
   },
   data() {
     return {
+      fields: [
+        {
+          key: 'date',
+          label: this.$t('transactionlist.date'),
+          formatter: (value, key, item) => {
+            return this.$moment(value).format(this.$t('transactionlist.formatter'))
+          },
+        },
+        { key: 'name', label: this.$t('transactionlist.community') },
+        { key: 'balance', label: this.$t('transactionlist.amount') },
+        { key: 'memo', label: this.$t('transactionlist.memo') },
+        {
+          key: 'decay',
+          label: this.$t('transactionlist.decay'),
+          formatter: (value, key, item) => {
+            if (value && value.balance >= 0) {
+              return value.balance
+            } else {
+              return '0'
+            }
+          },
+        },
+      ],
       items: [],
     }
   },

--- a/admin/src/locales/de.json
+++ b/admin/src/locales/de.json
@@ -52,7 +52,13 @@
   "remove": "Entfernen",
   "transaction": "Transaktion",
   "transactionlist": {
-    "title": "Alle geschöpften Transaktionen für den Nutzer"
+    "title": "Alle geschöpften Transaktionen für den Nutzer",
+    "amount":"Betrag",
+    "memo":"Nachricht",
+    "date":"Datum",
+    "decay":"Vergänglichkeit",
+    "community":"Gemeinschaft",
+    "formatter":"DD.MM.YYYY"
   },
   "unregistered_emails": "Nur unregistrierte Nutzer",
   "unregister_mail": {

--- a/admin/src/locales/de.json
+++ b/admin/src/locales/de.json
@@ -56,7 +56,6 @@
     "community": "Gemeinschaft",
     "date": "Datum",
     "decay": "Vergänglichkeit",
-    "formatter": "DD.MM.YYYY",
     "memo": "Nachricht",
     "title": "Alle geschöpften Transaktionen für den Nutzer"
   },

--- a/admin/src/locales/de.json
+++ b/admin/src/locales/de.json
@@ -52,13 +52,13 @@
   "remove": "Entfernen",
   "transaction": "Transaktion",
   "transactionlist": {
-    "title": "Alle geschöpften Transaktionen für den Nutzer",
-    "amount":"Betrag",
-    "memo":"Nachricht",
-    "date":"Datum",
-    "decay":"Vergänglichkeit",
-    "community":"Gemeinschaft",
-    "formatter":"DD.MM.YYYY"
+    "amount": "Betrag",
+    "community": "Gemeinschaft",
+    "date": "Datum",
+    "decay": "Vergänglichkeit",
+    "formatter": "DD.MM.YYYY",
+    "memo": "Nachricht",
+    "title": "Alle geschöpften Transaktionen für den Nutzer"
   },
   "unregistered_emails": "Nur unregistrierte Nutzer",
   "unregister_mail": {

--- a/admin/src/locales/en.json
+++ b/admin/src/locales/en.json
@@ -52,7 +52,13 @@
   "remove": "Remove",
   "transaction": "Transaction",
   "transactionlist": {
-    "title": "All creation-transactions for the user"
+    "title": "All creation-transactions for the user",
+    "amount":"Amount",
+    "memo":"Message",
+    "date":"Date",
+    "decay":"Decay",
+    "community":"Community",
+    "formatter":"MM.DD.YYYY"
   },
   "unregistered_emails": "Only unregistered users",
   "unregister_mail": {

--- a/admin/src/locales/en.json
+++ b/admin/src/locales/en.json
@@ -52,13 +52,13 @@
   "remove": "Remove",
   "transaction": "Transaction",
   "transactionlist": {
-    "title": "All creation-transactions for the user",
-    "amount":"Amount",
-    "memo":"Message",
-    "date":"Date",
-    "decay":"Decay",
-    "community":"Community",
-    "formatter":"MM.DD.YYYY"
+    "amount": "Amount",
+    "community": "Community",
+    "date": "Date",
+    "decay": "Decay",
+    "formatter": "MM.DD.YYYY",
+    "memo": "Message",
+    "title": "All creation-transactions for the user"
   },
   "unregistered_emails": "Only unregistered users",
   "unregister_mail": {

--- a/admin/src/locales/en.json
+++ b/admin/src/locales/en.json
@@ -56,7 +56,6 @@
     "community": "Community",
     "date": "Date",
     "decay": "Decay",
-    "formatter": "MM.DD.YYYY",
     "memo": "Message",
     "title": "All creation-transactions for the user"
   },


### PR DESCRIPTION
## 🍰 Pullrequest

1.  decay.balance wird sauber angezeigt, wenn kein decay dann 0 
2. Das Datum ist in einem sauberen Format
3.  folgende punkte aus der Transactiontabelle wurden entfernt
Decay Start | Decay End | Decay Duration | E-Mail | Typename
(siehe Bild)

### Issues
- fixes #1320 

![FireShot Capture 924 - Gradido Admin Interface - localhost](https://user-images.githubusercontent.com/1324583/150142143-e94aaa68-7aac-4676-91c6-edf3c57f33bf.png)

