### PR TITLE
feat(frontend): redirect to settings without username after login

### DIFF
--- a/frontend/src/components/Menu/Navbar.spec.js
+++ b/frontend/src/components/Menu/Navbar.spec.js
@@ -20,7 +20,7 @@ const mocks = {
     state: {
       firstName: 'Testy',
       lastName: 'User',
-      gradidoID: 'current-user-id',
+      username: 'te_u',
     },
   },
 }
@@ -51,24 +51,17 @@ describe('AuthNavbar', () => {
       })
 
       it("has the user's initials", () => {
-        expect(wrapper.find('.vue-avatar--wrapper').text()).toBe(
-          `${wrapper.vm.$store.state.firstName[0]}${wrapper.vm.$store.state.lastName[0]}`,
-        )
+        expect(wrapper.find('.vue-avatar--wrapper').text()).toBe('TU')
       })
     })
 
     describe('user info', () => {
       it('has the full name', () => {
-        expect(wrapper.find('div[data-test="navbar-item-username"]').text()).toBe(
-          `${wrapper.vm.$store.state.firstName} ${wrapper.vm.$store.state.lastName}`,
-        )
+        expect(wrapper.find('div[data-test="navbar-item-fullName"]').text()).toBe('Testy User')
       })
 
-      // I think this should be username
-      it.skip('has the email address', () => {
-        expect(wrapper.find('div[data-test="navbar-item-email"]').text()).toBe(
-          wrapper.vm.$store.state.email,
-        )
+      it('has the username', () => {
+        expect(wrapper.find('div[data-test="navbar-item-username"]').text()).toBe('te_u')
       })
     })
   })

--- a/frontend/src/components/Menu/Navbar.vue
+++ b/frontend/src/components/Menu/Navbar.vue
@@ -21,17 +21,17 @@
             <div class="d-flex align-items-center">
               <div class="mr-3">
                 <avatar
-                  :username="username.username"
-                  :initials="username.initials"
+                  :username="user.fullName"
+                  :initials="user.initials"
                   :color="'#fff'"
                   :size="61"
                 ></avatar>
               </div>
               <div>
-                <div data-test="navbar-item-username">{{ username.username }}</div>
+                <div data-test="navbar-item-fullName">{{ user.fullName }}</div>
 
-                <div data-test="navbar-item-email">
-                  {{ $store.state.email }}
+                <div data-test="navbar-item-username">
+                  {{ user.username }}
                 </div>
               </div>
             </div>
@@ -65,10 +65,11 @@ export default {
     }
   },
   computed: {
-    username() {
+    user() {
       return {
-        username: `${this.$store.state.firstName} ${this.$store.state.lastName}`,
+        fullName: `${this.$store.state.firstName} ${this.$store.state.lastName}`,
         initials: `${this.$store.state.firstName[0]}${this.$store.state.lastName[0]}`,
+        username: this.$store.state.username,
       }
     },
   },

--- a/frontend/src/layouts/templates/RightSide.spec.js
+++ b/frontend/src/layouts/templates/RightSide.spec.js
@@ -1,0 +1,50 @@
+import { mount } from '@vue/test-utils'
+import RightSide from './RightSide'
+
+const localVue = global.localVue
+
+describe('RightSide', () => {
+  let wrapper
+
+  const mocks = {
+    $route: {
+      path: '/community/contribute',
+    },
+  }
+
+  const Wrapper = () => {
+    return mount(RightSide, { localVue, mocks })
+  }
+
+  describe('at /community/contribute', () => {
+    beforeEach(() => {
+      wrapper = Wrapper()
+    })
+
+    it('has name set to "community"', () => {
+      expect(wrapper.vm.name).toBe('community')
+    })
+  })
+
+  describe('at /settings', () => {
+    beforeEach(() => {
+      mocks.$route.path = '/settings'
+      wrapper = Wrapper()
+    })
+
+    it('has name set to "empty"', () => {
+      expect(wrapper.vm.name).toBe('empty')
+    })
+  })
+
+  describe('at /overview', () => {
+    beforeEach(() => {
+      mocks.$route.path = '/overview'
+      wrapper = Wrapper()
+    })
+
+    it('has name set to "transactions"', () => {
+      expect(wrapper.vm.name).toBe('transactions')
+    })
+  })
+})

--- a/frontend/src/pages/Community.vue
+++ b/frontend/src/pages/Community.vue
@@ -287,9 +287,6 @@ export default {
       this.tabIndex = 0
       this.$router.push({ params: { tab: 'contribute' } })
     },
-    updateTransactions(pagination) {
-      this.$emit('update-transactions', pagination)
-    },
     updateState(id) {
       this.items.find((item) => item.id === id).state = 'PENDING'
     },

--- a/frontend/src/pages/Login.spec.js
+++ b/frontend/src/pages/Login.spec.js
@@ -29,6 +29,7 @@ describe('Login', () => {
       commit: mockStoreCommit,
       state: {
         publisherId: 12345,
+        username: 'present',
       },
     },
     $loading: {

--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -104,7 +104,9 @@ export default {
           if (this.$route.params.code) {
             this.$router.push(`/redeem/${this.$route.params.code}`)
           } else {
-            this.$router.push('/overview')
+            this.$store.state.username
+              ? this.$router.push('/overview')
+              : this.$router.push('/settings')
           }
         })
         .catch((error) => {

--- a/frontend/src/pages/Settings.vue
+++ b/frontend/src/pages/Settings.vue
@@ -3,7 +3,7 @@
     <user-card :balance="balance" :transactionCount="transactionCount"></user-card>
     <user-data />
     <hr />
-    <user-name />
+    <user-name ref="usernameForm" />
     <hr />
     <user-password />
     <hr />
@@ -34,13 +34,26 @@ export default {
     balance: { type: Number, default: 0 },
     transactionCount: { type: Number, default: 0 },
   },
+  data() {
+    return {
+      scrollToUsername: false,
+    }
+  },
   methods: {
     updateTransactions(pagination) {
       this.$emit('update-transactions', pagination)
     },
   },
+  mounted() {
+    if (this.scrollToUsername) {
+      this.$refs.usernameForm.$el.scrollIntoView()
+    }
+  },
   created() {
     this.updateTransactions(0)
+  },
+  beforeRouteEnter(_, from, next) {
+    next((vm) => (vm.scrollToUsername = from.path === '/login'))
   },
 }
 </script>


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
Redirects to settings and scrolls to username when no username is present after login

Watch out: __based on #2984__ 

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Is there one?

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
