### PR TITLE
fix: 🍰 isModerator on messages to switch the messages side in the messages overview

### DIFF
--- a/admin/src/components/ContributionMessages/slots/ContributionMessagesListItem.vue
+++ b/admin/src/components/ContributionMessages/slots/ContributionMessagesListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="contribution-messages-list-item">
-    <is-moderator v-if="isModerator" :message="message"></is-moderator>
+    <is-moderator v-if="message.isModerator" :message="message"></is-moderator>
     <is-not-moderator v-else :message="message"></is-not-moderator>
   </div>
 </template>
@@ -21,11 +21,6 @@ export default {
       default() {
         return {}
       },
-    },
-  },
-  computed: {
-    isModerator() {
-      return this.$store.state.moderator.id === this.message.userId
     },
   },
 }

--- a/admin/src/graphql/listContributionMessages.js
+++ b/admin/src/graphql/listContributionMessages.js
@@ -18,6 +18,7 @@ export const listContributionMessages = gql`
         userFirstName
         userLastName
         userId
+        isModerator
       }
     }
   }


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
As Moderator I want to see every message from moderators on the right side so we have a better overview of message from moderators and from users.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] Graphql call isModerator flag on messages
- [X] Switch the message side with the new flag isModerator on messages
