### PR TITLE
refactor(other):  build nginx docker image in workflow independent of other builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,7 +139,6 @@ jobs:
   build_test_nginx:
     name: Docker Build Test - Nginx
     runs-on: ubuntu-latest
-    needs: [build_test_backend, build_test_admin, build_test_frontend]
     steps:
       ##########################################################################
       # CHECKOUT CODE ##########################################################


### PR DESCRIPTION
## 🍰 Pullrequest
The nginx build does not depend on other builds in the test workflow.
So the build does not need to wait for other builds finishing.

### Issues
- fixes #2457 