### PR TITLE
feat(frontend): more compatible humhub auto-login link

### DIFF
--- a/backend/src/apis/humhub/HumHubClient.ts
+++ b/backend/src/apis/humhub/HumHubClient.ts
@@ -65,7 +65,7 @@ export class HumHubClient {
     const token = await new SignJWT({ username })
       .setProtectedHeader({ alg: 'HS256' })
       .setIssuedAt()
-      .setExpirationTime('2m')
+      .setExpirationTime(CONFIG.JWT_EXPIRES_IN)
       .sign(secret)
 
     return `${CONFIG.HUMHUB_API_URL}user/auth/external?authclient=jwt&jwt=${token}`

--- a/backend/src/apis/humhub/model/Profile.ts
+++ b/backend/src/apis/humhub/model/Profile.ts
@@ -10,11 +10,7 @@ export class Profile {
     const publishNameLogic = new PublishNameLogic(user)
     this.firstname = publishNameLogic.getFirstName(user.humhubPublishName as PublishNameType)
     this.lastname = publishNameLogic.getLastName(user.humhubPublishName as PublishNameType)
-    if (user.alias && user.alias.length > 2) {
-      this.gradido_address = CONFIG.COMMUNITY_NAME + '/' + user.alias
-    } else {
-      this.gradido_address = CONFIG.COMMUNITY_NAME + '/' + user.gradidoID
-    }
+    this.gradido_address = CONFIG.COMMUNITY_NAME + '/' + user.gradidoID
   }
 
   firstname: string

--- a/backend/src/graphql/resolver/UserResolver.ts
+++ b/backend/src/graphql/resolver/UserResolver.ts
@@ -203,8 +203,13 @@ export class UserResolver {
     await EVENT_USER_LOGIN(dbUser)
     // load humhub state
     if (humhubUserPromise) {
-      const result = await humhubUserPromise
-      user.humhubAllowed = result?.result?.account.status === 1
+      try {
+        const result = await humhubUserPromise
+        user.humhubAllowed = result?.result?.account.status === 1
+      } catch (e) {
+        logger.error("couldn't reach out to humhub, disable for now", e)
+        user.humhubAllowed = false
+      }
     }
     user.klickTipp = await klicktippStatePromise
     logger.info(`successful Login: ${JSON.stringify(user, null, 2)}`)

--- a/frontend/src/pages/Circles.spec.js
+++ b/frontend/src/pages/Circles.spec.js
@@ -1,0 +1,84 @@
+import { mount } from '@vue/test-utils'
+import Circles from './Circles'
+import { authenticateHumhubAutoLogin } from '@/graphql/queries'
+
+const localVue = global.localVue
+
+const TEST_URL_WITH_JWT_TOKEN =
+  'https://community.gradido.net/user/auth/external?authclient=jwt&jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTY4NTI0NjQxMn0.V2h4Rf3LfdOYDsx2clVCx-jbhKoY5F4Ks5-YJGVtHRk'
+
+const apolloQueryMock = jest.fn().mockResolvedValue({
+  data: {
+    authenticateHumhubAutoLogin: TEST_URL_WITH_JWT_TOKEN,
+  },
+})
+
+describe('Circles', () => {
+  let wrapper
+
+  const mocks = {
+    $t: jest.fn((t) => t),
+    $n: jest.fn(),
+    $i18n: {
+      locale: 'en',
+    },
+    $apollo: {
+      query: apolloQueryMock,
+    },
+    $store: {
+      state: {
+        humhubAllowed: true,
+      },
+      commit: jest.fn(),
+    },
+  }
+
+  const Wrapper = () => {
+    return mount(Circles, {
+      localVue,
+      mocks,
+    })
+  }
+
+  describe('mount', () => {
+    beforeEach(() => {
+      wrapper = Wrapper()
+    })
+
+    it('renders the circles page', () => {
+      expect(wrapper.find('div.circles').exists()).toBeTruthy()
+    })
+
+    it('calls authenticateHumhubAutoLogin', () => {
+      expect(apolloQueryMock).toBeCalledWith(
+        expect.objectContaining({
+          query: authenticateHumhubAutoLogin,
+          fetchPolicy: 'network-only',
+        }),
+      )
+    })
+
+    it('sets humhubUri and enables button on success', async () => {
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.humhubUri).toBe(TEST_URL_WITH_JWT_TOKEN)
+      expect(wrapper.vm.enableButton).toBe(true)
+    })
+
+    describe('error apolloQueryMock', () => {
+      beforeEach(async () => {
+        jest.clearAllMocks()
+        apolloQueryMock.mockRejectedValue({
+          message: 'uups',
+        })
+        wrapper = Wrapper()
+        await wrapper.vm.$nextTick()
+      })
+
+      it('toasts an error message and disables humhub', () => {
+        expect(wrapper.vm.enableButton).toBe(true)
+        expect(wrapper.vm.humhubUri).toBe('')
+        expect(mocks.$store.commit).toBeCalledWith('humhubAllowed', false)
+      })
+    })
+  })
+})

--- a/frontend/src/pages/Circles.vue
+++ b/frontend/src/pages/Circles.vue
@@ -12,10 +12,10 @@
         <b-col cols="12">
           <div class="text-lg-right">
             <b-button
+              :href="this.humhubUri"
               v-if="this.humhubAllowed"
               variant="gradido"
               :disabled="this.enableButton === false"
-              @click="authenticateHumhubAutoLogin"
               target="_blank"
             >
               {{ $t('circles.button') }}
@@ -37,7 +37,8 @@ export default {
   name: 'Circles',
   data() {
     return {
-      enableButton: true,
+      enableButton: false,
+      humhubUri: '',
     }
   },
   computed: {
@@ -55,7 +56,7 @@ export default {
           fetchPolicy: 'network-only',
         })
         .then(async (result) => {
-          window.open(result.data.authenticateHumhubAutoLogin, '_blank')
+          this.humhubUri = result.data.authenticateHumhubAutoLogin
           this.enableButton = true
         })
         .catch(() => {
@@ -66,6 +67,9 @@ export default {
           this.$router.push('/settings/extern')
         })
     },
+  },
+  created() {
+    this.authenticateHumhubAutoLogin()
   },
 }
 </script>

--- a/frontend/src/pages/Circles.vue
+++ b/frontend/src/pages/Circles.vue
@@ -60,11 +60,10 @@ export default {
           this.enableButton = true
         })
         .catch(() => {
-          // this.toastError('authenticateHumhubAutoLogin failed!')
           this.enableButton = true
+          this.humhubUri = ''
           // something went wrong with login link so we disable humhub
           this.$store.commit('humhubAllowed', false)
-          this.$router.push('/settings/extern')
         })
     },
   },


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
- gradido_address on humub link always set to gradido_id
- increase humhub JWT Token Timeout to the same like wallet login
- static humhub link on circles page instead of invoking window.open, hopefully that fix the problem with safari on mac
- add try catch in user login in case humhub server isn't reachable or jwt secret isn't correct

