### PR TITLE
refactor(backend): refine assembly of error message in user resolver

### DIFF
--- a/backend/src/graphql/resolver/EmailOptinCodes.test.ts
+++ b/backend/src/graphql/resolver/EmailOptinCodes.test.ts
@@ -96,7 +96,7 @@ describe('EmailOptinCodes', () => {
         mutate({ mutation: forgotPassword, variables: { email: 'peter@lustig.de' } }),
       ).resolves.toMatchObject({
         data: null,
-        errors: [new GraphQLError('email already sent less than 10 minutes minutes ago')],
+        errors: [new GraphQLError('email already sent less than 10 minutes ago')],
       })
     })
 

--- a/backend/src/graphql/resolver/UserResolver.test.ts
+++ b/backend/src/graphql/resolver/UserResolver.test.ts
@@ -830,7 +830,7 @@ describe('UserResolver', () => {
                 new GraphQLError(
                   `email already sent less than ${printTimeDuration(
                     CONFIG.EMAIL_CODE_REQUEST_TIME,
-                  )} minutes ago`,
+                  )} ago`,
                 ),
               ],
             }),
@@ -870,13 +870,13 @@ describe('UserResolver', () => {
           CONFIG.EMAIL_CODE_REQUEST_TIME = emailCodeRequestTime
           await expect(mutate({ mutation: forgotPassword, variables })).resolves.toEqual(
             expect.objectContaining({
-              errors: [new GraphQLError('email already sent less than 10 minutes minutes ago')],
+              errors: [new GraphQLError('email already sent less than 10 minutes ago')],
             }),
           )
         })
 
         it('logs the error found', () => {
-          expect(logger.error).toBeCalledWith(`email already sent less than 10 minutes minutes ago`)
+          expect(logger.error).toBeCalledWith(`email already sent less than 10 minutes ago`)
         })
       })
     })

--- a/backend/src/graphql/resolver/UserResolver.ts
+++ b/backend/src/graphql/resolver/UserResolver.ts
@@ -392,16 +392,11 @@ export class UserResolver {
     }
 
     if (!canEmailResend(user.emailContact.updatedAt || user.emailContact.createdAt)) {
-      logger.error(
-        `email already sent less than ${printTimeDuration(
-          CONFIG.EMAIL_CODE_REQUEST_TIME,
-        )} minutes ago`,
-      )
-      throw new Error(
-        `email already sent less than ${printTimeDuration(
-          CONFIG.EMAIL_CODE_REQUEST_TIME,
-        )} minutes ago`,
-      )
+      const errorMessage = `email already sent less than ${printTimeDuration(
+        CONFIG.EMAIL_CODE_REQUEST_TIME,
+      )} ago`
+      logger.error(errorMessage)
+      throw new Error(errorMessage)
     }
 
     user.emailContact.updatedAt = new Date()


### PR DESCRIPTION
## 🍰 Pullrequest
The user resolver's error message for `forgotPAssword` requests in case the email cannot be resend contained the unit of time twice.