### PR TITLE
Fix: Upper case email on register breaks account

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -4,7 +4,7 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 const constants = {
-  DB_VERSION: '0024-combine_transaction_tables',
+  DB_VERSION: '0025-emails_to_lower',
   DECAY_START_TIME: new Date('2021-05-13 17:46:31'), // GMT+0
 }
 

--- a/backend/src/graphql/resolver/UserResolver.ts
+++ b/backend/src/graphql/resolver/UserResolver.ts
@@ -408,6 +408,7 @@ export class UserResolver {
   @Authorized([RIGHTS.SEND_ACTIVATION_EMAIL])
   @Mutation(() => Boolean)
   async sendActivationEmail(@Arg('email') email: string): Promise<boolean> {
+    email = email.trim().toLowerCase()
     const user = await DbUser.findOneOrFail({ email: email })
 
     const queryRunner = getConnection().createQueryRunner()
@@ -448,7 +449,7 @@ export class UserResolver {
   @Query(() => Boolean)
   async sendResetPasswordEmail(@Arg('email') email: string): Promise<boolean> {
     // TODO: this has duplicate code with createUser
-
+    email = email.trim().toLowerCase()
     const user = await DbUser.findOneOrFail({ email })
 
     const optInCode = await getOptInCode(user.id)

--- a/backend/src/graphql/resolver/UserResolver.ts
+++ b/backend/src/graphql/resolver/UserResolver.ts
@@ -335,7 +335,7 @@ export class UserResolver {
     }
 
     // Validate email unique
-    // TODO: i can register an email in upper/lower case twice
+    email = email.trim().toLowerCase()
     // TODO we cannot use repository.count(), since it does not allow to specify if you want to include the soft deletes
     const userFound = await DbUser.findOne({ email }, { withDeleted: true })
     if (userFound) {

--- a/database/migrations/0025-emails_to_lower.ts
+++ b/database/migrations/0025-emails_to_lower.ts
@@ -11,6 +11,7 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
   await queryFn('UPDATE `users` SET `email` = LOWER(`email`);')
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function downgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
   // This migration cannot be revered
 }

--- a/database/migrations/0025-emails_to_lower.ts
+++ b/database/migrations/0025-emails_to_lower.ts
@@ -1,0 +1,16 @@
+/* MIGRATION TO MAKE ALL EMAILS LOWERCASE
+ *
+ * Make all `email` values in `users` lowercase.
+ * This allows safe queries without any modificators
+ */
+
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function upgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  await queryFn('UPDATE `users` SET `email` = LOWER(`email`);')
+}
+
+export async function downgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  // This migration cannot be revered
+}


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

This fixes a bug where users who registered with uppercase letters in their email not being able to login even after password reset.

This affected 20 users on production, of which 7 were test accounts. Of the 13 users one was from early 2020, while the remaining 12 were the earliest from 16.10.2021. This means this bug was introduced with the switch to Apollo.

- Corrects existing users in the database
- Fixes the register call to properly sanitize user input

Sideeffect:
- Since the email is part of our password generation mechanism this PR will invalidate the passwords of affected users (20). Those have to reset their passwords to regain access to their account.

### Repro
1. Check out `master`
2. Register with `sPoNgEbOb@wHaTeVeR.oCeAn`
3. Try login  -> should fail, even when typing the email in the same upper cases as in the register form
4. Try reset password -> no effect on login success
5. Checkout this branch
6. Try login -> should not work 
7. Try reset password -> things should get rolling now
8. Register another account with UpperCase letters in the email
9. login should work out of the box now

### Todo
<!-- In case some parts are still missing, list them here. -->
- [] Please test and verify.
