### PR TITLE
fix(admin): reduce triggers of success toast on deleted user form to exactly one

### DIFF
--- a/admin/src/components/DeletedUserFormular.vue
+++ b/admin/src/components/DeletedUserFormular.vue
@@ -65,7 +65,6 @@ export default {
           },
         })
         .then((result) => {
-          this.toastSuccess(this.$t('user_recovered'))
           this.$emit('updateDeletedAt', {
             userId: this.item.userId,
             deletedAt: result.data.unDeleteUser,


### PR DESCRIPTION
## 🍰 Pullrequest
In the admin frontend's user search, when undeleting a user the succes toast was triggered twice

- in the compoment `UndeletedUserFormular`
  Here the success toast was inconsistently triggered only for undeletion, but not for deletion of a user, so it has been removed here to fix the issue.
- on the page `UserSearch`
  Here the success toast is triggered more globally for admin actions like user deletion/undeletion in the user entry.

### Issues
- fixes #2435 2435