### PR TITLE
[POC] Chat Ui frontend example

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "uuid": "^9.0.0",
     "vee-validate": "^3.4.5",
     "vue": "2.6.12",
+    "vue-advanced-chat": "^2.0.7",
     "vue-apollo": "^3.0.7",
     "vue-avatar": "^2.3.3",
     "vue-flatpickr-component": "^8.1.2",

--- a/frontend/src/components/Menu/Sidebar.vue
+++ b/frontend/src/components/Menu/Sidebar.vue
@@ -35,6 +35,10 @@
         </b-nav>
         <hr class="m-3" />
         <b-nav vertical class="w-100">
+          <b-nav-item to="/chat" class="mb-3" active-class="activeRoute">
+            <b-img src="/img/svg/settings.svg" height="20" class="svg-icon" />
+            <span class="ml-2">chat</span>
+          </b-nav-item>
           <b-nav-item to="/settings" class="mb-3" active-class="activeRoute">
             <b-img src="/img/svg/settings.svg" height="20" class="svg-icon" />
             <span class="ml-2">{{ $t('navigation.settings') }}</span>

--- a/frontend/src/pages/Chat.vue
+++ b/frontend/src/pages/Chat.vue
@@ -1,12 +1,25 @@
 <template>
   <div>
-    <h1>Chat</h1>
     <vue-advanced-chat
       :current-user-id="currentUserId"
+      :template-actions="JSON.stringify(templatesText)"
+      :text-messages="JSON.stringify(textMessages)"
+      :menu-actions="JSON.stringify(menuActions)"
       :rooms="JSON.stringify(rooms)"
       :messages="JSON.stringify(messages)"
       :room-actions="JSON.stringify(roomActions)"
+      :rooms-loaded="true"
+      show-files="true"
+      show-audio="true"
+      :show-footer="true"
+      :messages-loaded="messagesLoaded"
+      @send-message="sendMessage($event.detail[0])"
+      @fetch-messages="fetchMessages($event.detail[0])"
+      :theme="theme"
+      :is-device="isDevice"
+      @show-demo-options="showDemoOptions = $event"
     />
+    <b-button @click="theme = theme === 'light' ? 'dark' : 'light'">change style mode</b-button>
   </div>
 </template>
 <script>
@@ -18,21 +31,92 @@ export default {
   data() {
     return {
       currentUserId: '1234',
+      menuActions: [
+        {
+          name: 'inviteUser',
+          title: 'Invite User',
+        },
+        {
+          name: 'removeUser',
+          title: 'Remove User',
+        },
+        {
+          name: 'deleteRoom',
+          title: 'Delete Room',
+        },
+      ],
+      messageActions: [
+        {
+          name: 'addMessageToFavorite',
+          title: 'Add To Favorite',
+        },
+        {
+          name: 'shareMessage',
+          title: 'Share Message',
+        },
+      ],
+      templatesText: [
+        {
+          tag: 'help',
+          text: 'This is the help',
+        },
+        {
+          tag: 'action',
+          text: 'This is the action',
+        },
+      ],
+      textMessages: {
+        ROOMS_EMPTY: 'Aucune conversation',
+        ROOM_EMPTY: 'Aucune conversation sélectionnée',
+        NEW_MESSAGES: 'Nouveaux messages',
+        MESSAGE_DELETED: 'Ce message a été supprimé',
+        MESSAGES_EMPTY: 'Aucun message',
+        CONVERSATION_STARTED: 'La conversation a commencée le :',
+        TYPE_MESSAGE: 'Tapez votre message',
+        SEARCH: 'Rechercher',
+        IS_ONLINE: 'est en ligne',
+        LAST_SEEN: 'dernière connexion ',
+        IS_TYPING: 'est en train de taper...',
+        CANCEL_SELECT_MESSAGE: 'Annuler Sélection',
+      },
+      roomActions: [
+        {
+          name: 'archiveRoom',
+          title: 'Archive Room',
+        },
+        { name: 'inviteUser', title: 'Invite User' },
+        { name: 'removeUser', title: 'Remove User' },
+        { name: 'deleteRoom', title: 'Delete Room' },
+      ],
       rooms: [
         {
           roomId: '1',
-          roomName: 'Room 1',
+          roomName: 'John Snow',
           avatar: 'https://66.media.tumblr.com/avatar_c6a8eae4303e_512.pnj',
           users: [
             { _id: '1234', username: 'John Doe' },
             { _id: '4321', username: 'John Snow' },
           ],
         },
+        {
+          roomId: '2',
+          roomName: 'Max J. Mustermann',
+          avatar:
+            'https://64.media.tumblr.com/8889b6e26370f4e3837584c1c59721a6/f4f76ed6b0249d08-4b/s1280x1920/810e9e5fa724366d26c10c0fa22ba97dad8778d1.pnj',
+          users: [
+            { _id: '1234', username: 'Johnx Doe' },
+            { _id: '43210', username: 'Max J. Mustermann' },
+          ],
+        },
       ],
       messages: [],
       messagesLoaded: false,
+      showDemoOptions: true,
+      isDevice: true,
+      theme: 'light',
     }
   },
+
   methods: {
     fetchMessages({ options = {} }) {
       setTimeout(() => {
@@ -59,6 +143,14 @@ export default {
           timestamp: '10:20',
         })
       }
+      messages.push({
+        _id: '31',
+        content: `Hallo Welt`,
+        senderId: '1234',
+        username: 'John Doe',
+        date: '13 November',
+        timestamp: '10:20',
+      })
 
       return messages
     },
@@ -93,3 +185,11 @@ export default {
   },
 }
 </script>
+<style lang="scss">
+body {
+  font-family: 'Quicksand', sans-serif;
+}
+vue-advanced-chat {
+  border-radius: 55px;
+}
+</style>

--- a/frontend/src/pages/Chat.vue
+++ b/frontend/src/pages/Chat.vue
@@ -1,0 +1,95 @@
+<template>
+  <div>
+    <h1>Chat</h1>
+    <vue-advanced-chat
+      :current-user-id="currentUserId"
+      :rooms="JSON.stringify(rooms)"
+      :messages="JSON.stringify(messages)"
+      :room-actions="JSON.stringify(roomActions)"
+    />
+  </div>
+</template>
+<script>
+import { register } from 'vue-advanced-chat'
+register()
+
+export default {
+  name: 'Chat',
+  data() {
+    return {
+      currentUserId: '1234',
+      rooms: [
+        {
+          roomId: '1',
+          roomName: 'Room 1',
+          avatar: 'https://66.media.tumblr.com/avatar_c6a8eae4303e_512.pnj',
+          users: [
+            { _id: '1234', username: 'John Doe' },
+            { _id: '4321', username: 'John Snow' },
+          ],
+        },
+      ],
+      messages: [],
+      messagesLoaded: false,
+    }
+  },
+  methods: {
+    fetchMessages({ options = {} }) {
+      setTimeout(() => {
+        if (options.reset) {
+          this.messages = this.addMessages(true)
+        } else {
+          this.messages = [...this.addMessages(), ...this.messages]
+          this.messagesLoaded = true
+        }
+        // this.addNewMessage()
+      })
+    },
+
+    addMessages(reset) {
+      const messages = []
+
+      for (let i = 0; i < 30; i++) {
+        messages.push({
+          _id: reset ? i : this.messages.length + i,
+          content: `${reset ? '' : 'paginated'} message ${i + 1}`,
+          senderId: '4321',
+          username: 'John Doe',
+          date: '13 November',
+          timestamp: '10:20',
+        })
+      }
+
+      return messages
+    },
+
+    sendMessage(message) {
+      this.messages = [
+        ...this.messages,
+        {
+          _id: this.messages.length,
+          content: message.content,
+          senderId: this.currentUserId,
+          timestamp: new Date().toString().substring(16, 21),
+          date: new Date().toDateString(),
+        },
+      ]
+    },
+
+    addNewMessage() {
+      setTimeout(() => {
+        this.messages = [
+          ...this.messages,
+          {
+            _id: this.messages.length,
+            content: 'NEW MESSAGE',
+            senderId: '1234',
+            timestamp: new Date().toString().substring(16, 21),
+            date: new Date().toDateString(),
+          },
+        ]
+      }, 2000)
+    },
+  },
+}
+</script>

--- a/frontend/src/routes/routes.js
+++ b/frontend/src/routes/routes.js
@@ -78,6 +78,14 @@ const routes = [
       pageTitle: 'information',
     },
   },
