### PR TITLE
1729 load spinner if pending balance

### DIFF
--- a/frontend/src/components/GddTransactionList.vue
+++ b/frontend/src/components/GddTransactionList.vue
@@ -3,12 +3,14 @@
     <div class="list-group">
       <div v-if="!transactions" class="test-no-transactionlist text-right">
         <b-icon icon="exclamation-triangle" class="mr-2" variant="danger"></b-icon>
+        null nix da
         <small>
           {{ $t('error.no-transactionlist') }}
         </small>
       </div>
       <div v-if="transactionCount < 0" class="test-empty-transactionlist text-right">
         <b-icon icon="exclamation-triangle" class="mr-2" variant="danger"></b-icon>
+        nix da
         <small>{{ $t('error.empty-transactionlist') }}</small>
       </div>
 
@@ -70,7 +72,9 @@
       :total-rows="transactionCount"
     ></pagination-buttons>
     <div v-if="transactionCount <= 0" class="mt-4 text-center">
-      <span>{{ $t('transaction.nullTransactions') }}</span>
+     
+       <b-icon v-if="pending" icon="three-dots" animation="cylon"></b-icon>
+      <div v-else>{{ $t('transaction.nullTransactions') }}</div>
     </div>
   </div>
 </template>
@@ -108,6 +112,7 @@ export default {
     transactionCount: { type: Number, default: 0 },
     transactionLinkCount: { type: Number, default: 0 },
     showPagination: { type: Boolean, default: false },
+    pending: { type: Boolean },
   },
   methods: {
     updateTransactions() {

--- a/frontend/src/components/GddTransactionList.vue
+++ b/frontend/src/components/GddTransactionList.vue
@@ -3,14 +3,12 @@
     <div class="list-group">
       <div v-if="!transactions" class="test-no-transactionlist text-right">
         <b-icon icon="exclamation-triangle" class="mr-2" variant="danger"></b-icon>
-        null nix da
         <small>
           {{ $t('error.no-transactionlist') }}
         </small>
       </div>
       <div v-if="transactionCount < 0" class="test-empty-transactionlist text-right">
         <b-icon icon="exclamation-triangle" class="mr-2" variant="danger"></b-icon>
-        nix da
         <small>{{ $t('error.empty-transactionlist') }}</small>
       </div>
 

--- a/frontend/src/components/GddTransactionList.vue
+++ b/frontend/src/components/GddTransactionList.vue
@@ -70,8 +70,7 @@
       :total-rows="transactionCount"
     ></pagination-buttons>
     <div v-if="transactionCount <= 0" class="mt-4 text-center">
-     
-       <b-icon v-if="pending" icon="three-dots" animation="cylon"></b-icon>
+      <b-icon v-if="pending" icon="three-dots" animation="cylon"></b-icon>
       <div v-else>{{ $t('transaction.nullTransactions') }}</div>
     </div>
   </div>

--- a/frontend/src/components/Menu/Navbar.vue
+++ b/frontend/src/components/Menu/Navbar.vue
@@ -10,7 +10,10 @@
       </div>
 
       <b-navbar-nav class="ml-auto" is-nav>
-        <b-nav-item>{{ pending ? $t('em-dash') : balance | amount }} {{ $t('GDD') }}</b-nav-item>
+        <b-nav-item>
+          <b-icon v-if="pending" icon="three-dots" animation="cylon"></b-icon>
+          <div v-else>{{ pending ? $t('em-dash') : balance | amount }} {{ $t('GDD') }}</div>
+        </b-nav-item>
         <b-nav-item to="/profile" right class="d-none d-sm-none d-md-none d-lg-flex shadow-lg">
           <small>
             {{ $store.state.firstName }} {{ $store.state.lastName }}

--- a/frontend/src/components/Status.spec.js
+++ b/frontend/src/components/Status.spec.js
@@ -26,8 +26,8 @@ describe('Status', () => {
     })
 
     describe('balance is pending', () => {
-      it('it displays an en-dash', () => {
-        expect(wrapper.find('div.gdd-status-div').text()).toEqual('em-dash GDD')
+      it('it displays an animation icon test-pending-icon', () => {
+        expect(wrapper.find('.test-pending-icon').exists()).toBe(true)
       })
     })
 
@@ -36,6 +36,9 @@ describe('Status', () => {
         wrapper.setProps({
           pending: false,
         })
+      })
+      it('it no displays an animation icon test-pending-icon', () => {
+        expect(wrapper.find('.test-pending-icon').exists()).toBe(false)
       })
 
       it('it displays the ammount of GDD', () => {

--- a/frontend/src/components/Status.spec.js
+++ b/frontend/src/components/Status.spec.js
@@ -26,7 +26,7 @@ describe('Status', () => {
     })
 
     describe('balance is pending', () => {
-      it('it displays an animation icon test-pending-icon', () => {
+      it('displays an animation icon test-pending-icon', () => {
         expect(wrapper.find('.test-pending-icon').exists()).toBe(true)
       })
     })

--- a/frontend/src/components/Status.spec.js
+++ b/frontend/src/components/Status.spec.js
@@ -37,7 +37,8 @@ describe('Status', () => {
           pending: false,
         })
       })
-      it('it no displays an animation icon test-pending-icon', () => {
+
+      it('does not display an animation icon test-pending-icon', () => {
         expect(wrapper.find('.test-pending-icon').exists()).toBe(false)
       })
 

--- a/frontend/src/components/Status.vue
+++ b/frontend/src/components/Status.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="gdd-status">
     <div class="p-0 gdd-status-div">
-      {{ pending || balance === null ? $t('em-dash') : $n(balance, 'decimal') }} {{ statusText }}
+      <b-icon v-if="pending" icon="three-dots" animation="cylon"></b-icon>
+      <div v-else> {{ pending || balance === null ? $t('em-dash') : $n(balance, 'decimal') }} {{ statusText }}</div>
     </div>
   </div>
 </template>

--- a/frontend/src/components/Status.vue
+++ b/frontend/src/components/Status.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="gdd-status">
     <div class="p-0 gdd-status-div">
-      <b-icon v-if="pending" icon="three-dots" animation="cylon"></b-icon>
+      <b-icon v-if="pending" icon="three-dots" animation="cylon" class="test-pending-icon"></b-icon>
       <div v-else>
         {{ pending || balance === null ? $t('em-dash') : $n(balance, 'decimal') }} {{ statusText }}
       </div>

--- a/frontend/src/components/Status.vue
+++ b/frontend/src/components/Status.vue
@@ -2,7 +2,9 @@
   <div class="gdd-status">
     <div class="p-0 gdd-status-div">
       <b-icon v-if="pending" icon="three-dots" animation="cylon"></b-icon>
-      <div v-else> {{ pending || balance === null ? $t('em-dash') : $n(balance, 'decimal') }} {{ statusText }}</div>
+      <div v-else>
+        {{ pending || balance === null ? $t('em-dash') : $n(balance, 'decimal') }} {{ statusText }}
+      </div>
     </div>
   </div>
 </template>

--- a/frontend/src/pages/Overview.vue
+++ b/frontend/src/pages/Overview.vue
@@ -21,6 +21,7 @@
         :decayStartBlock="decayStartBlock"
         :transaction-count="transactionCount"
         :transactionLinkCount="transactionLinkCount"
+        :pending="pending"
         @update-transactions="updateTransactions"
         v-on="$listeners"
       />


### PR DESCRIPTION
## 🍰 Pullrequest
an animated icon is displayed if no balance has been loaded yet. this affects the balance in the navbar, the balnaceim status and the start text in the overview. 

### Issues
- fixes #1729 

https://user-images.githubusercontent.com/1324583/161424839-b5d56ee9-c204-4708-abc5-11c0a8396217.mp4


