### PR TITLE
feat(admin): resubmission

### DIFF
--- a/admin/src/components/ContributionMessages/ContributionMessagesFormular.vue
+++ b/admin/src/components/ContributionMessages/ContributionMessagesFormular.vue
@@ -114,15 +114,11 @@ export default {
   },
   methods: {
     combineResubmissionDateAndTime() {
-      if (this.resubmissionDate) {
-        const formattedDate = new Date(this.resubmissionDate)
-        const [hours, minutes] = this.resubmissionTime.split(':')
-        formattedDate.setHours(parseInt(hours))
-        formattedDate.setMinutes(parseInt(minutes))
-        return formattedDate
-      } else {
-        return null
-      }
+      const formattedDate = new Date(this.resubmissionDate)
+      const [hours, minutes] = this.resubmissionTime.split(':')
+      formattedDate.setHours(parseInt(hours))
+      formattedDate.setMinutes(parseInt(minutes))
+      return formattedDate
     },
     onSubmit(mType) {
       this.loading = true
@@ -196,7 +192,8 @@ export default {
       return (
         (this.chatOrMemo === 0 && this.form.text === '') ||
         this.loading ||
-        (this.chatOrMemo === 1 && this.form.memo.length < 5)
+        (this.chatOrMemo === 1 && this.form.memo.length < 5) ||
+        (this.showResubmissionDate && !this.resubmissionDate)
       )
     },
     moderatorDisabled() {

--- a/admin/src/components/ContributionMessages/ContributionMessagesFormular.vue
+++ b/admin/src/components/ContributionMessages/ContributionMessagesFormular.vue
@@ -112,15 +112,10 @@ export default {
     combineResubmissionDateAndTime() {
       if (this.resubmissionDate) {
         const formattedDate = new Date(this.resubmissionDate)
-        console.log('resubmission time: %s', this.resubmissionTime)
         const [hours, minutes] = this.resubmissionTime.split(':')
-        console.log('hours: %s, minutes: %s', hours, minutes)
         formattedDate.setHours(parseInt(hours))
-        console.log('set hours: %d', formattedDate.getHours())
         formattedDate.setMinutes(parseInt(minutes))
-        console.log('set minutes: %d', formattedDate.getMinutes())
-        console.log('IOS String: %s', formattedDate.toISOString())
-        return formattedDate.toString()
+        return formattedDate
       } else {
         return null
       }
@@ -136,14 +131,18 @@ export default {
               message: this.form.text,
               messageType: mType,
               resubmissionAt: this.showResubmissionDate
-                ? this.combineResubmissionDateAndTime()
+                ? this.combineResubmissionDateAndTime().toString()
                 : null,
             },
           })
           .then((result) => {
-            this.$emit('get-list-contribution-messages', this.contributionId)
-            this.$emit('update-status', this.contributionId)
-            this.form.text = ''
+            if (this.showResubmissionDate && this.combineResubmissionDateAndTime() > new Date()) {
+              this.$emit('update-contributions')
+            } else {
+              this.$emit('get-list-contribution-messages', this.contributionId)
+              this.$emit('update-status', this.contributionId)
+            }
+            this.onReset()
             this.toastSuccess(this.$t('message.request'))
             this.loading = false
           })

--- a/admin/src/components/ContributionMessages/ContributionMessagesFormular.vue
+++ b/admin/src/components/ContributionMessages/ContributionMessagesFormular.vue
@@ -90,6 +90,10 @@ export default {
       type: String,
       required: true,
     },
+    hideResubmission: {
+      type: Boolean,
+      required: true,
+    },
   },
   data() {
     return {
@@ -136,7 +140,11 @@ export default {
             },
           })
           .then((result) => {
-            if (this.showResubmissionDate && this.combineResubmissionDateAndTime() > new Date()) {
+            if (
+              this.hideResubmission &&
+              this.showResubmissionDate &&
+              this.combineResubmissionDateAndTime() > new Date()
+            ) {
               this.$emit('update-contributions')
             } else {
               this.$emit('get-list-contribution-messages', this.contributionId)

--- a/admin/src/components/ContributionMessages/ContributionMessagesList.spec.js
+++ b/admin/src/components/ContributionMessages/ContributionMessagesList.spec.js
@@ -89,6 +89,7 @@ describe('ContributionMessagesList', () => {
     contributionMemo: 'test memo',
     contributionUserId: 108,
     contributionStatus: 'PENDING',
+    hideResubmission: true,
   }
 
   const mocks = {
@@ -153,6 +154,16 @@ describe('ContributionMessagesList', () => {
       it('emits reload-contribution', () => {
         expect(wrapper.emitted('reload-contribution')).toBeTruthy()
         expect(wrapper.emitted('reload-contribution')[0]).toEqual([3])
+      })
+    })
+
+    describe('test update-contributions', () => {
+      beforeEach(() => {
+        wrapper.vm.updateContributions()
+      })
+
+      it('emits update-contributions', () => {
+        expect(wrapper.emitted('update-contributions')).toBeTruthy()
       })
     })
   })

--- a/admin/src/components/ContributionMessages/ContributionMessagesList.vue
+++ b/admin/src/components/ContributionMessages/ContributionMessagesList.vue
@@ -12,6 +12,7 @@
       <contribution-messages-formular
         :contributionId="contributionId"
         :contributionMemo="contributionMemo"
+        :hideResubmission="hideResubmission"
         @get-list-contribution-messages="$apollo.queries.Messages.refetch()"
         @update-status="updateStatus"
         @reload-contribution="reloadContribution"
@@ -46,6 +47,10 @@ export default {
     },
     contributionUserId: {
       type: Number,
+      required: true,
+    },
+    hideResubmission: {
+      type: Boolean,
       required: true,
     },
   },

--- a/admin/src/components/ContributionMessages/ContributionMessagesList.vue
+++ b/admin/src/components/ContributionMessages/ContributionMessagesList.vue
@@ -15,6 +15,7 @@
         @get-list-contribution-messages="$apollo.queries.Messages.refetch()"
         @update-status="updateStatus"
         @reload-contribution="reloadContribution"
+        @update-contributions="updateContributions"
       />
     </div>
   </div>
@@ -78,6 +79,9 @@ export default {
     },
     reloadContribution(id) {
       this.$emit('reload-contribution', id)
+    },
+    updateContributions() {
+      this.$emit('update-contributions')
     },
   },
 }

--- a/admin/src/components/Tables/OpenCreationsTable.spec.js
+++ b/admin/src/components/Tables/OpenCreationsTable.spec.js
@@ -70,6 +70,7 @@ const propsData = {
     { key: 'confirm', label: 'save' },
   ],
   toggleDetails: false,
+  hideResubmission: true,
 }
 
 const mocks = {

--- a/admin/src/components/Tables/OpenCreationsTable.vue
+++ b/admin/src/components/Tables/OpenCreationsTable.vue
@@ -112,6 +112,7 @@
                 :contributionStatus="row.item.status"
                 :contributionUserId="row.item.userId"
                 :contributionMemo="row.item.memo"
+                :hideResubmission="hideResubmission"
                 @update-status="updateStatus"
                 @reload-contribution="reloadContribution"
                 @update-contributions="updateContributions"
@@ -153,6 +154,10 @@ export default {
     },
     fields: {
       type: Array,
+      required: true,
+    },
+    hideResubmission: {
+      type: Boolean,
       required: true,
     },
   },

--- a/admin/src/components/Tables/OpenCreationsTable.vue
+++ b/admin/src/components/Tables/OpenCreationsTable.vue
@@ -114,6 +114,7 @@
                 :contributionMemo="row.item.memo"
                 @update-status="updateStatus"
                 @reload-contribution="reloadContribution"
+                @update-contributions="updateContributions"
               />
             </div>
           </template>
@@ -175,6 +176,9 @@ export default {
     },
     reloadContribution(id) {
       this.$emit('reload-contribution', id)
+    },
+    updateContributions() {
+      this.$emit('update-contributions')
     },
   },
 }

