### PR TITLE
Enable copying the link, username, amount, and memo text after transaction link creation

### DIFF
--- a/frontend/src/components/ClipboardCopy.vue
+++ b/frontend/src/components/ClipboardCopy.vue
@@ -4,10 +4,10 @@
       <b-form-input :value="link" type="text" readonly></b-form-input>
       <b-input-group-append>
         <b-button size="sm" text="Button" variant="primary" @click="copyLinkWithText">
-          {{ $t('gdd_per_link.copy-with-text') }}
+          {{ $t('gdd_per_link.copy-link-with-text') }}
         </b-button>
         <b-button size="sm" text="Button" variant="primary" @click="CopyLink">
-          {{ $t('gdd_per_link.copy') }}
+          {{ $t('gdd_per_link.copy-link') }}
         </b-button>
         <b-button variant="primary" class="text-light" @click="$emit('show-qr-code-button')">
           <b-img src="img/svg/qr-code.svg" width="19" class="svg"></b-img>

--- a/frontend/src/components/ClipboardCopy.vue
+++ b/frontend/src/components/ClipboardCopy.vue
@@ -3,6 +3,9 @@
     <b-input-group v-if="canCopyLink" size="lg" class="mb-3" prepend="Link">
       <b-form-input :value="link" type="text" readonly></b-form-input>
       <b-input-group-append>
+        <b-button size="sm" text="Button" variant="primary" @click="copyLinkWithText">
+          {{ $t('gdd_per_link.copy-with-text') }}
+        </b-button>
         <b-button size="sm" text="Button" variant="primary" @click="CopyLink">
           {{ $t('gdd_per_link.copy') }}
         </b-button>
