### PR TITLE
fix: Round Decay with Tranasction Links

### DIFF
--- a/backend/src/util/virtualTransactions.ts
+++ b/backend/src/util/virtualTransactions.ts
@@ -70,6 +70,7 @@ const virtualDecayTransaction = (
     typeId: TransactionTypeId.DECAY,
     amount: decay.decay ? decay.roundedDecay : new Decimal(0),
     balance: decay.balance
+      .toDecimalPlaces(2, Decimal.ROUND_DOWN)
       .minus(holdAvailabeAmount.toString())
       .toDecimalPlaces(2, Decimal.ROUND_DOWN),
     balanceDate: time,


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
Round down the balance before subtracting the hold available amount of transaction links in virtual decay transaction.

### Issues
- fixes #1831 (I hope)


### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
