### PR TITLE
add insert shadow in summary links transaction type

### DIFF
--- a/frontend/src/assets/scss/gradido.scss
+++ b/frontend/src/assets/scss/gradido.scss
@@ -168,6 +168,10 @@ a,
   background-color: #ebebeba3 !important;
 }
 
+.gradido-shadow-inset {
+  box-shadow: inset 0 0 0.3em rgb(241, 187, 187);
+}
+
 .gradido-max-width {
   width: 100%;
 }

--- a/frontend/src/components/Transactions/TransactionLinkSummary.vue
+++ b/frontend/src/components/Transactions/TransactionLinkSummary.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="transaction-slot-link">
+  <div class="transaction-slot-link gradido-shadow-inset">
     <div>
       <div @click="visible = !visible">
         <!-- Collaps Icon  -->


### PR DESCRIPTION
## 🍰 Pullrequest
`.gradido-shadow-inset {
  box-shadow: inset 0 0 0.3em rgb(241, 187, 187);
}`
a shadow for transactio type summary-links

### Issues
- fixes #1753 

![FireShot Capture 1093 -  - localhost](https://user-images.githubusercontent.com/1324583/162613295-cba5043e-52d0-41f3-9e89-945521283380.png)

