### PR TITLE
Fix: build for development and production links external modules properly

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -3,8 +3,9 @@ module.exports = {
   verbose: true,
   preset: 'ts-jest',
   collectCoverage: true,
-  collectCoverageFrom: ['src/**/*.ts', '!**/node_modules/**', '!src/seeds/**'],
+  collectCoverageFrom: ['src/**/*.ts', '!**/node_modules/**', '!src/seeds/**', '!build/**'],
   setupFiles: ['<rootDir>/test/testSetup.ts'],
+  modulePathIgnorePatterns: ['<rootDir>/build/'],
   moduleNameMapper: {
     '@/(.*)': '<rootDir>/src/$1',
     '@model/(.*)': '<rootDir>/src/graphql/model/$1',

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,11 +10,11 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "tsc --build --clean",
-    "start": "node build/src/index.js",
-    "dev": "nodemon -w src --ext ts --exec ts-node src/index.ts",
+    "start": "TZ=UTC TS_NODE_BASEURL=./build node -r tsconfig-paths/register build/src/index.js",
+    "dev": "TZ=UTC nodemon -w src --ext ts --exec ts-node -r tsconfig-paths/register src/index.ts",
     "lint": "eslint --max-warnings=0 --ext .js,.ts .",
     "test": "TZ=UTC NODE_ENV=development jest --runInBand --coverage --forceExit --detectOpenHandles",
-    "seed": "TZ=UTC ts-node src/seeds/index.ts"
+    "seed": "TZ=UTC ts-node -r tsconfig-paths/register src/seeds/index.ts"
   },
   "dependencies": {
     "@types/jest": "^27.0.2",
@@ -32,7 +32,6 @@
     "jest": "^27.2.4",
     "jsonwebtoken": "^8.5.1",
     "lodash.clonedeep": "^4.5.0",
-    "module-alias": "^2.2.2",
     "mysql2": "^2.3.0",
     "nodemailer": "^6.6.5",
     "random-bigint": "^0.0.1",
@@ -60,15 +59,7 @@
     "nodemon": "^2.0.7",
     "prettier": "^2.3.1",
     "ts-node": "^10.0.0",
+    "tsconfig-paths": "^3.14.0",
     "typescript": "^4.3.4"
-  },
-  "_moduleAliases": {
-    "@": "./build/src",
-    "@arg": "./build/src/graphql/arg",
-    "@dbTools": "../database/build/src",
-    "@entity": "../database/build/entity",
-    "@enum": "./build/src/graphql/enum",
-    "@model": "./build/src/graphql/model",
-    "@repository": "./build/src/typeorm/repository"
   }
 }

--- a/backend/src/server/createServer.ts
+++ b/backend/src/server/createServer.ts
@@ -1,5 +1,4 @@
 import 'reflect-metadata'
-import 'module-alias/register'
 
 import { ApolloServer } from 'apollo-server-express'
 import express, { Express } from 'express'

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -81,7 +81,7 @@
   },
   "references": [
     {
-      "path": "./../database/tsconfig.json",
+      "path": "../database/tsconfig.json",
       // add 'prepend' if you want to include the referenced project in your output file
       // "prepend": true
     }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -45,16 +45,17 @@
 
     /* Module Resolution Options */
     // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
+    "baseUrl": ".",                                 /* Base directory to resolve non-absolute module names. */
     "paths": {                                      /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-      "@/*": ["./src/*"],
-      "@arg/*": ["./src/graphql/arg/*"],
-      "@dbTools/*": ["../database/src/*"],
-      "@entity/*": ["../database/entity/*"],
-      "@enum/*": ["./src/graphql/enum/*"],
-      "@model/*": ["./src/graphql/model/*"],
-      "@repository/*": ["./src/typeorm/repository/*"],
-      "@test/*": ["./test/*"]
+      "@/*": ["src/*"],
+      "@arg/*": ["src/graphql/arg/*"],
+      "@enum/*": ["src/graphql/enum/*"],
+      "@model/*": ["src/graphql/model/*"],
+      "@repository/*": ["src/typeorm/repository/*"],
+      "@test/*": ["test/*"],
+      /* external */
+      "@dbTools/*": ["../database/src/*", "../../database/build/src/*"],
+      "@entity/*": ["../database/entity/*", "../../database/build/entity/*"]
     },
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
@@ -80,9 +81,9 @@
   },
   "references": [
     {
-      "path": "../database/tsconfig.json",
+      "path": "./../database/tsconfig.json",
       // add 'prepend' if you want to include the referenced project in your output file
-      // "prepend": true,
+      // "prepend": true
     }
   ]
 }

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -4102,11 +4102,6 @@ minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-module-alias@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.2.tgz#151cdcecc24e25739ff0aa6e51e1c5716974c0e0"
-  integrity sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -5236,6 +5231,16 @@ tsconfig-paths@^3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz#954c1fe973da6339c78e06b03ce2e48810b65f36"
   integrity sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
+
+tsconfig-paths@^3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.0.tgz#4fcc48f9ccea8826c41b9ca093479de7f5018976"
+  integrity sha512-cg/1jAZoL57R39+wiw4u/SCC6Ic9Q5NqjBOb+9xISedOYurfog9ZNmKJSxAnb2m/5Bq4lE9lhUcau33Ml8DM0g==
   dependencies:
     "@types/json5" "^0.0.29"
     json5 "^1.0.1"


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

- use tsconfig-paths package to resolve paths
- link build and src paths for the external database package
- some timezone stuff
- fix jest when `build/` folder is present 

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None

### How 2 Test

1. For me running `yarn build` on backend produces `build/`-folders in `backend/` and `database/`
2. Running `yarn dev` in `backend/` has the server properly started
3. Running `yarn start` in `backend/` has the server properly started

Is this fixing your issue @Mogge ?