### PR TITLE
community name in creation transaction is displayed cleanly

### DIFF
--- a/frontend/src/components/Transactions/TransactionCreation.vue
+++ b/frontend/src/components/Transactions/TransactionCreation.vue
@@ -31,7 +31,7 @@
               </b-col>
               <b-col cols="7">
                 <div class="gdd-transaction-list-item-name">
-                  {{ $t('decay.decay_since_last_transaction') }}
+                  {{ linkedUser.firstName + ' ' + linkedUser.lastName }}
                 </div>
               </b-col>
             </b-row>


### PR DESCRIPTION
 ## 🍰 Pullrequest
 community name in creation transaction is displayed cleanly
 
### Issues
 
- fixes #1577 

![FireShot Capture 1009 - Gradido Account - localhost](https://user-images.githubusercontent.com/1324583/157200004-89762d07-2b5a-45f0-b075-69d60c70512e.png)

