### PR TITLE
feat: Do not log IntrospectionQuery from Query Browser

### DIFF
--- a/backend/src/server/plugins.ts
+++ b/backend/src/server/plugins.ts
@@ -31,20 +31,24 @@ const filterVariables = (variables: any) => {
 const logPlugin = {
   requestDidStart(requestContext: any) {
     const { logger } = requestContext
-    const { query, mutation, variables } = requestContext.request
-    logger.info(`Request:
+    const { query, mutation, variables, operationName } = requestContext.request
+    if (operationName !== 'IntrospectionQuery') {
+      logger.info(`Request:
 ${mutation || query}variables: ${JSON.stringify(filterVariables(variables), null, 2)}`)
+    }
     return {
       willSendResponse(requestContext: any) {
-        if (requestContext.context.user) logger.info(`User ID: ${requestContext.context.user.id}`)
-        if (requestContext.response.data) {
-          logger.info('Response Success!')
-          logger.trace(`Response-Data:
+        if (operationName !== 'IntrospectionQuery') {
+          if (requestContext.context.user) logger.info(`User ID: ${requestContext.context.user.id}`)
+          if (requestContext.response.data) {
+            logger.info('Response Success!')
+            logger.trace(`Response-Data:
 ${JSON.stringify(requestContext.response.data, null, 2)}`)
-        }
-        if (requestContext.response.errors)
-          logger.error(`Response-Errors:
+          }
+          if (requestContext.response.errors)
+            logger.error(`Response-Errors:
 ${JSON.stringify(requestContext.response.errors, null, 2)}`)
+        }
         return requestContext
       },
     }


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
When using the graphql query browser the log is polluted by IntrospectionQuery. Do not log this queries.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
