### PR TITLE
fix(frontend): add a watch on gdt prop to assure propper loading when mounted

### DIFF
--- a/frontend/src/pages/Transactions.vue
+++ b/frontend/src/pages/Transactions.vue
@@ -79,7 +79,7 @@ export default {
       this.$emit('update-transactions', pagination)
     },
   },
-  mounted() {
+  created() {
     if (this.gdt) {
       this.updateGdt()
     }

--- a/frontend/src/pages/Transactions.vue
+++ b/frontend/src/pages/Transactions.vue
@@ -79,13 +79,18 @@ export default {
       this.$emit('update-transactions', pagination)
     },
   },
-  created() {
+  mounted() {
     if (this.gdt) {
       this.updateGdt()
     }
   },
   watch: {
     currentPage() {
+      if (this.gdt) {
+        this.updateGdt()
+      }
+    },
+    gdt() {
       if (this.gdt) {
         this.updateGdt()
       }


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
Gdt datas were not loaded when transaction component was loaded. Add a watch on gdt switch so if set on true we load gdt datas.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] Add watch on gdt