--- a/admin/src/components/input/TimePicker.spec.js
+++ b/admin/src/components/input/TimePicker.spec.js
@@ -1,0 +1,63 @@
+import { mount } from '@vue/test-utils'
+import TimePicker from './TimePicker.vue'
+
+describe('TimePicker', () => {
+  it('updates timeValue on input and emits input event', async () => {
+    const wrapper = mount(TimePicker, {
+      propsData: {
+        value: '12:34', // Set an initial value for testing
+      },
+    })
+
+    const input = wrapper.find('input[type="text"]')
+
+    // Simulate user input
+    await input.setValue('23:45')
+
+    // Check if timeValue is updated
+    expect(wrapper.vm.timeValue).toBe('23:45')
+
+    // Check if input event is emitted with updated value
+    expect(wrapper.emitted().input).toBeTruthy()
+    expect(wrapper.emitted().input[0]).toEqual(['23:45'])
+  })
+
+  it('validates and corrects time format on blur', async () => {
+    const wrapper = mount(TimePicker)
+
+    const input = wrapper.find('input[type="text"]')
+
+    // Simulate user input
+    await input.setValue('99:99')
+    expect(wrapper.emitted().input).toBeTruthy()
+    expect(wrapper.emitted().input[0]).toEqual(['99:99'])
+
+    // Trigger blur event
+    await input.trigger('blur')
+
+    // Check if timeValue is corrected to valid format
+    expect(wrapper.vm.timeValue).toBe('23:59') // Maximum allowed value for hours and minutes
+
+    // Check if input event is emitted with corrected value
+    expect(wrapper.emitted().input).toBeTruthy()
+    expect(wrapper.emitted().input[1]).toEqual(['23:59'])
+  })
+
+  it('check handling of empty input', async () => {
+    const wrapper = mount(TimePicker)
+    const input = wrapper.find('input[type="text"]')
+
+    // Simulate user input with non-numeric characters
+    await input.setValue('')
+
+    // Trigger blur event
+    await input.trigger('blur')
+
+    // Check if non-numeric characters are filtered out
+    expect(wrapper.vm.timeValue).toBe('00:00')
+
+    // Check if input event is emitted with filtered value
+    expect(wrapper.emitted().input).toBeTruthy()
+    expect(wrapper.emitted().input[1]).toEqual(['00:00'])
+  })
+})

