### PR TITLE
fix(other): add GMS_ACTIVE and GMS_URL to deploy .env.dist

### DIFF
--- a/deployment/bare_metal/.env.dist
+++ b/deployment/bare_metal/.env.dist
@@ -120,7 +120,7 @@ DEFAULT_PUBLISHER_ID=2896
 WEBHOOK_ELOPAGE_SECRET=secret
 
 # GMS
-#GMS_ACTIVE=true
+GMS_ACTIVE=false
 # Coordinates of Illuminz test instance
 #GMS_URL=http://54.176.169.179:3071
-#GMS_URL=http://localhost:4044/
+GMS_URL=http://localhost:4044/


### PR DESCRIPTION
Every Option in one of the .env.templates written this way:
`NEW_OPTION=$NEW_OPTION`
Must have an entry like this in deployment/bare_metal/.env.dist with there default value
`NEW_OPTION=false`

Especially for the vue modules.
If this is missing, on running start.sh 
`NEW_OPTION=$NEW_OPTION`
will be copied in .env, leading to this build error:

![grafik](https://github.com/gradido/gradido/assets/67117805/dd47e0f3-276f-4834-9758-a0c1fee588d4)
