### PR TITLE
Github workflow: update actions to the current API version using Node v 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # FRONTEND ###############################################################
       ##########################################################################
@@ -24,7 +24,7 @@ jobs:
           docker build --target test -t "gradido/frontend:test" frontend/
           docker save "gradido/frontend:test" > /tmp/frontend.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-frontend-test
           path: /tmp/frontend.tar
@@ -41,7 +41,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # ADMIN INTERFACE ########################################################
       ##########################################################################
@@ -50,7 +50,7 @@ jobs:
           docker build --target test -t "gradido/admin:test" admin/ --build-arg NODE_ENV="test"
           docker save "gradido/admin:test" > /tmp/admin.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-admin-test
           path: /tmp/admin.tar
@@ -67,7 +67,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # BACKEND ################################################################
       ##########################################################################
@@ -76,7 +76,7 @@ jobs:
           docker build -f ./backend/Dockerfile --target test -t "gradido/backend:test" .
           docker save "gradido/backend:test" > /tmp/backend.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-backend-test
           path: /tmp/backend.tar
@@ -93,7 +93,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DATABASE UP ############################################################
       ##########################################################################
@@ -102,7 +102,7 @@ jobs:
           docker build --target test_up -t "gradido/database:test_up" database/
           docker save "gradido/database:test_up" > /tmp/database_up.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-database-test_up
           path: /tmp/database_up.tar
@@ -119,7 +119,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # BUILD MARIADB DOCKER IMAGE #############################################
       ##########################################################################
@@ -128,7 +128,7 @@ jobs:
           docker build --target mariadb_server -t "gradido/mariadb:test" -f ./mariadb/Dockerfile ./
           docker save "gradido/mariadb:test" > /tmp/mariadb.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-mariadb-test
           path: /tmp/mariadb.tar
@@ -145,7 +145,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # BUILD NGINX DOCKER IMAGE ###############################################
       ##########################################################################
@@ -154,7 +154,7 @@ jobs:
           docker build -t "gradido/nginx:test" nginx/
           docker save "gradido/nginx:test" > /tmp/nginx.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-nginx-test
           path: /tmp/nginx.tar
@@ -171,12 +171,12 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGE ##################################################
       ##########################################################################
       - name: Download Docker Image (Frontend)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-frontend-test
           path: /tmp
@@ -200,12 +200,12 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGE ##################################################
       ##########################################################################
       - name: Download Docker Image (Frontend)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-frontend-test
           path: /tmp
@@ -229,12 +229,12 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGE ##################################################
       ##########################################################################
       - name: Download Docker Image (Frontend)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-frontend-test
           path: /tmp
@@ -258,12 +258,12 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGE ##################################################
       ##########################################################################
       - name: Download Docker Image (Admin Interface)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-admin-test
           path: /tmp
@@ -287,12 +287,12 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGE ##################################################
       ##########################################################################
       - name: Download Docker Image (Admin Interface)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-admin-test
           path: /tmp
@@ -316,12 +316,12 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGE ##################################################
       ##########################################################################
       - name: Download Docker Image (Admin Interface)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-admin-test
           path: /tmp
@@ -345,12 +345,12 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGE ##################################################
       ##########################################################################
       - name: Download Docker Image (Backend)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-backend-test
           path: /tmp
@@ -374,12 +374,12 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGE ##################################################
       ##########################################################################
       - name: Download Docker Image (Backend)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-database-test_up
           path: /tmp
@@ -403,12 +403,12 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGES #################################################
       ##########################################################################
       - name: Download Docker Image (Frontend)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-frontend-test
           path: /tmp
@@ -453,12 +453,12 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGES #################################################
       ##########################################################################
       - name: Download Docker Image (Admin Interface)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-admin-test
           path: /tmp
@@ -495,12 +495,12 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGES #################################################
       ##########################################################################
       - name: Download Docker Image (Mariadb)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-mariadb-test
           path: /tmp
@@ -543,7 +543,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOCKER COMPOSE DATABASE UP + RESET #####################################
       ##########################################################################


### PR DESCRIPTION
## 🍰 Pullrequest

Our Github workflows get the warning

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/upload-artifact, actions/checkout

related to the actions `actions/checkout@v2` and `actions/upload-artifact@v2` utilized in our workflows.

These are easy fixed by using their API version 3.

