### PR TITLE
fix(frontend): close all open collapse by change tabs in community

### DIFF
--- a/frontend/src/components/Contributions/ContributionList.vue
+++ b/frontend/src/components/Contributions/ContributionList.vue
@@ -3,6 +3,7 @@
     <div class="list-group" v-for="item in items" :key="item.id">
       <contribution-list-item
         v-bind="item"
+        @closeAllOpenCollapse="$emit('closeAllOpenCollapse')"
         :contributionId="item.id"
         :allContribution="allContribution"
         @update-contribution-form="updateContributionForm"

--- a/frontend/src/components/Contributions/ContributionListItem.spec.js
+++ b/frontend/src/components/Contributions/ContributionListItem.spec.js
@@ -132,6 +132,16 @@ describe('ContributionListItem', () => {
           expect(wrapper.emitted('delete-contribution')).toBeFalsy()
         })
       })
+
+      describe('updateState', () => {
+        beforeEach(async () => {
+          await wrapper.vm.updateState()
+        })
+
+        it('emit update-state', () => {
+          expect(wrapper.vm.$emit('update-state')).toBeTruthy()
+        })
+      })
     })
   })
 })

--- a/frontend/src/components/Contributions/ContributionListItem.vue
+++ b/frontend/src/components/Contributions/ContributionListItem.vue
@@ -65,8 +65,7 @@
             v-if="state === 'IN_PROGRESS'"
             v-b-toggle="collapsId"
             variant="warning"
-            @mousedown="$root.$emit('close-all-open-collapse')"
-            @click="getListContributionMessages"
+            @click="$emit('closeAllOpenCollapse'), getListContributionMessages"
           >
             {{ $t('contribution.alert.answerQuestion') }}
           </b-button>

--- a/frontend/src/components/Contributions/ContributionListItem.vue
+++ b/frontend/src/components/Contributions/ContributionListItem.vue
@@ -54,8 +54,7 @@
                 v-b-toggle="collapsId"
                 icon="chat-dots"
                 class="h2 mr-5"
-                @mousedown="$root.$emit('close-all-open-collapse')"
-                @click="getListContributionMessages"
+                @click="$emit('closeAllOpenCollapse'), getListContributionMessages"
               ></b-icon>
             </div>
           </div>

--- a/frontend/src/components/Contributions/ContributionListItem.vue
+++ b/frontend/src/components/Contributions/ContributionListItem.vue
@@ -32,12 +32,13 @@
               v-if="!['CONFIRMED', 'DELETED'].includes(state) && !allContribution"
               class="pointer ml-5"
               @click="
-                $emit('update-contribution-form', {
-                  id: id,
-                  contributionDate: contributionDate,
-                  memo: memo,
-                  amount: amount,
-                })
+                $emit('closeAllOpenCollapse'),
+                  $emit('update-contribution-form', {
+                    id: id,
+                    contributionDate: contributionDate,
+                    memo: memo,
+                    amount: amount,
+                  })
               "
             >
               <b-icon icon="pencil" class="h2"></b-icon>

--- a/frontend/src/components/Contributions/ContributionListItem.vue
+++ b/frontend/src/components/Contributions/ContributionListItem.vue
@@ -54,6 +54,7 @@
                 v-b-toggle="collapsId"
                 icon="chat-dots"
                 class="h2 mr-5"
+                @mousedown="$root.$emit('close-all-open-collapse')"
                 @click="getListContributionMessages"
               ></b-icon>
             </div>
@@ -64,6 +65,7 @@
             v-if="state === 'IN_PROGRESS'"
             v-b-toggle="collapsId"
             variant="warning"
+            @mousedown="$root.$emit('close-all-open-collapse')"
             @click="getListContributionMessages"
           >
             {{ $t('contribution.alert.answerQuestion') }}

--- a/frontend/src/pages/Community.vue
+++ b/frontend/src/pages/Community.vue
@@ -49,7 +49,7 @@
             :pageSize="pageSize"
           />
         </b-tab>
-        <b-tab :title="$t('navigation.community')">
+        <b-tab :title="$t('navigation.community')" @click="closeAllOpenCollapse">
           <b-alert show dismissible fade variant="secondary" class="text-dark">
             <h4 class="alert-heading">{{ $t('navigation.community') }}</h4>
             <p>
@@ -70,6 +70,7 @@
             :items="itemsAll"
             @update-list-contributions="updateListAllContributions"
             @update-contribution-form="updateContributionForm"
+            @close-all-open-collapse="closeAllOpenCollapse"
             :contributionCount="contributionCountAll"
             :showPagination="true"
             :pageSize="pageSizeAll"
@@ -112,6 +113,13 @@ export default {
     }
   },
   methods: {
+    closeAllOpenCollapse() {
+      // console.log('Community closeAllOpenCollapse ')
+      // console.log('closeAllOpenCollapse', this.$el.querySelectorAll('.collapse.show'))
+      this.$el.querySelectorAll('.collapse.show').forEach((value) => {
+        this.$root.$emit('bv::toggle::collapse', value.id)
+      })
+    },
     setContribution(data) {
       this.$apollo
         .mutate({

--- a/frontend/src/pages/Community.vue
+++ b/frontend/src/pages/Community.vue
@@ -39,6 +39,7 @@
             </b-alert>
           </div>
           <contribution-list
+            @closeAllOpenCollapse="closeAllOpenCollapse"
             :items="items"
             @update-list-contributions="updateListContributions"
             @update-contribution-form="updateContributionForm"
@@ -70,7 +71,6 @@
             :items="itemsAll"
             @update-list-contributions="updateListAllContributions"
             @update-contribution-form="updateContributionForm"
-            @close-all-open-collapse="closeAllOpenCollapse"
             :contributionCount="contributionCountAll"
             :showPagination="true"
             :pageSize="pageSizeAll"

--- a/frontend/src/pages/Community.vue
+++ b/frontend/src/pages/Community.vue
@@ -2,7 +2,7 @@
   <div class="community-page">
     <div>
       <b-tabs v-model="tabIndex" content-class="mt-3" align="center">
-        <b-tab :title="$t('community.submitContribution')">
+        <b-tab :title="$t('community.submitContribution')" @click="closeAllOpenCollapse">
           <contribution-form
             @set-contribution="setContribution"
             @update-contribution="updateContribution"


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
when i change the tab it closes all open tabs from the child elements. 
if i have a message box open within the contribution list and want to open another one, it also closes the open one first.

### Issues
- fixes #2380 
 
