### PR TITLE
Remove member area from menu (desktop and mobile), when user has no elopage account

### DIFF
--- a/frontend/src/components/ContentFooter.spec.js
+++ b/frontend/src/components/ContentFooter.spec.js
@@ -97,24 +97,14 @@ describe('ContentFooter', () => {
         )
       })
 
-      it('has a link to the members area', () => {
-        expect(wrapper.findAll('a.nav-link').at(2).text()).toEqual('navigation.members_area')
-      })
-
-      it('links to the elopage', () => {
-        expect(wrapper.findAll('a.nav-link').at(2).attributes('href')).toEqual(
-          'https://elopage.com/s/gradido/sign_in?locale=en',
-        )
-      })
-
       it('links to the whitepaper', () => {
-        expect(wrapper.findAll('a.nav-link').at(3).attributes('href')).toEqual(
+        expect(wrapper.findAll('a.nav-link').at(2).attributes('href')).toEqual(
           'https://docs.google.com/document/d/1kcX1guOi6tDgnFHD9tf7fB_MneKTx-0nHJxzdN8ygNs/edit?usp=sharing',
         )
       })
 
       it('links to the support', () => {
-        expect(wrapper.findAll('a.nav-link').at(4).attributes('href')).toEqual(
+        expect(wrapper.findAll('a.nav-link').at(3).attributes('href')).toEqual(
           'https://gradido.net/en/contact/',
         )
       })
@@ -142,20 +132,14 @@ describe('ContentFooter', () => {
           )
         })
 
-        it('links to the German elopage when locale is de', () => {
-          expect(wrapper.findAll('a.nav-link').at(2).attributes('href')).toEqual(
-            'https://elopage.com/s/gradido/sign_in?locale=de',
-          )
-        })
-
         it('links to the German whitepaper when locale is de', () => {
-          expect(wrapper.findAll('a.nav-link').at(3).attributes('href')).toEqual(
+          expect(wrapper.findAll('a.nav-link').at(2).attributes('href')).toEqual(
             'https://docs.google.com/document/d/1jZp-DiiMPI9ZPNXmjsvOQ1BtnfDFfx8BX7CDmA8KKjY/edit?usp=sharing',
           )
         })
 
         it('links to the German support-page when locale is de', () => {
-          expect(wrapper.findAll('a.nav-link').at(4).attributes('href')).toEqual(
+          expect(wrapper.findAll('a.nav-link').at(3).attributes('href')).toEqual(
             'https://gradido.net/de/contact/',
           )
         })

--- a/frontend/src/components/ContentFooter.vue
+++ b/frontend/src/components/ContentFooter.vue
@@ -35,12 +35,6 @@
             {{ $t('footer.privacy_policy') }}
           </b-nav-item>
           <b-nav-item
-            :href="`https://elopage.com/s/gradido/sign_in?locale=${$i18n.locale}`"
-            target="_blank"
-          >
-            {{ $t('navigation.members_area') }}
-          </b-nav-item>
-          <b-nav-item
             :href="
               $i18n.locale === 'de'
                 ? 'https://docs.google.com/document/d/1jZp-DiiMPI9ZPNXmjsvOQ1BtnfDFfx8BX7CDmA8KKjY/edit?usp=sharing'

--- a/frontend/src/components/Menu/Navbar.spec.js
+++ b/frontend/src/components/Menu/Navbar.spec.js
@@ -17,7 +17,7 @@ const mocks = {
   $t: jest.fn((t) => t),
   $store: {
     state: {
-      hasElopage: false,
+      hasElopage: true,
       isAdmin: true,
     },
   },
@@ -39,7 +39,7 @@ describe('Navbar', () => {
       expect(wrapper.find('div.component-navbar').exists()).toBeTruthy()
     })
 
-    describe('navigation Navbar', () => {
+    describe('navigation Navbar (general elements)', () => {
       it('has .navbar-brand in the navbar', () => {
         expect(wrapper.find('.navbar-brand').exists()).toBeTruthy()
       })
@@ -66,7 +66,8 @@ describe('Navbar', () => {
       it('has first nav-item "navigation.profile" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(6).text()).toEqual('navigation.profile')
       })
-
+    })
+    describe('navigation Navbar (user has an elopage account)', () => {
       it('has a link to the members area', () => {
         expect(wrapper.findAll('.nav-item').at(7).text()).toContain('navigation.members_area')
         expect(wrapper.findAll('.nav-item').at(7).find('a').attributes('href')).toBe(
@@ -79,6 +80,18 @@ describe('Navbar', () => {
       })
       it('has first nav-item "navigation.logout" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(9).text()).toEqual('navigation.logout')
+      })
+    })
+    describe('navigation Navbar (user has no elopage account)', () => {
+      beforeAll(() => {
+        mocks.$store.state.hasElopage = false
+        wrapper = Wrapper()
+      })
+      it('has first nav-item "navigation.admin_area" in navbar', () => {
+        expect(wrapper.findAll('.nav-item').at(7).text()).toEqual('navigation.admin_area')
+      })
+      it('has first nav-item "navigation.logout" in navbar', () => {
+        expect(wrapper.findAll('.nav-item').at(8).text()).toEqual('navigation.logout')
       })
     })
   })

--- a/frontend/src/components/Menu/Navbar.spec.js
+++ b/frontend/src/components/Menu/Navbar.spec.js
@@ -43,9 +43,11 @@ describe('Navbar', () => {
       it('has .navbar-brand in the navbar', () => {
         expect(wrapper.find('.navbar-brand').exists()).toBeTruthy()
       })
+
       it('has b-navbar-toggle in the navbar', () => {
         expect(wrapper.find('.navbar-toggler').exists()).toBeTruthy()
       })
+
       it('has ten b-nav-item in the navbar', () => {
         expect(wrapper.findAll('.nav-item')).toHaveLength(10)
       })
@@ -57,16 +59,20 @@ describe('Navbar', () => {
       it('has first nav-item "navigation.overview" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(3).text()).toEqual('navigation.overview')
       })
+
       it('has first nav-item "navigation.send" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(4).text()).toEqual('navigation.send')
       })
+
       it('has first nav-item "navigation.transactions" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(5).text()).toEqual('navigation.transactions')
       })
+
       it('has first nav-item "navigation.profile" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(6).text()).toEqual('navigation.profile')
       })
     })
+
     describe('navigation Navbar (user has an elopage account)', () => {
       it('has a link to the members area', () => {
         expect(wrapper.findAll('.nav-item').at(7).text()).toContain('navigation.members_area')
@@ -78,23 +84,28 @@ describe('Navbar', () => {
       it('has first nav-item "navigation.admin_area" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(8).text()).toEqual('navigation.admin_area')
       })
+
       it('has first nav-item "navigation.logout" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(9).text()).toEqual('navigation.logout')
       })
     })
+
     describe('navigation Navbar (user has no elopage account)', () => {
       beforeAll(() => {
         mocks.$store.state.hasElopage = false
         wrapper = Wrapper()
       })
+
       it('has first nav-item "navigation.admin_area" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(7).text()).toEqual('navigation.admin_area')
       })
+
       it('has first nav-item "navigation.logout" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(8).text()).toEqual('navigation.logout')
       })
     })
   })
+
   describe('check watch visible true', () => {
     beforeEach(async () => {
       await wrapper.setProps({ visible: true })

--- a/frontend/src/components/Menu/Navbar.vue
+++ b/frontend/src/components/Menu/Navbar.vue
@@ -57,12 +57,9 @@
           {{ $t('navigation.profile') }}
         </b-nav-item>
         <br />
-        <b-nav-item :href="elopageUri" class="mb-3" target="_blank">
+        <b-nav-item v-if="$store.state.hasElopage" :href="elopageUri" class="mb-3" target="_blank">
           <b-icon icon="link45deg" aria-hidden="true"></b-icon>
           {{ $t('navigation.members_area') }}
-          <b-badge v-if="!$store.state.hasElopage" pill variant="danger">
-            {{ $t('math.exclaim') }}
-          </b-badge>
         </b-nav-item>
         <b-nav-item class="mb-3" v-if="$store.state.isAdmin" @click="$emit('admin')">
           <b-icon icon="shield-check" aria-hidden="true"></b-icon>

--- a/frontend/src/components/Menu/Navbar.vue
+++ b/frontend/src/components/Menu/Navbar.vue
@@ -60,6 +60,9 @@
         <b-nav-item v-if="$store.state.hasElopage" :href="elopageUri" class="mb-3" target="_blank">
           <b-icon icon="link45deg" aria-hidden="true"></b-icon>
           {{ $t('navigation.members_area') }}
+          <b-badge v-if="!$store.state.hasElopage" pill variant="danger">
+            {{ $t('math.exclaim') }}
+          </b-badge>
         </b-nav-item>
         <b-nav-item class="mb-3" v-if="$store.state.isAdmin" @click="$emit('admin')">
           <b-icon icon="shield-check" aria-hidden="true"></b-icon>

--- a/frontend/src/components/Menu/Sidebar.spec.js
+++ b/frontend/src/components/Menu/Sidebar.spec.js
@@ -31,11 +31,7 @@ describe('Sidebar', () => {
       expect(wrapper.find('div#component-sidebar').exists()).toBeTruthy()
     })
 
-    describe('navigation Navbar', () => {
-      it('has seven b-nav-item in the navbar', () => {
-        expect(wrapper.findAll('.nav-item')).toHaveLength(8)
-      })
-
+    describe('navigation Navbar (general elements)', () => {
       it('has first nav-item "navigation.overview" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(0).text()).toEqual('navigation.overview')
       })
@@ -55,7 +51,12 @@ describe('Sidebar', () => {
       it('has first nav-item "navigation.profile" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(4).text()).toEqual('navigation.profile')
       })
-
+    })
+    // ----
+    describe('navigation Navbar (user has an elopage account)', () => {
+      it('has seven b-nav-item in the navbar', () => {
+        expect(wrapper.findAll('.nav-item')).toHaveLength(8)
+      })
       it('has a link to the members area', () => {
         expect(wrapper.findAll('.nav-item').at(5).text()).toEqual('navigation.members_area')
         expect(wrapper.findAll('.nav-item').at(5).find('a').attributes('href')).toBe('#')
@@ -67,6 +68,21 @@ describe('Sidebar', () => {
 
       it('has first nav-item "navigation.logout" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(7).text()).toEqual('navigation.logout')
+      })
+    })
+    describe('navigation Navbar (user has no elopage account)', () => {
+      beforeAll(() => {
+        mocks.$store.state.hasElopage = false
+        wrapper = Wrapper()
+      })
+      it('has six b-nav-item in the navbar', () => {
+        expect(wrapper.findAll('.nav-item')).toHaveLength(7)
+      })
+      it('has first nav-item "navigation.admin_area" in navbar', () => {
+        expect(wrapper.findAll('.nav-item').at(5).text()).toEqual('navigation.admin_area')
+      })
+      it('has first nav-item "navigation.logout" in navbar', () => {
+        expect(wrapper.findAll('.nav-item').at(6).text()).toEqual('navigation.logout')
       })
     })
   })

--- a/frontend/src/components/Menu/Sidebar.spec.js
+++ b/frontend/src/components/Menu/Sidebar.spec.js
@@ -55,7 +55,7 @@ describe('Sidebar', () => {
     })
 
     describe('navigation Navbar (user has an elopage account)', () => {
-      it('has seven b-nav-item in the navbar', () => {
+      it('has eight b-nav-item in the navbar', () => {
         expect(wrapper.findAll('.nav-item')).toHaveLength(8)
       })
 
@@ -79,7 +79,7 @@ describe('Sidebar', () => {
         wrapper = Wrapper()
       })
 
-      it('has six b-nav-item in the navbar', () => {
+      it('has seven b-nav-item in the navbar', () => {
         expect(wrapper.findAll('.nav-item')).toHaveLength(7)
       })
 

--- a/frontend/src/components/Menu/Sidebar.spec.js
+++ b/frontend/src/components/Menu/Sidebar.spec.js
@@ -27,6 +27,7 @@ describe('Sidebar', () => {
     beforeEach(() => {
       wrapper = Wrapper()
     })
+
     it('renders the component', () => {
       expect(wrapper.find('div#component-sidebar').exists()).toBeTruthy()
     })
@@ -52,11 +53,12 @@ describe('Sidebar', () => {
         expect(wrapper.findAll('.nav-item').at(4).text()).toEqual('navigation.profile')
       })
     })
-    // ----
+
     describe('navigation Navbar (user has an elopage account)', () => {
       it('has seven b-nav-item in the navbar', () => {
         expect(wrapper.findAll('.nav-item')).toHaveLength(8)
       })
+
       it('has a link to the members area', () => {
         expect(wrapper.findAll('.nav-item').at(5).text()).toEqual('navigation.members_area')
         expect(wrapper.findAll('.nav-item').at(5).find('a').attributes('href')).toBe('#')
@@ -70,17 +72,21 @@ describe('Sidebar', () => {
         expect(wrapper.findAll('.nav-item').at(7).text()).toEqual('navigation.logout')
       })
     })
+
     describe('navigation Navbar (user has no elopage account)', () => {
       beforeAll(() => {
         mocks.$store.state.hasElopage = false
         wrapper = Wrapper()
       })
+
       it('has six b-nav-item in the navbar', () => {
         expect(wrapper.findAll('.nav-item')).toHaveLength(7)
       })
+
       it('has first nav-item "navigation.admin_area" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(5).text()).toEqual('navigation.admin_area')
       })
+
       it('has first nav-item "navigation.logout" in navbar', () => {
         expect(wrapper.findAll('.nav-item').at(6).text()).toEqual('navigation.logout')
       })

--- a/frontend/src/components/Menu/Sidebar.vue
+++ b/frontend/src/components/Menu/Sidebar.vue
@@ -27,9 +27,17 @@
         </b-nav>
         <hr />
         <b-nav vertical class="w-100">
-          <b-nav-item v-if="$store.state.hasElopage" class="mb-3" :href="elopageUri" target="_blank">
+          <b-nav-item
+            v-if="$store.state.hasElopage"
+            class="mb-3"
+            :href="elopageUri"
+            target="_blank"
+          >
             <b-icon icon="link45deg" aria-hidden="true"></b-icon>
             {{ $t('navigation.members_area') }}
+            <b-badge v-if="!$store.state.hasElopage" pill variant="danger">
+              {{ $t('math.exclaim') }}
+            </b-badge>
           </b-nav-item>
           <b-nav-item class="mb-3" v-if="$store.state.isAdmin" @click="$emit('admin')">
             <b-icon icon="shield-check" aria-hidden="true"></b-icon>

--- a/frontend/src/components/Menu/Sidebar.vue
+++ b/frontend/src/components/Menu/Sidebar.vue
@@ -27,12 +27,9 @@
         </b-nav>
         <hr />
         <b-nav vertical class="w-100">
-          <b-nav-item class="mb-3" :href="elopageUri" target="_blank">
+          <b-nav-item v-if="$store.state.hasElopage" class="mb-3" :href="elopageUri" target="_blank">
             <b-icon icon="link45deg" aria-hidden="true"></b-icon>
             {{ $t('navigation.members_area') }}
-            <b-badge v-if="!$store.state.hasElopage" pill variant="danger">
-              {{ $t('math.exclaim') }}
-            </b-badge>
           </b-nav-item>
           <b-nav-item class="mb-3" v-if="$store.state.isAdmin" @click="$emit('admin')">
             <b-icon icon="shield-check" aria-hidden="true"></b-icon>


### PR DESCRIPTION
## 🍰 Pullrequest
The meber area entry is not displayed in the footer and not in the menu, if the user has no elopage account.

### Issues
- fixes #2094

### Todo
- [X] None
