### PR TITLE
refactor(database): add index to contribution_message

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -12,7 +12,7 @@ Decimal.set({
 })
 
 const constants = {
-  DB_VERSION: '0074-insert_communityuuid in_existing_users',
+  DB_VERSION: '0075-contribution_message_add_index',
   DECAY_START_TIME: new Date('2021-05-13 17:46:31-0000'), // GMT+0
   LOG4JS_CONFIG: 'log4js-config.json',
   // default log level on production should be info

--- a/database/entity/0075-contribution_message_add_index/ContributionMessage.ts
+++ b/database/entity/0075-contribution_message_add_index/ContributionMessage.ts
@@ -18,10 +18,10 @@ export class ContributionMessage extends BaseEntity {
   @PrimaryGeneratedColumn('increment', { unsigned: true })
   id: number
 
+  @Index()
   @Column({ name: 'contribution_id', unsigned: true, nullable: false })
   contributionId: number
 
-  @Index()
   @ManyToOne(() => Contribution, (contribution) => contribution.messages)
   @JoinColumn({ name: 'contribution_id' })
   contribution: Contribution

--- a/database/entity/0075-contribution_message_add_index/ContributionMessage.ts
+++ b/database/entity/0075-contribution_message_add_index/ContributionMessage.ts
@@ -1,0 +1,56 @@
+import {
+  BaseEntity,
+  Column,
+  DeleteDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm'
+import { Contribution } from '../Contribution'
+import { User } from '../User'
+
+@Entity('contribution_messages', {
+  engine: 'InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci',
+})
+export class ContributionMessage extends BaseEntity {
+  @PrimaryGeneratedColumn('increment', { unsigned: true })
+  id: number
+
+  @Column({ name: 'contribution_id', unsigned: true, nullable: false })
+  contributionId: number
+
+  @Index()
+  @ManyToOne(() => Contribution, (contribution) => contribution.messages)
+  @JoinColumn({ name: 'contribution_id' })
+  contribution: Contribution
+
+  @Column({ name: 'user_id', unsigned: true, nullable: false })
+  userId: number
+
+  @ManyToOne(() => User, (user) => user.messages)
+  @JoinColumn({ name: 'user_id' })
+  user: User
+
+  @Column({ length: 2000, nullable: false, collation: 'utf8mb4_unicode_ci' })
+  message: string
+
+  @Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP', name: 'created_at' })
+  createdAt: Date
+
+  @Column({ type: 'datetime', default: null, nullable: true, name: 'updated_at' })
+  updatedAt: Date
+
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deletedAt: Date | null
+
+  @Column({ name: 'deleted_by', default: null, unsigned: true, nullable: true })
+  deletedBy: number
+
+  @Column({ length: 12, nullable: false, collation: 'utf8mb4_unicode_ci' })
+  type: string
+
+  @Column({ name: 'is_moderator', type: 'bool', nullable: false, default: false })
+  isModerator: boolean
+}

--- a/database/entity/ContributionMessage.ts
+++ b/database/entity/ContributionMessage.ts
@@ -1,1 +1,1 @@
-export { ContributionMessage } from './0048-add_is_moderator_to_contribution_messages/ContributionMessage'
+export { ContributionMessage } from './0075-contribution_message_add_index/ContributionMessage'

--- a/database/migrations/0075-contribution_message_add_index.ts
+++ b/database/migrations/0075-contribution_message_add_index.ts
@@ -1,0 +1,15 @@
+/* MIGRATION TO ADD PRIVATE KEY IN COMMUNITY TABLE
+ *
+ * This migration adds a field for the private key in the community.table
+ */
+
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function upgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  await queryFn('ALTER TABLE `contribution_messages` ADD INDEX(`contribution_id`);')
+}
+
+export async function downgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  await queryFn('ALTER TABLE `contribution_messages` DROP INDEX `contribution_id`')
+}

--- a/dht-node/src/config/index.ts
+++ b/dht-node/src/config/index.ts
@@ -4,7 +4,7 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 const constants = {
-  DB_VERSION: '0074-insert_communityuuid in_existing_users',
+  DB_VERSION: '0075-contribution_message_add_index',
   LOG4JS_CONFIG: 'log4js-config.json',
   // default log level on production should be info
   LOG_LEVEL: process.env.LOG_LEVEL || 'info',

--- a/federation/src/config/index.ts
+++ b/federation/src/config/index.ts
@@ -10,7 +10,7 @@ Decimal.set({
 })
 
 const constants = {
-  DB_VERSION: '0074-insert_communityuuid in_existing_users',
+  DB_VERSION: '0075-contribution_message_add_index',
   DECAY_START_TIME: new Date('2021-05-13 17:46:31-0000'), // GMT+0
   LOG4JS_CONFIG: 'log4js-config.json',
   // default log level on production should be info


### PR DESCRIPTION
Bernd notice a slowdown of admin interface in production.
I measure 4 seconds of list confirmed contributions (limit 25) query and 4 additional seconds for counting the total confirmed contributions.
With a production db copy on my dev pc I have still 3 seconds per query.
After adding only one index to db, for contribution_messages.contribution_id
the time duration is down to ~40 ms for each query.