### PR TITLE
[WIP] 1759 integrate the text for the redemption link in the meta preview

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
     "vue-i18n": "^8.22.4",
     "vue-jest": "^3.0.7",
     "vue-loading-overlay": "^3.4.2",
+    "vue-meta": "^2.4.0",
     "vue-moment": "^4.1.0",
     "vue-qrcode": "^0.3.5",
     "vue-qrcode-reader": "^2.3.16",

--- a/frontend/src/pages/TransactionLink.vue
+++ b/frontend/src/pages/TransactionLink.vue
@@ -33,6 +33,10 @@ import { redeemTransactionLink } from '@/graphql/mutations'
 
 export default {
   name: 'TransactionLink',
+  metaInfo: {
+    title: 'GDD einloesen',
+    titleTemplate: `%s | this.memo`,
+  },
   components: {
     TransactionLinkItem,
     RedeemLoggedOut,

--- a/frontend/src/plugins/dashboard-plugin.js
+++ b/frontend/src/plugins/dashboard-plugin.js
@@ -18,6 +18,8 @@ import 'vue-loading-overlay/dist/vue-loading.css'
 
 import VueApollo from 'vue-apollo'
 
+import VueMeta from 'vue-meta'
+
 export default {
   install(Vue) {
     Vue.use(GlobalComponents)
@@ -29,5 +31,9 @@ export default {
     Vue.use(FlatPickr)
     Vue.use(Loading)
     Vue.use(VueApollo)
+    Vue.use(VueMeta, {
+      // optional pluginOptions
+      refreshOnceOnNavigation: true,
+    })
   },
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -14602,6 +14602,13 @@ vue-loading-overlay@^3.4.2:
   resolved "https://registry.yarnpkg.com/vue-loading-overlay/-/vue-loading-overlay-3.4.2.tgz#34792a83218df1d35dff50121ce9fac2114f1c38"
   integrity sha512-xcB+NPjl76eA0uggm707x3ZFgrNosZXpynHipyS3K+rrK1NztOV49R1LY+/4ij5W1KYANp7eRI2EIHrxCpmWAw==
 
+vue-meta@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/vue-meta/-/vue-meta-2.4.0.tgz#a419fb4b4135ce965dab32ec641d1989c2ee4845"
+  integrity sha512-XEeZUmlVeODclAjCNpWDnjgw+t3WA6gdzs6ENoIAgwO1J1d5p1tezDhtteLUFwcaQaTtayRrsx7GL6oXp/m2Jw==
+  dependencies:
+    deepmerge "^4.2.2"
+
 vue-moment@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/vue-moment/-/vue-moment-4.1.0.tgz#092a8ff723a96c6f85a0a8e23ad30f0bf320f3b0"


### PR DESCRIPTION
## 🍰 Pullrequest
i have included the vue-meta package to dynamically change meta information about certain pages in the wallet in the future. the page that is accessed via a redeem link should offer the meta information that comes from the link. 

this is in WIP and still needs deep changes and more understanding. e.g. it would be possible to adapt this on the server side. which i would prefer. 

### Issues
- fixes #1759 

![Bildschirmfoto von 2022-04-11 08-03-24](https://user-images.githubusercontent.com/1324583/162675647-beb47d2f-f079-48f7-9784-2e7ec095f6e8.png)

