### PR TITLE
fix: Include Deleted Email Contacts in User Search

### DIFF
--- a/backend/src/typeorm/repository/User.ts
+++ b/backend/src/typeorm/repository/User.ts
@@ -28,8 +28,8 @@ export class UserRepository extends Repository<DbUser> {
   ): Promise<[DbUser[], number]> {
     const query = this.createQueryBuilder('user')
       .select(select)
-      .leftJoinAndSelect('user.emailContact', 'emailContact')
       .withDeleted()
+      .leftJoinAndSelect('user.emailContact', 'emailContact')
       .where(
         new Brackets((qb) => {
           qb.where(


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
When searching for users in the admin interface that have a deleted email contact, an error is thrown. Include the deleted email contacts in the left join.

### Issues
- fixes #2280 


### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
