### PR TITLE
refactor: No Reset DB in Backend Unit Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -489,7 +489,7 @@ jobs:
   unit_test_backend:
     name: Unit tests - Backend
     runs-on: ubuntu-latest
-    needs: [build_test_mariadb]
+    needs: [build_test_mariadb, build_test_database_up]
     steps:
       ##########################################################################
       # CHECKOUT CODE ##########################################################

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -511,14 +511,6 @@ jobs:
       ##########################################################################
       - name: backend | docker-compose
         run: docker-compose -f docker-compose.yml -f docker-compose.test.yml up --detach --no-deps mariadb
-      - name: Sleep for 30 seconds
-        run: sleep 30s
-        shell: bash
-      - name: backend | docker-compose database
-        run: docker-compose -f docker-compose.yml -f docker-compose.test.yml up --detach --no-deps database
-      - name: Sleep for 30 seconds
-        run: sleep 30s
-        shell: bash
       - name: backend Unit tests | test
         run: cd database && yarn && yarn build && cd ../backend && yarn && yarn test
         # run: docker-compose -f docker-compose.yml -f docker-compose.test.yml exec -T backend yarn test

--- a/backend/src/graphql/resolver/UserResolver.test.ts
+++ b/backend/src/graphql/resolver/UserResolver.test.ts
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
-import { testEnvironment, resetEntities, createUser } from '@test/helpers'
+import { testEnvironment, createUser, headerPushMock, cleanDB } from '@test/helpers'
 import { createUserMutation, setPasswordMutation } from '@test/graphql'
 import gql from 'graphql-tag'
 import { GraphQLError } from 'graphql'
-import { resetDB } from '@dbTools/helpers'
 import { LoginEmailOptIn } from '@entity/LoginEmailOptIn'
 import { User } from '@entity/User'
 import CONFIG from '@/config'
@@ -30,30 +29,19 @@ jest.mock('@/apis/KlicktippController', () => {
 })
 */
 
-let token: string
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const headerPushMock = jest.fn((t) => (token = t.value))
-
-const context = {
-  setHeaders: {
-    push: headerPushMock,
-    forEach: jest.fn(),
-  },
-}
-
 let mutate: any, query: any, con: any
 
 beforeAll(async () => {
-  const testEnv = await testEnvironment(context)
+  const testEnv = await testEnvironment()
   mutate = testEnv.mutate
   query = testEnv.query
   con = testEnv.con
+  await cleanDB()
 })
 
 afterAll(async () => {
-  await resetDB(true)
-  await con.close()
+  await cleanDB()
+  con.close()
 })
 
 describe('UserResolver', () => {
@@ -75,7 +63,7 @@ describe('UserResolver', () => {
     })
 
     afterAll(async () => {
-      await resetEntities([User, LoginEmailOptIn])
+      await cleanDB()
     })
 
     it('returns success', () => {
@@ -213,7 +201,7 @@ describe('UserResolver', () => {
       })
 
       afterAll(async () => {
-        await resetEntities([User, LoginEmailOptIn])
+        await cleanDB()
       })
 
       it('sets email checked to true', () => {
@@ -256,7 +244,7 @@ describe('UserResolver', () => {
       })
 
       afterAll(async () => {
-        await resetEntities([User, LoginEmailOptIn])
+        await cleanDB()
       })
 
       it('throws an error', () => {
@@ -282,7 +270,7 @@ describe('UserResolver', () => {
       })
 
       afterAll(async () => {
-        await resetEntities([User, LoginEmailOptIn])
+        await cleanDB()
       })
 
       it('throws an error', () => {
@@ -323,7 +311,7 @@ describe('UserResolver', () => {
     let result: User
 
     afterAll(async () => {
-      await resetEntities([User, LoginEmailOptIn])
+      await cleanDB()
     })
 
     describe('no users in database', () => {
@@ -353,7 +341,7 @@ describe('UserResolver', () => {
       })
 
       afterAll(async () => {
-        await resetEntities([User, LoginEmailOptIn])
+        await cleanDB()
       })
 
       it('returns the user object', () => {

--- a/backend/test/helpers.ts
+++ b/backend/test/helpers.ts
@@ -7,8 +7,28 @@ import { resetDB, initialize } from '@dbTools/helpers'
 import { createUserMutation, setPasswordMutation } from './graphql'
 import { LoginEmailOptIn } from '@entity/LoginEmailOptIn'
 import { User } from '@entity/User'
+import { entities } from '@entity/index'
 
-export const testEnvironment = async (context: any) => {
+let token = ''
+
+export const headerPushMock = jest.fn((t) => (token = t.value))
+
+const context = {
+  token,
+  setHeaders: {
+    push: headerPushMock,
+    forEach: jest.fn(),
+  },
+}
+
+export const cleanDB = async () => {
+  // this only works as lond we do not have foreign key constraints
+  for (let i = 0; i < entities.length; i++) {
+    await resetEntity(entities[i])
+  }
+}
+
+export const testEnvironment = async () => {
   const server = await createServer(context)
   const con = server.con
   const testClient = createTestClient(server.apollo)
@@ -24,12 +44,6 @@ export const resetEntity = async (entity: any) => {
   if (items.length > 0) {
     const ids = items.map((i: any) => i.id)
     await entity.delete(ids)
-  }
-}
-
-export const resetEntities = async (entities: any[]) => {
-  for (let i = 0; i < entities.length; i++) {
-    await resetEntity(entities[i])
   }
 }
 


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
Avoid using reset database from the database folder. Use a helper instead, that removes all data from the tables.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