@@ -22,6 +25,8 @@ export default {
   name: 'ClipboardCopy',
   props: {
     link: { type: String, required: true },
+    amount: { type: Number, required: true },
+    memo: { type: String, required: true },
   },
   data() {
     return {
@@ -34,6 +39,21 @@ export default {
         .writeText(this.link)
         .then(() => {
           this.toastSuccess(this.$t('gdd_per_link.link-copied'))
+        })
+        .catch(() => {
+          this.canCopyLink = false
+          this.toastError(this.$t('gdd_per_link.not-copied'))
+        })
+    },
+    copyLinkWithText() {
+      navigator.clipboard
+        .writeText(
+          `${this.link}
+${this.$store.state.firstName} ${this.$t('transaction-link.send_you')} ${this.amount} Gradido.
+"${this.memo}"`,
+        )
+        .then(() => {
+          this.toastSuccess(this.$t('gdd_per_link.link-and-text-copied'))
         })
         .catch(() => {
           this.canCopyLink = false

--- a/frontend/src/components/GddSend/TransactionResultLink.vue
+++ b/frontend/src/components/GddSend/TransactionResultLink.vue
@@ -3,7 +3,12 @@
     <b-col>
       <b-card class="p-0 gradido-custom-background">
         <div class="h3 mb-4">{{ $t('gdd_per_link.created') }}</div>
-        <clipboard-copy :link="link" @show-qr-code-button="showQrCodeButton" />
+        <clipboard-copy
+          :link="link"
+          :amount="amount"
+          :memo="memo"
+          @show-qr-code-button="showQrCodeButton"
+        ></clipboard-copy>
 
         <div class="text-center">
           <figure-qr-code v-if="showQrcode" :link="link" />
@@ -27,10 +32,9 @@ export default {
     FigureQrCode,
   },
   props: {
-    link: {
-      type: String,
-      required: true,
-    },
+    link: { type: String, required: true },
+    amount: { type: Number, required: true },
+    memo: { type: String, required: true },
   },
   data() {
     return {

--- a/frontend/src/components/TransactionLinks/TransactionLink.vue
+++ b/frontend/src/components/TransactionLinks/TransactionLink.vue
@@ -20,7 +20,7 @@
 
               <b-dropdown-item v-if="validLink" class="test-copy-link" @click="copy">
                 <b-icon icon="clipboard"></b-icon>
-                {{ $t('gdd_per_link.copy') }}
+                {{ $t('gdd_per_link.copy-link') }}
               </b-dropdown-item>
               <b-dropdown-item
                 v-if="validLink"
@@ -28,7 +28,7 @@
                 @click="copyLinkWithText()"
               >
                 <b-icon icon="clipboard-plus"></b-icon>
-                {{ $t('gdd_per_link.copy-with-text') }}
+                {{ $t('gdd_per_link.copy-link-with-text') }}
               </b-dropdown-item>
               <b-dropdown-item
                 v-if="validLink"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -150,7 +150,6 @@
   "GDD": "GDD",
   "gdd_per_link": {
     "choose-amount": "Wähle einen Betrag aus, welchen du per Link versenden möchtest. Du kannst auch noch eine Nachricht eintragen. Beim Klick „Jetzt generieren“ wird ein Link erstellt, den du versenden kannst.",
-    "copy": "kopieren",
     "copy-link": "Link kopieren",
     "copy-link-with-text": "Link und Text kopieren",
     "created": "Der Link wurde erstellt!",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -151,7 +151,8 @@
   "gdd_per_link": {
     "choose-amount": "Wähle einen Betrag aus, welchen du per Link versenden möchtest. Du kannst auch noch eine Nachricht eintragen. Beim Klick „Jetzt generieren“ wird ein Link erstellt, den du versenden kannst.",
     "copy": "kopieren",
-    "copy-with-text": "Link und Text kopieren",
+    "copy-link": "Link kopieren",
+    "copy-link-with-text": "Link und Text kopieren",
     "created": "Der Link wurde erstellt!",
     "credit-your-gradido": "Damit die Gradido gutgeschrieben werden können, klicke auf den Link!",
     "decay-14-day": "Vergänglichkeit für 14 Tage",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -12,7 +12,6 @@
       "hasAccount": "You already have an account?",
       "hereLogin": "Log in here",
       "learnMore": "Learn more …",
-
       "oneDignity": "We gift to each other and give thanks with Gradido.",
       "oneDonation": "You are a gift for the community. 1000 thanks because you are with us.",
       "oneGratitude": "For each other, for all people, for nature."
@@ -151,7 +150,6 @@
   "GDD": "GDD",
   "gdd_per_link": {
     "choose-amount": "Select an amount that you would like to send via link. You can also enter a message. Click 'Generate now' to create a link that you can share.",
-    "copy": "copy",
     "copy-link": "Copy link",
     "copy-link-with-text": "Copy link and text",
     "created": "Link was created!",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -12,6 +12,7 @@
       "hasAccount": "You already have an account?",
       "hereLogin": "Log in here",
       "learnMore": "Learn more …",
+
       "oneDignity": "We gift to each other and give thanks with Gradido.",
       "oneDonation": "You are a gift for the community. 1000 thanks because you are with us.",
       "oneGratitude": "For each other, for all people, for nature."
@@ -151,7 +152,8 @@
   "gdd_per_link": {
     "choose-amount": "Select an amount that you would like to send via link. You can also enter a message. Click 'Generate now' to create a link that you can share.",
     "copy": "copy",
-    "copy-with-text": "Copy link and text",
+    "copy-link": "Copy link",
+    "copy-link-with-text": "Copy link and text",
     "created": "Link was created!",
     "credit-your-gradido": "For the Gradido to be credited, click on the link!",
     "decay-14-day": "Decay for 14 days",

--- a/frontend/src/pages/Send.spec.js
+++ b/frontend/src/pages/Send.spec.js
@@ -20,6 +20,9 @@ describe('Send', () => {
     balance: 123.45,
     GdtBalance: 1234.56,
     pending: true,
+    amount: '15',
+    link: 'http://localhost/redeem/0123456789',
+    memo: 'Quis auctor elit sed vulputate mi sit amet mauris commodo quis imperdiet.',
   }
 
   const mocks = {
@@ -28,6 +31,7 @@ describe('Send', () => {
     $store: {
       state: {
         email: 'sender@example.org',
+        firstName: 'Testy',
       },
     },
     $apollo: {
@@ -228,21 +232,26 @@ describe('Send', () => {
             navigator.clipboard = navigatorClipboard
           })
 
-          describe('copy with success', () => {
+          describe('copy link with success', () => {
             beforeEach(async () => {
               navigatorClipboardMock.mockResolvedValue()
-              await wrapper.findAll('button').at(0).trigger('click')
+              await wrapper.findAll('button').at(1).trigger('click')
             })
 
+            it('should call clipboard.writeText', () => {
+              expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+                'http://localhost/redeem/0123456789',
+              )
+            })
             it('toasts success message', () => {
               expect(toastSuccessSpy).toBeCalledWith('gdd_per_link.link-copied')
             })
           })
 
-          describe('copy with error', () => {
+          describe('copy link with error', () => {
             beforeEach(async () => {
               navigatorClipboardMock.mockRejectedValue()
-              await wrapper.findAll('button').at(0).trigger('click')
+              await wrapper.findAll('button').at(1).trigger('click')
             })
 
             it('toasts error message', () => {
@@ -253,7 +262,7 @@ describe('Send', () => {
 
         describe('close button click', () => {
           beforeEach(async () => {
-            await wrapper.findAll('button').at(2).trigger('click')
+            await wrapper.findAll('button').at(3).trigger('click')
           })
 
           it('Shows the TransactionForm', () => {

--- a/frontend/src/pages/Send.spec.js
+++ b/frontend/src/pages/Send.spec.js
@@ -20,9 +20,6 @@ describe('Send', () => {
     balance: 123.45,
     GdtBalance: 1234.56,
     pending: true,
-    amount: '15',
-    link: 'http://localhost/redeem/0123456789',
-    memo: 'Quis auctor elit sed vulputate mi sit amet mauris commodo quis imperdiet.',
   }
 
   const mocks = {
@@ -252,6 +249,46 @@ describe('Send', () => {
             beforeEach(async () => {
               navigatorClipboardMock.mockRejectedValue()
               await wrapper.findAll('button').at(1).trigger('click')
+            })
+
+            it('toasts error message', () => {
+              expect(toastErrorSpy).toBeCalledWith('gdd_per_link.not-copied')
+            })
+          })
+        })
+
+        describe('copy link and text with success', () => {
+          const navigatorClipboard = navigator.clipboard
+          beforeAll(() => {
+            delete navigator.clipboard
+            navigator.clipboard = { writeText: navigatorClipboardMock }
+          })
+          afterAll(() => {
+            navigator.clipboard = navigatorClipboard
+          })
+
+          describe('copy link and text with success', () => {
+            beforeEach(async () => {
+              navigatorClipboardMock.mockResolvedValue()
+              await wrapper.findAll('button').at(0).trigger('click')
+            })
+
+            it('should call clipboard.writeText', () => {
+              expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+                'http://localhost/redeem/0123456789\n' +
+                  'Testy transaction-link.send_you 56.78 Gradido.\n' +
+                  '"Make the best of the link!"',
+              )
+            })
+            it('toasts success message', () => {
+              expect(toastSuccessSpy).toBeCalledWith('gdd_per_link.link-and-text-copied')
+            })
+          })
+
+          describe('copy link and text with error', () => {
+            beforeEach(async () => {
+              navigatorClipboardMock.mockRejectedValue()
+              await wrapper.findAll('button').at(0).trigger('click')
             })
 
             it('toasts error message', () => {

--- a/frontend/src/pages/Send.vue
+++ b/frontend/src/pages/Send.vue
@@ -41,7 +41,12 @@
           ></transaction-result-send-error>
         </template>
         <template #transactionResultLink>
-          <transaction-result-link :link="link" @on-reset="onReset"></transaction-result-link>
+          <transaction-result-link
+            :link="link"
+            :amount="amount"
+            :memo="memo"
+            @on-reset="onReset"
+          ></transaction-result-link>
         </template>
       </gdd-send>
       <hr />
@@ -145,6 +150,8 @@ export default {
             .then((result) => {
               this.$emit('set-tunneled-email', null)
               this.link = result.data.createTransactionLink.link
+              this.amount = this.transactionData.amount
+              this.memo = this.transactionData.memo
               this.transactionData = { ...EMPTY_TRANSACTION_DATA }
               this.currentTransactionStep = TRANSACTION_STEPS.transactionResultLink
               this.updateTransactions({})


### PR DESCRIPTION

## 🍰 Pullrequest
When sending Gradido via link, now the user can get the QR code, just copy the link to the clipboard, and copy the link, username, amount, and memo text by clicking a button.

![2077](https://user-images.githubusercontent.com/3883288/181215617-286e437d-6d1e-40b6-b385-4cd39cf0caf5.jpg)


### Issues
- fixes #2077


### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] none
