### PR TITLE
refactor(backend): camelcase exception for FederationClient_XX_X

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -27,7 +27,8 @@ module.exports = {
     },
   },
   rules: {
-    'no-console': ['error'],
+    'no-console': 'error',
+    camelcase: ['error', { allow: 'FederationClient_*' }],
     'no-debugger': 'error',
     'prettier/prettier': [
       'error',

--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
   },
   rules: {
     'no-console': 'error',
-    camelcase: ['error', { allow: 'FederationClient_*' }],
+    camelcase: ['error', { allow: ['FederationClient_*'] }],
     'no-debugger': 'error',
     'prettier/prettier': [
       'error',

--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -185,6 +185,7 @@ module.exports = {
         tsconfigRootDir: __dirname,
         project: ['./tsconfig.json', '**/tsconfig.json'],
         // this is to properly reference the referenced project database without requirement of compiling it
+        // eslint-disable-next-line camelcase
         EXPERIMENTAL_useSourceOfProjectReferenceRedirect: true,
       },
     },

--- a/backend/src/federation/client/Client_1_1.ts
+++ b/backend/src/federation/client/Client_1_1.ts
@@ -1,5 +1,0 @@
-// eslint-disable-next-line camelcase
-import { Client_1_0 } from './Client_1_0'
-
-// eslint-disable-next-line camelcase
-export class Client_1_1 extends Client_1_0 {}

--- a/backend/src/federation/client/FederationClient.ts
+++ b/backend/src/federation/client/FederationClient.ts
@@ -2,22 +2,19 @@ import { FederatedCommunity as DbFederatedCommunity } from '@entity/FederatedCom
 
 import { ApiVersionType } from '@/federation/enum/apiVersionType'
 
-// eslint-disable-next-line camelcase
-import { Client_1_0 } from './Client_1_0'
-// eslint-disable-next-line camelcase
-import { Client_1_1 } from './Client_1_1'
+import { FederationClient_1_0 } from './FederationClient_1_0'
+import { FederationClient_1_1 } from './FederationClient_1_1'
 
-// eslint-disable-next-line camelcase
-type FederationClient = Client_1_0 | Client_1_1
+type FederationClientType = FederationClient_1_0 | FederationClient_1_1
 
 interface ClientInstance {
   id: number
   // eslint-disable-next-line no-use-before-define
-  client: FederationClient
+  client: FederationClientType
 }
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
-export class Client {
+export class FederationClient {
   private static instanceArray: ClientInstance[] = []
 
   /**
@@ -30,9 +27,9 @@ export class Client {
   private static createFederationClient = (dbCom: DbFederatedCommunity) => {
     switch (dbCom.apiVersion) {
       case ApiVersionType.V1_0:
-        return new Client_1_0(dbCom)
+        return new FederationClient_1_0(dbCom)
       case ApiVersionType.V1_1:
-        return new Client_1_1(dbCom)
+        return new FederationClient_1_1(dbCom)
       default:
         return null
     }
@@ -44,14 +41,14 @@ export class Client {
    * This implementation let you subclass the Singleton class while keeping
    * just one instance of each subclass around.
    */
-  public static getInstance(dbCom: DbFederatedCommunity): FederationClient | null {
-    const instance = Client.instanceArray.find((instance) => instance.id === dbCom.id)
+  public static getInstance(dbCom: DbFederatedCommunity): FederationClientType | null {
+    const instance = FederationClient.instanceArray.find((instance) => instance.id === dbCom.id)
     if (instance) {
       return instance.client
     }
-    const client = Client.createFederationClient(dbCom)
+    const client = FederationClient.createFederationClient(dbCom)
     if (client) {
-      Client.instanceArray.push({ id: dbCom.id, client } as ClientInstance)
+      FederationClient.instanceArray.push({ id: dbCom.id, client } as ClientInstance)
     }
     return client
   }

--- a/backend/src/federation/client/FederationClient_1_0.ts
+++ b/backend/src/federation/client/FederationClient_1_0.ts
@@ -4,8 +4,7 @@ import { GraphQLClient } from 'graphql-request'
 import { getPublicKey } from '@/federation/query/getPublicKey'
 import { backendLogger as logger } from '@/server/logger'
 
-// eslint-disable-next-line camelcase
-export class Client_1_0 {
+export class FederationClient_1_0 {
   dbCom: DbFederatedCommunity
   endpoint: string
   client: GraphQLClient

--- a/backend/src/federation/client/FederationClient_1_1.ts
+++ b/backend/src/federation/client/FederationClient_1_1.ts
@@ -1,0 +1,3 @@
+import { FederationClient_1_0 } from './FederationClient_1_0'
+
+export class FederationClient_1_1 extends FederationClient_1_0 {}

--- a/backend/src/federation/validateCommunities.test.ts
+++ b/backend/src/federation/validateCommunities.test.ts
@@ -103,6 +103,7 @@ describe('validate Communities', () => {
           .into(DbFederatedCommunity)
           .values(variables2)
           .orUpdate({
+            // eslint-disable-next-line camelcase
             conflict_target: ['id', 'publicKey', 'apiVersion'],
             overwrite: ['end_point', 'last_announced_at'],
           })
@@ -141,6 +142,7 @@ describe('validate Communities', () => {
           .into(DbFederatedCommunity)
           .values(variables3)
           .orUpdate({
+            // eslint-disable-next-line camelcase
             conflict_target: ['id', 'publicKey', 'apiVersion'],
             overwrite: ['end_point', 'last_announced_at'],
           })

--- a/backend/src/federation/validateCommunities.test.ts
+++ b/backend/src/federation/validateCommunities.test.ts
@@ -70,6 +70,7 @@ describe('validate Communities', () => {
           .into(DbFederatedCommunity)
           .values(variables1)
           .orUpdate({
+            // eslint-disable-next-line camelcase
             conflict_target: ['id', 'publicKey', 'apiVersion'],
             overwrite: ['end_point', 'last_announced_at'],
           })

--- a/backend/src/federation/validateCommunities.ts
+++ b/backend/src/federation/validateCommunities.ts
@@ -5,7 +5,7 @@ import { FederatedCommunity as DbFederatedCommunity } from '@entity/FederatedCom
 
 import { backendLogger as logger } from '@/server/logger'
 
-import { Client } from './client/Client'
+import { FederationClient } from './client/FederationClient'
 import { ApiVersionType } from './enum/apiVersionType'
 
 export function startValidateCommunities(timerInterval: number): void {
@@ -37,7 +37,7 @@ export async function validateCommunities(): Promise<void> {
       continue
     }
     try {
-      const client = Client.getInstance(dbCom)
+      const client = FederationClient.getInstance(dbCom)
       const pubKey = await client?.getPublicKey()
       if (pubKey && pubKey === dbCom.publicKey.toString()) {
         await DbFederatedCommunity.update({ id: dbCom.id }, { verifiedAt: new Date() })


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

This PR defines a camelcase exception for the FederationClient to be suffixed by the Version without requiring an camelcase exception every time. We define a global exception.

Furthermore the Client_XX_X is renamed to FederationClient_XX_X to avoid potential conflicts where the camelcase rule should not be taking place.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/gradido/gradido/issues/2997

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