+  {
+    path: '/chat',
+    component: () => import('@/pages/Chat'),
+    meta: {
+      requiresAuth: true,
+      pageTitle: 'chat',
+    },
+  },
   // {
   //   path: '/storys',
   //   component: () => import('@/pages/TopStorys'),

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6044,6 +6044,11 @@ emittery@^0.7.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.7.2.tgz#25595908e13af0f5674ab419396e2fb394cdfa82"
   integrity sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==
 
+emoji-picker-element@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/emoji-picker-element/-/emoji-picker-element-1.12.1.tgz#854a9bbae4d9a04fa2b5cd0763845921f4904c83"
+  integrity sha512-F9AY/re8uqZmBcCXLHLGvyy7fxuMQdZl9R8OToLRH8Vnns+WMX8RYUbI2nSJklzl5+82qzpYWeus1/puDepWcQ==
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -9827,6 +9832,11 @@ lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
+linkifyjs@2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-2.1.9.tgz#af06e45a2866ff06c4766582590d098a4d584702"
+  integrity sha512-74ivurkK6WHvHFozVaGtQWV38FzBwSTGNmJolEgFp7QgR2bl6ArUWlvT4GcHKbPe1z3nWYi+VUdDZk16zDOVug==
 
 load-json-file@^2.0.0:
   version "2.0.0"
@@ -14238,6 +14248,14 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vue-advanced-chat@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/vue-advanced-chat/-/vue-advanced-chat-2.0.7.tgz#bd35830c19fc5eb4e26545dc554d88e7808913cc"
+  integrity sha512-s+6v+KtVT46lFM8YohneLLS/vN10sSTAPfZiqAczXf13Q8vQWD9rSeWAokL0zuJeQ+jguNgFI6oN2wbI/RC1iw==
+  dependencies:
+    emoji-picker-element "1.12.1"
+    linkifyjs "2.1.9"
 
 vue-apollo@^3.0.7:
   version "3.0.7"


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
I have created an example for a frontend chat ui for gradido communities. 
the backend is not part of this example. 

- Customizeable realtime chat messaging
- Backend agnostic
- Images, videos, files, voice messages & emojis
- Edit messages & reply to other messages
- Tag users & emojis shortcut suggestions
- UI elements for seen, new, deleted, typing and system messages
- Text formatting - bold, italic, strikethrough, underline, code, multiline
- Online / Offline users status
- Flexible options and slots
- Light and dark theme modes

https://github.com/gradido/gradido/assets/1324583/77fea611-42e4-416d-8be4-a3558caac8bf


