### PR TITLE
Fix: Elopage Hook Crash

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -4,7 +4,7 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 const constants = {
-  DB_VERSION: '0020-rename_and_clean_state_users',
+  DB_VERSION: '0021-elopagebuys_fields_nullable',
 }
 
 const server = {

--- a/database/entity/0003-login_server_tables/LoginElopageBuys.ts
+++ b/database/entity/0003-login_server_tables/LoginElopageBuys.ts
@@ -5,8 +5,8 @@ export class LoginElopageBuys extends BaseEntity {
   @PrimaryGeneratedColumn('increment', { unsigned: true })
   id: number
 
-  @Column({ name: 'elopage_user_id', nullable: false })
-  elopageUserId: number
+  @Column({ type: 'int', width: 11, name: 'elopage_user_id', nullable: true, default: null })
+  elopageUserId: number | null
 
   @Column({ name: 'affiliate_program_id', nullable: false })
   affiliateProgramId: number

--- a/database/entity/0021-elopagebuys_fields_nullable/LoginElopageBuys.ts
+++ b/database/entity/0021-elopagebuys_fields_nullable/LoginElopageBuys.ts
@@ -1,0 +1,52 @@
+import { BaseEntity, Entity, PrimaryGeneratedColumn, Column } from 'typeorm'
+
+@Entity('login_elopage_buys')
+export class LoginElopageBuys extends BaseEntity {
+  @PrimaryGeneratedColumn('increment', { unsigned: true })
+  id: number
+
+  @Column({ type: 'int', width: 11, name: 'elopage_user_id', nullable: true, default: null })
+  elopageUserId: number | null
+
+  @Column({ type: 'int', width: 11, name: 'affiliate_program_id', nullable: true, default: null })
+  affiliateProgramId: number | null
+
+  @Column({ type: 'int', width: 11, name: 'publisher_id', nullable: true, default: null })
+  publisherId: number | null
+
+  @Column({ type: 'int', width: 11, name: 'order_id', nullable: true, default: null })
+  orderId: number | null
+
+  @Column({ type: 'int', width: 11, name: 'product_id', nullable: true, default: null })
+  productId: number | null
+
+  @Column({ name: 'product_price', nullable: false })
+  productPrice: number
+
+  @Column({
+    name: 'payer_email',
+    length: 255,
+    nullable: false,
+    charset: 'utf8',
+    collation: 'utf8_bin',
+  })
+  payerEmail: string
+
+  @Column({
+    name: 'publisher_email',
+    length: 255,
+    nullable: false,
+    charset: 'utf8',
+    collation: 'utf8_bin',
+  })
+  publisherEmail: string
+
+  @Column({ nullable: false })
+  payed: boolean
+
+  @Column({ name: 'success_date', nullable: false })
+  successDate: Date
+
+  @Column({ length: 255, nullable: false })
+  event: string
+}

--- a/database/entity/LoginElopageBuys.ts
+++ b/database/entity/LoginElopageBuys.ts
@@ -1,1 +1,1 @@
-export { LoginElopageBuys } from './0003-login_server_tables/LoginElopageBuys'
+export { LoginElopageBuys } from './0021-elopagebuys_fields_nullable/LoginElopageBuys'

--- a/database/migrations/0021-elopagebuys_fields_nullable.ts
+++ b/database/migrations/0021-elopagebuys_fields_nullable.ts
@@ -1,0 +1,25 @@
+/* MIGRATION TO ALLOW NULL FIELDS ON ELOPAGEBUYS
+ *
+ * This migration allows null on `affiliate_program_id`,
+ * `publisher_id`, `order_id`. `product_id`.
+ */
+
+export async function upgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  await queryFn(
+    'ALTER TABLE `login_elopage_buys` MODIFY COLUMN `affiliate_program_id` int(11) DEFAULT NULL;',
+  )
+  await queryFn(
+    'ALTER TABLE `login_elopage_buys` MODIFY COLUMN `publisher_id` int(11) DEFAULT NULL;',
+  )
+  await queryFn('ALTER TABLE `login_elopage_buys` MODIFY COLUMN `order_id` int(11) DEFAULT NULL;')
+  await queryFn('ALTER TABLE `login_elopage_buys` MODIFY COLUMN `product_id` int(11) DEFAULT NULL;')
+}
+
+export async function downgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  await queryFn(
+    'ALTER TABLE `login_elopage_buys` MODIFY COLUMN `affiliate_program_id` int(11) NOT NULL;',
+  )
+  await queryFn('ALTER TABLE `login_elopage_buys` MODIFY COLUMN `publisher_id` int(11) NOT NULL;')
+  await queryFn('ALTER TABLE `login_elopage_buys` MODIFY COLUMN `order_id` int(11) NOT NULL;')
+  await queryFn('ALTER TABLE `login_elopage_buys` MODIFY COLUMN `product_id` int(11) NOT NULL;')
+}


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Fixes a crash which occurs on production due to a field not reliable being an integer delivered by elopage. In order to fix this we check if the parsed fields are actually parsable as integer and make the fields in the database nullable. Exception is the price, here we write 0 if we cannot parse it.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #1473

### Todo
<!-- In case some parts are still missing, list them here. -->
- [ ] Make ticket for webhook failures not to crash server
