### PR TITLE
fix(frontend): fix to less moderator/admins on information page

### DIFF
--- a/backend/src/graphql/arg/Paginated.ts
+++ b/backend/src/graphql/arg/Paginated.ts
@@ -6,15 +6,15 @@ import { Order } from '@enum/Order'
 
 @ArgsType()
 export class Paginated {
-  @Field(() => Int, { defaultValue: 1 })
+  @Field(() => Int, { nullable: true })
   @IsPositive()
-  currentPage: number
+  currentPage?: number
 
   @Field(() => Int, { nullable: true })
   @IsPositive()
   pageSize?: number
 
-  @Field(() => Order, { defaultValue: Order.DESC })
+  @Field(() => Order, { nullable: true })
   @IsEnum(Order)
-  order: Order
+  order?: Order
 }

--- a/backend/src/graphql/arg/Paginated.ts
+++ b/backend/src/graphql/arg/Paginated.ts
@@ -10,9 +10,9 @@ export class Paginated {
   @IsPositive()
   currentPage: number
 
-  @Field(() => Int, { defaultValue: 3 })
+  @Field(() => Int, { nullable: true })
   @IsPositive()
-  pageSize: number
+  pageSize?: number
 
   @Field(() => Order, { defaultValue: Order.DESC })
   @IsEnum(Order)

--- a/backend/src/graphql/resolver/util/findContributions.ts
+++ b/backend/src/graphql/resolver/util/findContributions.ts
@@ -7,6 +7,7 @@ import { SearchContributionsFilterArgs } from '@arg/SearchContributionsFilterArg
 import { Connection } from '@typeorm/connection'
 
 import { LogError } from '@/server/LogError'
+import { Order } from '@/graphql/enum/Order'
 
 interface Relations {
   [key: string]: boolean | Relations
@@ -28,7 +29,7 @@ function joinRelationsRecursive(
 }
 
 export const findContributions = async (
-  { pageSize = 3, currentPage, order }: Paginated,
+  { pageSize = 3, currentPage = 1, order = Order.DESC }: Paginated,
   filter: SearchContributionsFilterArgs,
   withDeleted = false,
   relations: Relations | undefined = undefined,

--- a/backend/src/graphql/resolver/util/findContributions.ts
+++ b/backend/src/graphql/resolver/util/findContributions.ts
@@ -28,7 +28,7 @@ function joinRelationsRecursive(
 }
 
 export const findContributions = async (
-  paginate: Paginated,
+  { pageSize = 3, currentPage, order }: Paginated,
   filter: SearchContributionsFilterArgs,
   withDeleted = false,
   relations: Relations | undefined = undefined,
@@ -61,9 +61,9 @@ export const findContributions = async (
     )
   }
   return queryBuilder
-    .orderBy('Contribution.createdAt', paginate.order)
-    .addOrderBy('Contribution.id', paginate.order)
-    .skip((paginate.currentPage - 1) * paginate.pageSize)
-    .take(paginate.pageSize)
+    .orderBy('Contribution.createdAt', order)
+    .addOrderBy('Contribution.id', order)
+    .skip((currentPage - 1) * pageSize)
+    .take(pageSize)
     .getManyAndCount()
 }

--- a/backend/src/graphql/resolver/util/findContributions.ts
+++ b/backend/src/graphql/resolver/util/findContributions.ts
@@ -6,8 +6,8 @@ import { Paginated } from '@arg/Paginated'
 import { SearchContributionsFilterArgs } from '@arg/SearchContributionsFilterArgs'
 import { Connection } from '@typeorm/connection'
 
-import { LogError } from '@/server/LogError'
 import { Order } from '@/graphql/enum/Order'
+import { LogError } from '@/server/LogError'
 
 interface Relations {
   [key: string]: boolean | Relations


### PR DESCRIPTION
It seems default value in graphql/arg/Paginated overwrite default values which are used in various places in resolvers.
In searchAdminUsers default value is set to 25 was overwritten by 3 in Paginated. The frontend call searchAdminUsers without parameters so it gets only the default count of results.

TODO: Rethink pagination mechanism in light of larger communities. Not all places can handle more than one page results.