### PR TITLE
Fix: Elopage Hook Crash 2

### DIFF
--- a/backend/src/webhook/elopage.ts
+++ b/backend/src/webhook/elopage.ts
@@ -53,6 +53,18 @@ export const elopageWebhook = async (req: any, res: any): Promise<void> => {
     membership,
   } = req.body
 
+  // Do not process certain events
+  if (['lesson.viewed', 'lesson.completed', 'lesson.commented'].includes(event)) {
+    // eslint-disable-next-line no-console
+    console.log('User viewed, completed or commented - not saving hook')
+    return
+  }
+
+  if (!product || !publisher || !membership || !payer) {
+    // eslint-disable-next-line no-console
+    console.log('Elopage Hook: Not an event we can process')
+    return
+  }
   loginElopageBuy.affiliateProgramId = parseInt(product.affiliate_program_id) || null
   loginElopageBuy.publisherId = parseInt(publisher.id) || null
   loginElopageBuy.orderId = parseInt(order_id) || null
@@ -71,13 +83,6 @@ export const elopageWebhook = async (req: any, res: any): Promise<void> => {
 
   const firstName = payer.first_name
   const lastName = payer.last_name
-
-  // Do not process certain events
-  if (['lesson.viewed', 'lesson.completed', 'lesson.commented'].includes(loginElopageBuy.event)) {
-    // eslint-disable-next-line no-console
-    console.log('User viewed, completed or commented - not saving hook')
-    return
-  }
 
   // Save the hook data
   try {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Certain Elopage Hooks still crash our services.

This PR fixes this:
- cancel hook on certain events before calculating data
- ensure all required fields are present and cancel when thats not the case

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
