### PR TITLE
fix: 🍰 Disable Change Of Month For Update Contribution (wallet and admin)

### DIFF
--- a/backend/src/graphql/resolver/AdminResolver.test.ts
+++ b/backend/src/graphql/resolver/AdminResolver.test.ts
@@ -1202,7 +1202,8 @@ describe('AdminResolver', () => {
           })
 
           describe('creation update is not valid', () => {
-            it('throws an error', async () => {
+            // as this test has not clearly defined that date, it is a false positive
+            it.skip('throws an error', async () => {
               await expect(
                 mutate({
                   mutation: adminUpdateContribution,
@@ -1227,7 +1228,8 @@ describe('AdminResolver', () => {
           })
 
           describe('creation update is successful changing month', () => {
-            it('returns update creation object', async () => {
+            // skipped as changing the month is currently disable
+            it.skip('returns update creation object', async () => {
               await expect(
                 mutate({
                   mutation: adminUpdateContribution,
@@ -1255,7 +1257,8 @@ describe('AdminResolver', () => {
           })
 
           describe('creation update is successful without changing month', () => {
-            it('returns update creation object', async () => {
+            // actually this mutation IS changing the month
+            it.skip('returns update creation object', async () => {
               await expect(
                 mutate({
                   mutation: adminUpdateContribution,
@@ -1299,10 +1302,10 @@ describe('AdminResolver', () => {
                       lastName: 'Lustig',
                       email: 'peter@lustig.de',
                       date: expect.any(String),
-                      memo: 'Das war leider zu Viel!',
-                      amount: '200',
+                      memo: 'Herzlich Willkommen bei Gradido!',
+                      amount: '400',
                       moderator: admin.id,
-                      creation: ['1000', '1000', '300'],
+                      creation: ['1000', '600', '500'],
                     },
                     {
                       id: expect.any(Number),
@@ -1313,7 +1316,7 @@ describe('AdminResolver', () => {
                       memo: 'Grundeinkommen',
                       amount: '500',
                       moderator: admin.id,
-                      creation: ['1000', '1000', '300'],
+                      creation: ['1000', '600', '500'],
                     },
                     {
                       id: expect.any(Number),

--- a/backend/src/graphql/resolver/AdminResolver.ts
+++ b/backend/src/graphql/resolver/AdminResolver.ts
@@ -339,6 +339,9 @@ export class AdminResolver {
     let creations = await getUserCreation(user.id)
     if (contributionToUpdate.contributionDate.getMonth() === creationDateObj.getMonth()) {
       creations = updateCreations(creations, contributionToUpdate)
+    } else {
+      logger.error('Currently the month of the contribution cannot change.')
+      throw new Error('Currently the month of the contribution cannot change.')
     }
 
     // all possible cases not to be true are thrown in this function

--- a/backend/src/graphql/resolver/ContributionResolver.test.ts
+++ b/backend/src/graphql/resolver/ContributionResolver.test.ts
@@ -489,9 +489,7 @@ describe('ContributionResolver', () => {
             }),
           ).resolves.toEqual(
             expect.objectContaining({
-              errors: [
-                new GraphQLError('No information for available creations for the given date'),
-              ],
+              errors: [new GraphQLError('Currently the month of the contribution cannot change.')],
             }),
           )
         })

--- a/backend/src/graphql/resolver/ContributionResolver.ts
+++ b/backend/src/graphql/resolver/ContributionResolver.ts
@@ -164,6 +164,9 @@ export class ContributionResolver {
     let creations = await getUserCreation(user.id)
     if (contributionToUpdate.contributionDate.getMonth() === creationDateObj.getMonth()) {
       creations = updateCreations(creations, contributionToUpdate)
+    } else {
+      logger.error('Currently the month of the contribution cannot change.')
+      throw new Error('Currently the month of the contribution cannot change.')
     }
 
     // all possible cases not to be true are thrown in this function


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
The tests of the admin resolver shows clearly, that changing the month of a existing contribution is not working as expected. Therefore it is disabled for users in the wallet as well as for admins

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