--- a/admin/src/components/input/TimePicker.vue
+++ b/admin/src/components/input/TimePicker.vue
@@ -36,8 +36,8 @@ export default {
       let [hours, minutes] = this.timeValue.split(':')
 
       // Validate hours and minutes
-      hours = Math.min(Math.max(parseInt(hours) || 0, 0), 23)
-      minutes = Math.min(Math.max(parseInt(minutes) || 0, 0), 59)
+      hours = Math.min(parseInt(hours) || 0, 23)
+      minutes = Math.min(parseInt(minutes) || 0, 59)
 
       // Update the value with correct format
       this.timeValue = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`

--- a/admin/src/components/input/TimePicker.vue
+++ b/admin/src/components/input/TimePicker.vue
@@ -1,0 +1,48 @@
+<template>
+  <div>
+    <input
+      type="text"
+      v-model="timeValue"
+      @input="updateValues"
+      @blur="validateAndCorrect"
+      placeholder="hh:mm"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  // Code written from chatGPT 3.5
+  name: 'TimePicker',
+  props: {
+    value: {
+      type: String,
+      default: '00:00',
+    },
+  },
+  data() {
+    return {
+      timeValue: this.value,
+    }
+  },
+  methods: {
+    updateValues(event) {
+      // Allow only numbers and ":"
+      const inputValue = event.target.value.replace(/[^0-9:]/g, '')
+      this.timeValue = inputValue
+      this.$emit('input', inputValue)
+    },
+    validateAndCorrect() {
+      let [hours, minutes] = this.timeValue.split(':')
+
+      // Validate hours and minutes
+      hours = Math.min(Math.max(parseInt(hours) || 0, 0), 23)
+      minutes = Math.min(Math.max(parseInt(minutes) || 0, 0), 59)
+
+      // Update the value with correct format
+      this.timeValue = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`
+      this.$emit('input', this.timeValue)
+    },
+  },
+}
+</script>

