### PR TITLE
add .btn-outline-secondary in scss

### DIFF
--- a/frontend/src/assets/scss/custom/gradido-custom/_buttons.scss
+++ b/frontend/src/assets/scss/custom/gradido-custom/_buttons.scss
@@ -27,3 +27,9 @@ $btn-focus-width:             $input-btn-focus-width !default;
 $btn-active-box-shadow:       none !default;
 
 $btn-hover-translate-y:       -1px !default;
+
+
+
+.btn-outline-secondary {
+    color: #4385b1 !important; 
+  }

--- a/frontend/src/views/Pages/Register.vue
+++ b/frontend/src/views/Pages/Register.vue
@@ -270,4 +270,3 @@ export default {
   },
 }
 </script>
-<style></style>


### PR DESCRIPTION
## 🍰 Pullrequest
add 
`.btn-outline-secondary {
    color: #4385b1 !important; 
  }`
in 
frontend/src/assets/scss/custom/gradido-custom/_buttons.scss
 