### PR TITLE
fix(frontend): make invisible community visible

### DIFF
--- a/frontend/src/components/CommunitySwitch.vue
+++ b/frontend/src/components/CommunitySwitch.vue
@@ -72,7 +72,4 @@ export default {
   transform: translateY(-50%);
   position: relative;
 }
-.community-switch ul li:first-child {
-  display: none;
-}
 </style>


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
In my tests, an empty line was constantly displayed, which broke the design, so I had made the first element invisible via css. But this empty line does not seem to exist anymore and my CSS statement now leads to problems that the first community is not visible. So this PR remove this css to show all options of community switch. 

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