--- a/admin/src/graphql/adminCreateContributionMessage.js
+++ b/admin/src/graphql/adminCreateContributionMessage.js
@@ -1,11 +1,17 @@
 import gql from 'graphql-tag'
 
 export const adminCreateContributionMessage = gql`
-  mutation ($contributionId: Int!, $message: String!, $messageType: ContributionMessageType) {
+  mutation (
+    $contributionId: Int!
+    $message: String!
+    $messageType: ContributionMessageType
+    $resubmissionAt: String
+  ) {
     adminCreateContributionMessage(
       contributionId: $contributionId
       message: $message
       messageType: $messageType
+      resubmissionAt: $resubmissionAt
     ) {
       id
       message

--- a/admin/src/graphql/adminListContributions.js
+++ b/admin/src/graphql/adminListContributions.js
@@ -9,6 +9,7 @@ export const adminListContributions = gql`
     $userId: Int
     $query: String
     $noHashtag: Boolean
+    $hideResubmission: Boolean
   ) {
     adminListContributions(
       currentPage: $currentPage
@@ -18,6 +19,7 @@ export const adminListContributions = gql`
       userId: $userId
       query: $query
       noHashtag: $noHashtag
+      hideResubmission: $hideResubmission
     ) {
       contributionCount
       contributionList {

--- a/admin/src/locales/de.json
+++ b/admin/src/locales/de.json
@@ -99,6 +99,8 @@
     }
   },
   "hide_details": "Details verbergen",
+  "hide_resubmission": "Wiedervorlage verbergen",
+  "hide_resubmission_tooltip": "Verbirgt alle Schöpfungen für die ein Moderator ein Erinnerungsdatum festgelegt hat.",
   "lastname": "Nachname",
   "math": {
     "equals": "=",
@@ -111,6 +113,7 @@
   "moderator": {
     "chat": "Chat",
     "history": "Die Daten wurden geändert. Dies sind die alten Daten.",
+    "show-submission-form": "warten auf Erinnerung?",
     "moderator": "Moderator",
     "notice": "Moderator Notiz",
     "memo": "Memo",

--- a/admin/src/locales/en.json
+++ b/admin/src/locales/en.json
@@ -99,6 +99,8 @@
     }
   },
   "hide_details": "Hide details",
+  "hide_resubmission": "Hide resubmission",
+  "hide_resubmission_tooltip": "Hides all creations for which a moderator has set a reminder date.",
   "lastname": "Lastname",
   "math": {
     "equals": "=",
@@ -111,6 +113,7 @@
   "moderator": {
     "chat": "Chat",
     "history": "The data has been changed. This is the old data.",
+    "show-submission-form": "wait for reminder?",
     "moderator": "Moderator",
     "notice": "Moderator note",
     "memo": "Memo",

--- a/admin/src/pages/CreationConfirm.spec.js
+++ b/admin/src/pages/CreationConfirm.spec.js
@@ -347,6 +347,7 @@ describe('CreationConfirm', () => {
         it('refetches contributions with proper filter', () => {
           expect(adminListContributionsMock).toBeCalledWith({
             currentPage: 1,
+            hideResubmission: false,
             noHashtag: null,
             order: 'DESC',
             pageSize: 25,
@@ -364,6 +365,7 @@ describe('CreationConfirm', () => {
           it('refetches contributions with proper filter', () => {
             expect(adminListContributionsMock).toBeCalledWith({
               currentPage: 1,
+              hideResubmission: true,
               noHashtag: null,
               order: 'DESC',
               pageSize: 25,
@@ -382,6 +384,7 @@ describe('CreationConfirm', () => {
           it('refetches contributions with proper filter', () => {
             expect(adminListContributionsMock).toBeCalledWith({
               currentPage: 1,
+              hideResubmission: false,
               noHashtag: null,
               order: 'DESC',
               pageSize: 25,
@@ -400,6 +403,7 @@ describe('CreationConfirm', () => {
           it('refetches contributions with proper filter', () => {
             expect(adminListContributionsMock).toBeCalledWith({
               currentPage: 1,
+              hideResubmission: false,
               noHashtag: null,
               order: 'DESC',
               pageSize: 25,
@@ -418,6 +422,7 @@ describe('CreationConfirm', () => {
           it('refetches contributions with proper filter', () => {
             expect(adminListContributionsMock).toBeCalledWith({
               currentPage: 1,
+              hideResubmission: false,
               noHashtag: null,
               order: 'DESC',
               pageSize: 25,
@@ -440,6 +445,7 @@ describe('CreationConfirm', () => {
               it('calls the API again', () => {
                 expect(adminListContributionsMock).toBeCalledWith({
                   currentPage: 2,
+                  hideResubmission: false,
                   noHashtag: null,
                   order: 'DESC',
                   pageSize: 25,
@@ -457,6 +463,7 @@ describe('CreationConfirm', () => {
                 it('refetches contributions with proper filter and current page = 1', () => {
                   expect(adminListContributionsMock).toBeCalledWith({
                     currentPage: 1,
+                    hideResubmission: true,
                     noHashtag: null,
                     order: 'DESC',
                     pageSize: 25,
@@ -480,6 +487,7 @@ describe('CreationConfirm', () => {
         it('calls the API with query', () => {
           expect(adminListContributionsMock).toBeCalledWith({
             currentPage: 1,
+            hideResubmission: true,
             noHashtag: null,
             order: 'DESC',
             pageSize: 25,
@@ -496,6 +504,7 @@ describe('CreationConfirm', () => {
           it('calls the API with empty query', () => {
             expect(adminListContributionsMock).toBeCalledWith({
               currentPage: 1,
+              hideResubmission: true,
               noHashtag: null,
               order: 'DESC',
               pageSize: 25,

--- a/admin/src/pages/CreationConfirm.vue
+++ b/admin/src/pages/CreationConfirm.vue
@@ -6,8 +6,8 @@
       <input type="checkbox" class="noHashtag" v-model="noHashtag" />
       <span class="ml-2" v-b-tooltip="$t('no_hashtag_tooltip')">{{ $t('no_hashtag') }}</span>
     </p>
-    <p class="mb-4">
-      <input type="checkbox" class="hideResubmission" v-model="hideResubmission" />
+    <p class="mb-4" v-if="showResubmissionCheckbox">
+      <input type="checkbox" class="hideResubmission" v-model="hideResubmissionModel" />
       <span class="ml-2" v-b-tooltip="$t('hide_resubmission_tooltip')">
         {{ $t('hide_resubmission') }}
       </span>
@@ -132,7 +132,7 @@ export default {
       pageSize: 25,
       query: '',
       noHashtag: null,
-      hideResubmission: true,
+      hideResubmissionModel: true,
     }
   },
   watch: {
@@ -432,6 +432,12 @@ export default {
         default:
           return 'info'
       }
+    },
+    showResubmissionCheckbox() {
+      return this.tabIndex === 0
+    },
+    hideResubmission() {
+      return this.showResubmissionCheckbox ? this.hideResubmissionModel : false
     },
   },
   apollo: {

--- a/admin/src/pages/CreationConfirm.vue
+++ b/admin/src/pages/CreationConfirm.vue
@@ -2,10 +2,16 @@
 <template>
   <div class="creation-confirm">
     <user-query class="mb-2 mt-2" v-model="query" :placeholder="$t('user_memo_search')" />
-    <label class="mb-4">
+    <p class="mb-2">
       <input type="checkbox" class="noHashtag" v-model="noHashtag" />
       <span class="ml-2" v-b-tooltip="$t('no_hashtag_tooltip')">{{ $t('no_hashtag') }}</span>
-    </label>
+    </p>
+    <p class="mb-4">
+      <input type="checkbox" class="hideResubmission" v-model="hideResubmission" />
+      <span class="ml-2" v-b-tooltip="$t('hide_resubmission_tooltip')">
+        {{ $t('hide_resubmission') }}
+      </span>
+    </p>
     <div>
       <b-tabs v-model="tabIndex" content-class="mt-3" fill>
         <b-tab active :title-link-attributes="{ 'data-test': 'open' }">
@@ -125,6 +131,7 @@ export default {
       pageSize: 25,
       query: '',
       noHashtag: null,
+      hideResubmission: true,
     }
   },
   watch: {
@@ -438,6 +445,7 @@ export default {
           statusFilter: this.statusFilter,
           query: this.query,
           noHashtag: this.noHashtag,
+          hideResubmission: this.hideResubmission,
         }
       },
       fetchPolicy: 'no-cache',

--- a/admin/src/pages/CreationConfirm.vue
+++ b/admin/src/pages/CreationConfirm.vue
@@ -53,6 +53,7 @@
       class="mt-4"
       :items="items"
       :fields="fields"
+      :hideResubmission="hideResubmission"
       @show-overlay="showOverlay"
       @update-status="updateStatus"
       @reload-contribution="reloadContribution"

--- a/admin/src/pages/Overview.spec.js
+++ b/admin/src/pages/Overview.spec.js
@@ -116,6 +116,7 @@ describe('Overview', () => {
     it('calls the adminListContributions query', () => {
       expect(adminListContributionsMock).toBeCalledWith({
         currentPage: 1,
+        hideResubmission: true,
         order: 'DESC',
         pageSize: 25,
         statusFilter: ['IN_PROGRESS', 'PENDING'],

--- a/admin/src/pages/Overview.vue
+++ b/admin/src/pages/Overview.vue
@@ -49,6 +49,7 @@ export default {
         // may be at some point we need a pagination here
         return {
           statusFilter: this.statusFilter,
+          hideResubmission: true,
         }
       },
       update({ adminListContributions }) {

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -12,7 +12,7 @@ Decimal.set({
 })
 
 const constants = {
-  DB_VERSION: '0076-add_updated_by_contribution',
+  DB_VERSION: '0077-add_resubmission_date_contribution_message',
   DECAY_START_TIME: new Date('2021-05-13 17:46:31-0000'), // GMT+0
   LOG4JS_CONFIG: 'log4js-config.json',
   // default log level on production should be info

--- a/backend/src/data/ContributionMessage.builder.ts
+++ b/backend/src/data/ContributionMessage.builder.ts
@@ -43,9 +43,7 @@ export class ContributionMessageBuilder {
 
   public setParentContribution(contribution: Contribution): this {
     this.contributionMessage.contributionId = contribution.id
-    this.contributionMessage.createdAt = contribution.updatedAt
-      ? contribution.updatedAt
-      : contribution.createdAt
+    this.contributionMessage.contribution = contribution
     return this
   }
 

--- a/backend/src/graphql/arg/ContributionMessageArgs.ts
+++ b/backend/src/graphql/arg/ContributionMessageArgs.ts
@@ -1,3 +1,4 @@
+import { isValidDateString } from '@/graphql/validator/DateString'
 import { IsInt, IsString, IsEnum } from 'class-validator'
 import { ArgsType, Field, Int, InputType } from 'type-graphql'
 
@@ -17,4 +18,8 @@ export class ContributionMessageArgs {
   @Field(() => ContributionMessageType, { defaultValue: ContributionMessageType.DIALOG })
   @IsEnum(ContributionMessageType)
   messageType: ContributionMessageType
+
+  @Field(() => String, { nullable: true })
+  @isValidDateString()
+  resubmissionAt?: string | null
 }

--- a/backend/src/graphql/arg/ContributionMessageArgs.ts
+++ b/backend/src/graphql/arg/ContributionMessageArgs.ts
@@ -1,8 +1,9 @@
-import { isValidDateString } from '@/graphql/validator/DateString'
 import { IsInt, IsString, IsEnum } from 'class-validator'
 import { ArgsType, Field, Int, InputType } from 'type-graphql'
 
 import { ContributionMessageType } from '@enum/ContributionMessageType'
+
+import { isValidDateString } from '@/graphql/validator/DateString'
 
 @InputType()
 @ArgsType()

--- a/backend/src/graphql/arg/SearchContributionsFilterArgs.ts
+++ b/backend/src/graphql/arg/SearchContributionsFilterArgs.ts
@@ -22,4 +22,8 @@ export class SearchContributionsFilterArgs {
   @Field(() => Boolean, { nullable: true })
   @IsBoolean()
   noHashtag?: boolean | null
+
+  @Field(() => Boolean, { nullable: true })
+  @IsBoolean()
+  hideResubmission?: boolean | null
 }

--- a/backend/src/graphql/resolver/ContributionMessageResolver.ts
+++ b/backend/src/graphql/resolver/ContributionMessageResolver.ts
@@ -125,7 +125,7 @@ export class ContributionMessageResolver {
   @Authorized([RIGHTS.ADMIN_CREATE_CONTRIBUTION_MESSAGE])
   @Mutation(() => ContributionMessage)
   async adminCreateContributionMessage(
-    @Args() { contributionId, message, messageType }: ContributionMessageArgs,
+    @Args() { contributionId, message, messageType, resubmissionAt }: ContributionMessageArgs,
     @Ctx() context: Context,
   ): Promise<ContributionMessage> {
     const moderator = getUser(context)
@@ -156,6 +156,9 @@ export class ContributionMessageResolver {
       contributionMessage.userId = moderator.id
       contributionMessage.type = messageType
       contributionMessage.isModerator = true
+      if (resubmissionAt) {
+        contributionMessage.resubmissionAt = new Date(resubmissionAt)
+      }
       await queryRunner.manager.insert(DbContributionMessage, contributionMessage)
 
       if (messageType !== ContributionMessageType.MODERATOR) {

--- a/backend/src/graphql/resolver/util/findContributions.ts
+++ b/backend/src/graphql/resolver/util/findContributions.ts
@@ -1,6 +1,6 @@
 /* eslint-disable security/detect-object-injection */
-import { Brackets, In, IsNull, LessThanOrEqual, Like, MoreThan, Not, SelectQueryBuilder } from '@dbTools/typeorm'
-import { Contribution, Contribution as DbContribution } from '@entity/Contribution'
+import { Brackets, In, Like, Not, SelectQueryBuilder } from '@dbTools/typeorm'
+import { Contribution as DbContribution } from '@entity/Contribution'
 import { ContributionMessage } from '@entity/ContributionMessage'
 
 import { Paginated } from '@arg/Paginated'
@@ -20,7 +20,6 @@ function joinRelationsRecursive(
   currentPath: string,
 ): void {
   for (const key in relations) {
-    // console.log('leftJoin: %s, %s', `${currentPath}.${key}`, key)
     queryBuilder.leftJoinAndSelect(`${currentPath}.${key}`, key)
     if (typeof relations[key] === 'object') {
       // If it's a nested relation

--- a/database/entity/0077-add_resubmission_date_contribution_message/ContributionMessage.ts
+++ b/database/entity/0077-add_resubmission_date_contribution_message/ContributionMessage.ts
@@ -1,12 +1,14 @@
 import {
   BaseEntity,
   Column,
+  CreateDateColumn,
   DeleteDateColumn,
   Entity,
   Index,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
+  UpdateDateColumn,
 } from 'typeorm'
 import { Contribution } from '../Contribution'
 import { User } from '../User'
@@ -36,9 +38,11 @@ export class ContributionMessage extends BaseEntity {
   @Column({ length: 2000, nullable: false, collation: 'utf8mb4_unicode_ci' })
   message: string
 
+  @CreateDateColumn()
   @Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP', name: 'created_at' })
   createdAt: Date
 
+  @UpdateDateColumn()
   @Column({ type: 'datetime', default: null, nullable: true, name: 'updated_at' })
   updatedAt: Date
 

--- a/database/entity/0077-add_resubmission_date_contribution_message/ContributionMessage.ts
+++ b/database/entity/0077-add_resubmission_date_contribution_message/ContributionMessage.ts
@@ -1,0 +1,59 @@
+import {
+  BaseEntity,
+  Column,
+  DeleteDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm'
+import { Contribution } from '../Contribution'
+import { User } from '../User'
+
+@Entity('contribution_messages', {
+  engine: 'InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci',
+})
+export class ContributionMessage extends BaseEntity {
+  @PrimaryGeneratedColumn('increment', { unsigned: true })
+  id: number
+
+  @Index()
+  @Column({ name: 'contribution_id', unsigned: true, nullable: false })
+  contributionId: number
+
+  @ManyToOne(() => Contribution, (contribution) => contribution.messages)
+  @JoinColumn({ name: 'contribution_id' })
+  contribution: Contribution
+
+  @Column({ name: 'user_id', unsigned: true, nullable: false })
+  userId: number
+
+  @ManyToOne(() => User, (user) => user.messages)
+  @JoinColumn({ name: 'user_id' })
+  user: User
+
+  @Column({ length: 2000, nullable: false, collation: 'utf8mb4_unicode_ci' })
+  message: string
+
+  @Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP', name: 'created_at' })
+  createdAt: Date
+
+  @Column({ type: 'datetime', default: null, nullable: true, name: 'updated_at' })
+  updatedAt: Date
+
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deletedAt: Date | null
+
+  @Column({ name: 'deleted_by', default: null, unsigned: true, nullable: true })
+  deletedBy: number
+
+  @Column({ type: 'datetime', name: 'resubmission_at', default: null, nullable: true })
+  resubmissionAt: Date | null
+
+  @Column({ length: 12, nullable: false, collation: 'utf8mb4_unicode_ci' })
+  type: string
+
+  @Column({ name: 'is_moderator', type: 'bool', nullable: false, default: false })
+  isModerator: boolean
+}

--- a/database/entity/ContributionMessage.ts
+++ b/database/entity/ContributionMessage.ts
@@ -1,1 +1,1 @@
-export { ContributionMessage } from './0075-contribution_message_add_index/ContributionMessage'
+export { ContributionMessage } from './0077-add_resubmission_date_contribution_message/ContributionMessage'

--- a/database/migrations/0077-add_resubmission_date_contribution_message.ts
+++ b/database/migrations/0077-add_resubmission_date_contribution_message.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function upgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  await queryFn(
+    `ALTER TABLE \`contribution_messages\` ADD COLUMN \`resubmission_at\` datetime NULL DEFAULT NULL AFTER \`deleted_by\`;`,
+  )
+}
+
+export async function downgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  await queryFn(`ALTER TABLE \`contribution_messages\` DROP COLUMN \`resubmission_at\`;`)
+}

