### PR TITLE
refactor(frontend): transaction info, right-justified, so that the commas

### DIFF
--- a/frontend/src/components/DecayInformations/DecayInformation-Long.vue
+++ b/frontend/src/components/DecayInformations/DecayInformation-Long.vue
@@ -14,7 +14,7 @@
           <b-col cols="12" lg="4" md="4">
             <div>{{ $t('decay.last_transaction') }}</div>
           </b-col>
-          <b-col offset="1" offset-md="0" offset-lg="0">
+          <b-col offset="1" offset-md="0" offset-lg="0" class="text-right mr-5">
             <div>
               <span>
                 {{ $d(new Date(decay.start), 'long') }}
@@ -25,11 +25,13 @@
         <duration-row :decayStart="decay.start" :decayEnd="decay.end" />
 
         <!-- Decay-->
-        <b-row>
-          <b-col cols="12" lg="4" md="4">
+        <b-row class="mt-2">
+          <b-col cols="12" lg="3" md="3">
             <div>{{ $t('decay.decay') }}</div>
           </b-col>
-          <b-col offset="1" offset-md="0" offset-lg="0">{{ decay.decay | GDD }}</b-col>
+          <b-col offset="1" offset-md="0" offset-lg="0" class="text-right mr-5">
+            {{ decay.decay | GDD }}
+          </b-col>
         </b-row>
       </b-col>
     </b-row>
@@ -38,15 +40,17 @@
       <b-col>
         <b-row>
           <!-- eslint-disable-next-line @intlify/vue-i18n/no-dynamic-keys-->
-          <b-col cols="12" lg="4" md="4">{{ $t(`decay.types.${typeId.toLowerCase()}`) }}</b-col>
-          <b-col offset="1" offset-md="0" offset-lg="0">{{ amount | GDD }}</b-col>
+          <b-col cols="12" lg="3" md="3">{{ $t(`decay.types.${typeId.toLowerCase()}`) }}</b-col>
+          <b-col offset="1" offset-md="0" offset-lg="0" class="text-right mr-5">
+            {{ amount | GDD }}
+          </b-col>
         </b-row>
         <!-- Total-->
         <b-row>
-          <b-col cols="12" lg="4" md="4">
+          <b-col cols="12" lg="3" md="3">
             <div>{{ $t('decay.total') }}</div>
           </b-col>
-          <b-col offset="1" offset-md="0" offset-lg="0">
+          <b-col offset="1" offset-md="0" offset-lg="0" class="text-right mr-5">
             <b>{{ (Number(amount) + Number(decay.decay)) | GDD }}</b>
           </b-col>
         </b-row>

--- a/frontend/src/components/TransactionRows/DurationRow.vue
+++ b/frontend/src/components/TransactionRows/DurationRow.vue
@@ -4,7 +4,7 @@
       <b-col cols="12" lg="4" md="4">
         <div>{{ $t('decay.past_time') }}</div>
       </b-col>
-      <b-col offset="1" offset-md="0" offset-lg="0">
+      <b-col offset="1" offset-md="0" offset-lg="0" class="text-right mr-5">
         <span v-if="duration">{{ durationText }}</span>
       </b-col>
     </b-row>


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
Transaction info, right-justified, so that the commas of the amounts are below each other.

### Issues
- fixes #1006 

![image](https://user-images.githubusercontent.com/1324583/228575905-e723c8c1-d922-4944-acf0-091380e6aad2.png)

