### PR TITLE
fix(backend): prevent running validate communities continuous

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -128,7 +128,8 @@ if (
 
 const federation = {
   FEDERATION_BACKEND_SEND_ON_API: process.env.FEDERATION_BACKEND_SEND_ON_API ?? '1_0',
-  FEDERATION_VALIDATE_COMMUNITY_TIMER: // ?? operator don't work here as expected
+  // ?? operator don't work here as expected
+  FEDERATION_VALIDATE_COMMUNITY_TIMER:
     Number(process.env.FEDERATION_VALIDATE_COMMUNITY_TIMER) || 60000,
   FEDERATION_XCOM_SENDCOINS_ENABLED:
     process.env.FEDERATION_XCOM_SENDCOINS_ENABLED === 'true' ?? false,

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -130,7 +130,7 @@ const federation = {
   FEDERATION_BACKEND_SEND_ON_API: process.env.FEDERATION_BACKEND_SEND_ON_API ?? '1_0',
   // ?? operator don't work here as expected
   FEDERATION_VALIDATE_COMMUNITY_TIMER:
-    Number(process.env.FEDERATION_VALIDATE_COMMUNITY_TIMER) || 60000,
+    Number(process.env.FEDERATION_VALIDATE_COMMUNITY_TIMER ?? 60000) ,
   FEDERATION_XCOM_SENDCOINS_ENABLED:
     process.env.FEDERATION_XCOM_SENDCOINS_ENABLED === 'true' ?? false,
   // default value for community-uuid is equal uuid of stage-3

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -128,8 +128,8 @@ if (
 
 const federation = {
   FEDERATION_BACKEND_SEND_ON_API: process.env.FEDERATION_BACKEND_SEND_ON_API ?? '1_0',
-  FEDERATION_VALIDATE_COMMUNITY_TIMER:
-    Number(process.env.FEDERATION_VALIDATE_COMMUNITY_TIMER) ?? 60000,
+  FEDERATION_VALIDATE_COMMUNITY_TIMER: // ?? operator don't work here as expected
+    Number(process.env.FEDERATION_VALIDATE_COMMUNITY_TIMER) || 60000,
   FEDERATION_XCOM_SENDCOINS_ENABLED:
     process.env.FEDERATION_XCOM_SENDCOINS_ENABLED === 'true' ?? false,
   // default value for community-uuid is equal uuid of stage-3

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -129,8 +129,9 @@ if (
 const federation = {
   FEDERATION_BACKEND_SEND_ON_API: process.env.FEDERATION_BACKEND_SEND_ON_API ?? '1_0',
   // ?? operator don't work here as expected
-  FEDERATION_VALIDATE_COMMUNITY_TIMER:
-    Number(process.env.FEDERATION_VALIDATE_COMMUNITY_TIMER ?? 60000) ,
+  FEDERATION_VALIDATE_COMMUNITY_TIMER: Number(
+    process.env.FEDERATION_VALIDATE_COMMUNITY_TIMER ?? 60000,
+  ),
   FEDERATION_XCOM_SENDCOINS_ENABLED:
     process.env.FEDERATION_XCOM_SENDCOINS_ENABLED === 'true' ?? false,
   // default value for community-uuid is equal uuid of stage-3

--- a/backend/src/federation/validateCommunities.ts
+++ b/backend/src/federation/validateCommunities.ts
@@ -13,8 +13,12 @@ import { backendLogger as logger } from '@/server/logger'
 import { startCommunityAuthentication } from './authenticateCommunities'
 import { PublicCommunityInfoLoggingView } from './client/1_0/logging/PublicCommunityInfoLogging.view'
 import { ApiVersionType } from './enum/apiVersionType'
+import { LogError } from '@/server/LogError'
 
 export async function startValidateCommunities(timerInterval: number): Promise<void> {
+  if (Number.isNaN(timerInterval) || timerInterval <= 0) {
+    throw new LogError('FEDERATION_VALIDATE_COMMUNITY_TIMER is not a positive number')
+  }
   logger.info(
     `Federation: startValidateCommunities loop with an interval of ${timerInterval} ms...`,
   )

--- a/backend/src/federation/validateCommunities.ts
+++ b/backend/src/federation/validateCommunities.ts
@@ -8,12 +8,12 @@ import { FederatedCommunityLoggingView } from '@logging/FederatedCommunityLoggin
 import { FederationClient as V1_0_FederationClient } from '@/federation/client/1_0/FederationClient'
 import { PublicCommunityInfo } from '@/federation/client/1_0/model/PublicCommunityInfo'
 import { FederationClientFactory } from '@/federation/client/FederationClientFactory'
+import { LogError } from '@/server/LogError'
 import { backendLogger as logger } from '@/server/logger'
 
 import { startCommunityAuthentication } from './authenticateCommunities'
 import { PublicCommunityInfoLoggingView } from './client/1_0/logging/PublicCommunityInfoLogging.view'
 import { ApiVersionType } from './enum/apiVersionType'
-import { LogError } from '@/server/LogError'
 
 export async function startValidateCommunities(timerInterval: number): Promise<void> {
   if (Number.isNaN(timerInterval) || timerInterval <= 0) {


### PR DESCRIPTION
## 🍰 Pullrequest
FEDERATION_VALIDATE_COMMUNITY_TIMER: 
    Number(process.env.FEDERATION_VALIDATE_COMMUNITY_TIMER) `??`  60000,
  
lead to FEDERATION_VALIDATE_COMMUNITY_TIMER = NaN if process.env.FEDERATION_VALIDATE_COMMUNITY_TIMER wasn't set. That lead to continuously running validate communities, put one CPU Core to 100% all time and fill the hdd with logs.

So to prevent this, changing back FEDERATION_VALIDATE_COMMUNITY_TIMER: 
    Number(process.env.FEDERATION_VALIDATE_COMMUNITY_TIMER) `||` 60000
and add additional check for positive number before running validate communities.
