### PR TITLE
change config DECAY_START_TIME in UTC  0000

### DIFF
--- a/frontend/src/config/index.js
+++ b/frontend/src/config/index.js
@@ -5,7 +5,7 @@
 const pkg = require('../../package')
 
 const constants = {
-  DECAY_START_TIME: new Date('2021-05-13 17:46:31'), // GMT+0
+  DECAY_START_TIME: new Date('2021-05-13 17:46:31-0000'), // GMT+0
   CONFIG_VERSION: {
     DEFAULT: 'DEFAULT',
     EXPECTED: 'v1.2022-03-18',


### PR DESCRIPTION
## 🍰 Pullrequest
The date for the decay start block was set to UTC 0000 so that no time offset occurs and the date can be recognised cleanly so that the startDecayBlock can be found and displayed. 


### Issues
- fixes #1805 