### PR TITLE
fix(other): deployment bugfixes

### DIFF
--- a/deployment/bare_metal/nginx/common/limit_requests.conf
+++ b/deployment/bare_metal/nginx/common/limit_requests.conf
@@ -1,3 +1,4 @@
 limit_req_zone $binary_remote_addr zone=frontend:20m rate=5r/s;
 limit_req_zone $binary_remote_addr zone=backend:25m rate=15r/s;
 limit_req_zone $binary_remote_addr zone=api:5m rate=30r/s;
+limit_conn_zone $binary_remote_addr zone=addr:10m;

--- a/deployment/bare_metal/nginx/sites-available/gradido.conf.ssl.template
+++ b/deployment/bare_metal/nginx/sites-available/gradido.conf.ssl.template
@@ -1,3 +1,5 @@
+include /etc/nginx/common/limit_requests.conf;
+
 server {
     if ($host = $COMMUNITY_HOST) {
         return 301 https://$host$request_uri;
@@ -21,7 +23,6 @@ server {
 
     include /etc/nginx/common/protect.conf;
     include /etc/nginx/common/protect_add_header.conf;
-    include /etc/nginx/common/limit_requests.conf;
 
     # protect from slow loris
     client_body_timeout 10s;

--- a/deployment/bare_metal/nginx/sites-available/gradido.conf.template
+++ b/deployment/bare_metal/nginx/sites-available/gradido.conf.template
@@ -1,3 +1,5 @@
+include /etc/nginx/common/limit_requests.conf;
+
 server {
     server_name $COMMUNITY_HOST;
 
@@ -6,7 +8,6 @@ server {
 
     include /etc/nginx/common/protect.conf;
     include /etc/nginx/common/protect_add_header.conf;
-    include /etc/nginx/common/limit_requests.conf;
 
     # protect from slow loris
     client_body_timeout 10s;

--- a/deployment/bare_metal/nginx/sites-available/update-page.conf.ssl.template
+++ b/deployment/bare_metal/nginx/sites-available/update-page.conf.ssl.template
@@ -1,3 +1,4 @@
+include /etc/nginx/common/limit_requests.conf;
 
 server {
     if ($host = $COMMUNITY_HOST) {
@@ -21,7 +22,6 @@ server {
 
     include /etc/nginx/common/protect.conf;
     include /etc/nginx/common/protect_add_header.conf;
-    include /etc/nginx/common/limit_requests.conf;
 
     # protect from slow loris
     client_body_timeout 10s;

--- a/deployment/bare_metal/nginx/sites-available/update-page.conf.template
+++ b/deployment/bare_metal/nginx/sites-available/update-page.conf.template
@@ -1,3 +1,4 @@
+include /etc/nginx/common/limit_requests.conf;
 
 server {
     server_name $COMMUNITY_HOST;
@@ -6,7 +7,6 @@ server {
 
     include /etc/nginx/common/protect.conf;
     include /etc/nginx/common/protect_add_header.conf;
-    include /etc/nginx/common/limit_requests.conf;
 
     # protect from slow loris
     client_body_timeout 10s;

--- a/deployment/hetzner_cloud/cloudConfig.yaml
+++ b/deployment/hetzner_cloud/cloudConfig.yaml
@@ -9,6 +9,7 @@ users:
 
 packages:
   - fail2ban
+  - python3-systemd
   - ufw
   - git
   - mariadb-server

--- a/deployment/hetzner_cloud/install.sh
+++ b/deployment/hetzner_cloud/install.sh
@@ -80,6 +80,14 @@ expect eof
 ")
 echo "$SECURE_MYSQL"
 
+# Configure fail2ban, seems to not run out of the box on Debian 12
+echo -e "[sshd]\nbackend = systemd" | tee /etc/fail2ban/jail.d/sshd.conf
+# enable nginx-limit-req filter to block also user which exceed nginx request limiter
+echo -e "[nginx-limit-req]\nenabled = true\nlogpath  = $SCRIPT_PATH/log/nginx-error.*.log" | tee /etc/fail2ban/jail.d/nginx-limit-req.conf
+# enable nginx bad request filter 
+echo -e "[nginx-bad-request]\nenabled = true\nlogpath  = $SCRIPT_PATH/log/nginx-error.*.log" | tee /etc/fail2ban/jail.d/nginx-bad-request.conf
+systemctl restart fail2ban
+
 # Configure nginx
 rm /etc/nginx/sites-enabled/default
 envsubst "$(env | sed -e 's/=.*//' -e 's/^/\$/g')" < $SCRIPT_PATH/nginx/sites-available/gradido.conf.template > $SCRIPT_PATH/nginx/sites-available/gradido.conf


### PR DESCRIPTION
- correct position of include /etc/nginx/common/limit_requests.conf; cannot be inside server, at lest in newer nginx version
- fix fail2ban, don't start out of the box on debian 12
- fail2ban, enable nginx-bad-request and nginx-limit-req filter