--- a/dht-node/src/config/index.ts
+++ b/dht-node/src/config/index.ts
@@ -4,7 +4,7 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 const constants = {
-  DB_VERSION: '0076-add_updated_by_contribution',
+  DB_VERSION: '0077-add_resubmission_date_contribution_message',
   LOG4JS_CONFIG: 'log4js-config.json',
   // default log level on production should be info
   LOG_LEVEL: process.env.LOG_LEVEL || 'info',

--- a/federation/src/config/index.ts
+++ b/federation/src/config/index.ts
@@ -10,7 +10,7 @@ Decimal.set({
 })
 
 const constants = {
-  DB_VERSION: '0076-add_updated_by_contribution',
+  DB_VERSION: '0077-add_resubmission_date_contribution_message',
   DECAY_START_TIME: new Date('2021-05-13 17:46:31-0000'), // GMT+0
   LOG4JS_CONFIG: 'log4js-config.json',
   // default log level on production should be info

--- a/frontend/src/components/ContributionMessages/ContributionMessagesListItem.vue
+++ b/frontend/src/components/ContributionMessages/ContributionMessagesListItem.vue
@@ -4,8 +4,11 @@
       <b-row class="mb-3 border border-197 p-1">
         <b-col cols="10">
           <small>{{ $d(new Date(message.createdAt), 'short') }}</small>
-          <div class="font-weight-bold" data-test="username">
+          <div class="font-weight-bold" data-test="username" v-if="isNotModerator">
             {{ storeName.username }} {{ $t('contribution.isEdited') }}
+          </div>
+          <div class="font-weight-bold" data-test="moderator-name" v-else>
+            {{ $t('community.moderator') }} {{ $t('contribution.isEdited') }}
           </div>
           <div class="small">
             {{ $t('contribution.oldContribution') }}


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
Select a date on which the contribution should be displayed again. Until then it will be hidden in default mode. But you can display it at any time by unchecking the checkbox for resubmission. 

- update findContributions query builder 
- add checkbox to admin underneath checkbox for hashtag
- add signal which will be emitted after adding comment to contribution which set resubmission date for updating contribution list
- add resubmission_at date to contribution_messages table and entity and ContributionMessageArgs
- add props to ContributionMessagesFormular for accessing checkbox for hiding resubmission to only update contribution list after adding resubmission date if resubmission should be hided 
- update frontend to show "moderator has edited contribution" in histories messages if messages was created from moderator