### PR TITLE
feat: Link Transaction to Transaction Link on Redeem

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -10,7 +10,7 @@ Decimal.set({
 })
 
 const constants = {
-  DB_VERSION: '0031-remove_sendEmail_from_transaction_link',
+  DB_VERSION: '0032-add-transaction-link-to-transaction',
   DECAY_START_TIME: new Date('2021-05-13 17:46:31'), // GMT+0
 }
 

--- a/backend/src/graphql/model/Transaction.ts
+++ b/backend/src/graphql/model/Transaction.ts
@@ -30,6 +30,7 @@ export class Transaction {
     this.creationDate = transaction.creationDate
     this.linkedUser = linkedUser
     this.linkedTransactionId = transaction.linkedTransactionId
+    this.transactionLinkId = transaction.transactionLinkId
   }
 
   @Field(() => Number)
@@ -67,4 +68,8 @@ export class Transaction {
 
   @Field(() => Number, { nullable: true })
   linkedTransactionId?: number | null
+
+  // Links to the TransactionLink when transaction was created by a link
+  @Field(() => Number, { nullable: true })
+  transactionLinkId?: number | null
 }

--- a/backend/src/graphql/resolver/TransactionLinkResolver.ts
+++ b/backend/src/graphql/resolver/TransactionLinkResolver.ts
@@ -156,14 +156,13 @@ export class TransactionLinkResolver {
       throw new Error('Transaction Link already redeemed.')
     }
 
-    await executeTransaction(transactionLink.amount, transactionLink.memo, linkedUser, user)
-
-    // TODO: Rollback transaction when updating links fails
-    transactionLink.redeemedAt = now
-    transactionLink.redeemedBy = user.id
-    transactionLink.save().catch(() => {
-      throw new Error('Could not update transaction link.')
-    })
+    await executeTransaction(
+      transactionLink.amount,
+      transactionLink.memo,
+      linkedUser,
+      user,
+      transactionLink,
+    )
 
     return true
   }

--- a/database/entity/0032-add-transaction-link-to-transaction/Transaction.ts
+++ b/database/entity/0032-add-transaction-link-to-transaction/Transaction.ts
@@ -1,0 +1,94 @@
+import Decimal from 'decimal.js-light'
+import { BaseEntity, Entity, PrimaryGeneratedColumn, Column } from 'typeorm'
+import { DecimalTransformer } from '../../src/typeorm/DecimalTransformer'
+
+@Entity('transactions')
+export class Transaction extends BaseEntity {
+  @PrimaryGeneratedColumn('increment', { unsigned: true })
+  id: number
+
+  @Column({ name: 'user_id', unsigned: true, nullable: false })
+  userId: number
+
+  @Column({ type: 'int', unsigned: true, nullable: true, default: null })
+  previous: number | null
+
+  @Column({ name: 'type_id', unsigned: true, nullable: false })
+  typeId: number
+
+  @Column({
+    type: 'decimal',
+    precision: 40,
+    scale: 20,
+    nullable: false,
+    transformer: DecimalTransformer,
+  })
+  amount: Decimal
+
+  @Column({
+    type: 'decimal',
+    precision: 40,
+    scale: 20,
+    nullable: false,
+    transformer: DecimalTransformer,
+  })
+  balance: Decimal
+
+  @Column({
+    name: 'balance_date',
+    type: 'datetime',
+    default: () => 'CURRENT_TIMESTAMP',
+    nullable: false,
+  })
+  balanceDate: Date
+
+  @Column({
+    type: 'decimal',
+    precision: 40,
+    scale: 20,
+    nullable: false,
+    transformer: DecimalTransformer,
+  })
+  decay: Decimal
+
+  @Column({
+    name: 'decay_start',
+    type: 'datetime',
+    nullable: true,
+    default: null,
+  })
+  decayStart: Date | null
+
+  @Column({ length: 255, nullable: false, collation: 'utf8mb4_unicode_ci' })
+  memo: string
+
+  @Column({ name: 'creation_date', type: 'datetime', nullable: true, default: null })
+  creationDate: Date | null
+
+  @Column({
+    name: 'linked_user_id',
+    type: 'int',
+    unsigned: true,
+    nullable: true,
+    default: null,
+  })
+  linkedUserId?: number | null
+
+  @Column({
+    name: 'linked_transaction_id',
+    type: 'int',
+    unsigned: true,
+    nullable: true,
+    default: null,
+  })
+  linkedTransactionId?: number | null
+
+  @Column({
+    name: 'transaction_link_id',
+    type: 'int',
+    unsigned: true,
+    nullable: true,
+    default: null,
+  })
+  transactionLinkId?: number | null
+}

--- a/database/entity/Transaction.ts
+++ b/database/entity/Transaction.ts
@@ -1,1 +1,1 @@
-export { Transaction } from './0029-clean_transaction_table/Transaction'
+export { Transaction } from './0032-add-transaction-link-to-transaction/Transaction'

--- a/database/migrations/0032-add-transaction-link-to-transaction.ts
+++ b/database/migrations/0032-add-transaction-link-to-transaction.ts
@@ -1,0 +1,14 @@
+/* MIGRATION TO ADD transactionLinkId FIELDTO TRANSACTION */
+
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function upgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  await queryFn(
+    'ALTER TABLE `transactions` ADD COLUMN `transactionLinkId` int UNSIGNED DEFAULT NULL;',
+  )
+}
+
+export async function downgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  await queryFn('ALTER TABLE `transactions` DROP COLUMN `transactionLinkId`;')
+}

--- a/database/migrations/0032-add-transaction-link-to-transaction.ts
+++ b/database/migrations/0032-add-transaction-link-to-transaction.ts
@@ -5,10 +5,10 @@
 
 export async function upgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
   await queryFn(
-    'ALTER TABLE `transactions` ADD COLUMN `transactionLinkId` int UNSIGNED DEFAULT NULL;',
+    'ALTER TABLE `transactions` ADD COLUMN `transaction_link_id` int UNSIGNED DEFAULT NULL;',
   )
 }
 
 export async function downgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
-  await queryFn('ALTER TABLE `transactions` DROP COLUMN `transactionLinkId`;')
+  await queryFn('ALTER TABLE `transactions` DROP COLUMN `transaction_link_id`;')
 }

--- a/database/migrations/0032-add-transaction-link-to-transaction.ts
+++ b/database/migrations/0032-add-transaction-link-to-transaction.ts
@@ -5,7 +5,7 @@
 
 export async function upgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
   await queryFn(
-    'ALTER TABLE `transactions` ADD COLUMN `transaction_link_id` int UNSIGNED DEFAULT NULL;',
+    'ALTER TABLE `transactions` ADD COLUMN `transaction_link_id` int UNSIGNED DEFAULT NULL AFTER `linked_transaction_id`;',
   )
 }
 


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
Adds new column `transaction_link_id` to transactions table. This field is filled by the ID of an transaction link when the transaction is created by redeeming a link.

### Issues
- fixes #1593 
- fixes #1592

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
