### PR TITLE
fix: Linked User Email in Transaction List

### DIFF
--- a/backend/src/graphql/resolver/TransactionResolver.ts
+++ b/backend/src/graphql/resolver/TransactionResolver.ts
@@ -6,7 +6,7 @@ import CONFIG from '@/config'
 
 import { Context, getUser } from '@/server/context'
 import { Resolver, Query, Args, Authorized, Ctx, Mutation } from 'type-graphql'
-import { getCustomRepository, getConnection } from '@dbTools/typeorm'
+import { getCustomRepository, getConnection, In } from '@dbTools/typeorm'
 
 import { sendTransactionReceivedEmail } from '@/mailer/sendTransactionReceivedEmail'
 
@@ -224,11 +224,11 @@ export class TransactionResolver {
     logger.debug(`involvedUserIds=${involvedUserIds}`)
 
     // We need to show the name for deleted users for old transactions
-    const involvedDbUsers = await dbUser
-      .createQueryBuilder()
-      .withDeleted()
-      .where('id IN (:...userIds)', { userIds: involvedUserIds })
-      .getMany()
+    const involvedDbUsers = await dbUser.find({
+      where: { id: In(involvedUserIds) },
+      withDeleted: true,
+      relations: ['emailContact'],
+    })
     const involvedUsers = involvedDbUsers.map((u) => new User(u))
     logger.debug(`involvedUsers=${involvedUsers}`)
 

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -37,15 +37,13 @@ export const transactionsQuery = gql`
         linkedUser {
           firstName
           lastName
+          email
         }
         decay {
           decay
           start
           end
           duration
-        }
-        linkedUser {
-          email
         }
         transactionLinkId
       }


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
Due to refactoring the email contact, the email of the linked user in the transaction list got lost. Here it is again

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
