### PR TITLE
Changed the toasted message for successful creating a creation.

### DIFF
--- a/admin/src/pages/CreationConfirm.vue
+++ b/admin/src/pages/CreationConfirm.vue
@@ -75,7 +75,7 @@ export default {
         case 'confirmed':
           this.confirmResult.splice(index, 1)
           this.$store.commit('openCreationsMinus', 1)
-          this.$toasted.success('Pending Creation has been deleted')
+          this.$toasted.success('Creation has been created')
           break
         default:
           this.$toasted.error('Case ' + event + ' is not supported')


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
Toast message was 'Pending Creation has been deleted', this is confusing for the user so change it to:
'Creation has been created'

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #1325 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
