### PR TITLE
Added a required to the password repeat field, errors are shown immed…

### DIFF
--- a/frontend/src/components/Inputs/InputPasswordConfirmation.vue
+++ b/frontend/src/components/Inputs/InputPasswordConfirmation.vue
@@ -24,8 +24,12 @@
     <b-row class="mb-2">
       <b-col>
         <input-password
-          :rules="{ samePassword: value.password }"
+          :rules="{
+            required: true,
+            samePassword: value.password,
+          }"
           :label="register ? $t('form.passwordRepeat') : $t('form.password_new_repeat')"
+          :immediate="true"
           :name="createId(register ? $t('form.passwordRepeat') : $t('form.password_new_repeat'))"
           :placeholder="register ? $t('form.passwordRepeat') : $t('form.password_new_repeat')"
           v-model="passwordRepeat"


### PR DESCRIPTION
…iatly on password repeat

<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
A user could change his password without confirming it. Now the confirmation is required to be equal the password that was setten.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #1302 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
