### PR TITLE
feat(backend): speedup listTransactions

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -12,7 +12,7 @@ Decimal.set({
 })
 
 const constants = {
-  DB_VERSION: '0084-introduce_humhub_registration',
+  DB_VERSION: '0085-add_index_transactions_user_id',
   DECAY_START_TIME: new Date('2021-05-13 17:46:31-0000'), // GMT+0
   LOG4JS_CONFIG: 'log4js-config.json',
   // default log level on production should be info

--- a/backend/src/graphql/resolver/BalanceResolver.ts
+++ b/backend/src/graphql/resolver/BalanceResolver.ts
@@ -29,13 +29,15 @@ export class BalanceResolver {
     logger.addContext('user', user.id)
     logger.info(`balance(userId=${user.id})...`)
 
-    const gdtResolver = new GdtResolver()
-    const balanceGDT = await gdtResolver.gdtBalance(context)
+    if(!context.balanceGDT) {
+      const gdtResolver = new GdtResolver()
+      context.balanceGDT = await gdtResolver.gdtBalance(context)
+    }
 
     logger.info(`time for load gdt balance: ${new Date().getTime() - now.getTime()} ms`)
     let profilingTime = new Date()
 
-    logger.debug(`balanceGDT=${balanceGDT}`)
+    logger.debug(`balanceGDT=${context.balanceGDT}`)
 
     const lastTransaction = context.lastTransaction
       ? context.lastTransaction
@@ -55,7 +57,7 @@ export class BalanceResolver {
       logger.info(`no balance found, return Default-Balance!`)
       return new Balance({
         balance: new Decimal(0),
-        balanceGDT,
+        balanceGDT: context.balanceGDT,
         count: 0,
         linkCount: 0,
       })

--- a/backend/src/graphql/resolver/BalanceResolver.ts
+++ b/backend/src/graphql/resolver/BalanceResolver.ts
@@ -37,21 +37,11 @@ export class BalanceResolver {
       balanceGDT = context.balanceGDT
     }
 
-    logger.info(`time for load gdt balance: ${new Date().getTime() - now.getTime()} ms`)
-    let profilingTime = new Date()
-
     logger.debug(`balanceGDT=${context.balanceGDT}`)
 
     const lastTransaction = context.lastTransaction
       ? context.lastTransaction
       : await getLastTransaction(user.id)
-
-    logger.info(
-      `time for load lastTransaction from db (if not already done): ${
-        new Date().getTime() - profilingTime.getTime()
-      } ms`,
-    )
-    profilingTime = new Date()
 
     logger.debug(`lastTransaction=${lastTransaction}`)
 
@@ -73,11 +63,6 @@ export class BalanceResolver {
 
     logger.debug(`transactionCount=${count}`)
 
-    logger.info(
-      `time for count transaction in db: ${new Date().getTime() - profilingTime.getTime()} ms`,
-    )
-    profilingTime = new Date()
-
     const linkCount = await dbTransactionLink.count({
       where: {
         userId: user.id,
@@ -86,13 +71,6 @@ export class BalanceResolver {
       },
     })
     logger.debug(`linkCount=${linkCount}`)
-
-    logger.info(
-      `time for count transaction links in db: ${
-        new Date().getTime() - profilingTime.getTime()
-      } ms`,
-    )
-    profilingTime = new Date()
 
     // The decay is always calculated on the last booked transaction
     const calculatedDecay = calculateDecay(
@@ -111,13 +89,6 @@ export class BalanceResolver {
     const { sumHoldAvailableAmount } = context.sumHoldAvailableAmount
       ? { sumHoldAvailableAmount: context.sumHoldAvailableAmount }
       : await transactionLinkSummary(user.id, now)
-
-    logger.info(
-      `time for load transactionLinkSummary from db (if not already done): ${
-        new Date().getTime() - profilingTime.getTime()
-      } ms`,
-    )
-    profilingTime = new Date()
 
     logger.debug(`context.sumHoldAvailableAmount=${context.sumHoldAvailableAmount}`)
     logger.debug(`sumHoldAvailableAmount=${sumHoldAvailableAmount}`)

--- a/backend/src/graphql/resolver/BalanceResolver.ts
+++ b/backend/src/graphql/resolver/BalanceResolver.ts
@@ -15,6 +15,7 @@ import { calculateDecay } from '@/util/decay'
 import { GdtResolver } from './GdtResolver'
 import { getLastTransaction } from './util/getLastTransaction'
 import { transactionLinkSummary } from './util/transactionLinkSummary'
+import { DecayLoggingView } from '@/logging/DecayLogging.view'
 
 @Resolver()
 export class BalanceResolver {
@@ -85,9 +86,9 @@ export class BalanceResolver {
     )
     logger.info(
       'calculatedDecay',
-      lastTransaction.balance,
-      lastTransaction.balanceDate,
-      calculatedDecay,
+      lastTransaction.balance.toString(),
+      lastTransaction.balanceDate.toISOString(),
+      new DecayLoggingView(calculatedDecay),
     )
 
     // The final balance is reduced by the link amount withheld
@@ -115,7 +116,7 @@ export class BalanceResolver {
       count,
       linkCount,
     })
-    logger.info('new Balance', balance, balanceGDT, count, linkCount, newBalance)
+    logger.info('new Balance', balance.toString(), balanceGDT?.toString(), count, linkCount, newBalance.toString())
 
     return newBalance
   }

--- a/backend/src/graphql/resolver/TransactionResolver.ts
+++ b/backend/src/graphql/resolver/TransactionResolver.ts
@@ -309,7 +309,11 @@ export class TransactionResolver {
     logger.debug(`involvedUserIds=`, involvedUserIds)
     logger.debug(`involvedRemoteUsers=`, involvedRemoteUsers)
 
-    logger.info(`time for collect involved user and load remote user: ${new Date().getTime() - profilingTime.getTime()} ms`)
+    logger.info(
+      `time for collect involved user and load remote user: ${
+        new Date().getTime() - profilingTime.getTime()
+      } ms`,
+    )
     profilingTime = new Date()
 
     // We need to show the name for deleted users for old transactions
@@ -320,7 +324,9 @@ export class TransactionResolver {
     })
     const involvedUsers = involvedDbUsers.map((u) => new User(u))
     logger.debug(`involvedUsers=`, involvedUsers)
-    logger.info(`time for load involved user from db: ${new Date().getTime() - profilingTime.getTime()} ms`)
+    logger.info(
+      `time for load involved user from db: ${new Date().getTime() - profilingTime.getTime()} ms`,
+    )
     profilingTime = new Date()
 
     const self = new User(user)
@@ -329,7 +335,11 @@ export class TransactionResolver {
     const { sumHoldAvailableAmount, sumAmount, lastDate, firstDate, transactionLinkcount } =
       await transactionLinkSummary(user.id, now)
 
-    logger.debug(`time for load transactionLinkSummary db: ${new Date().getTime() - profilingTime.getTime()} ms`)
+    logger.debug(
+      `time for load transactionLinkSummary db: ${
+        new Date().getTime() - profilingTime.getTime()
+      } ms`,
+    )
     profilingTime = new Date()
 
     context.linkCount = transactionLinkcount
@@ -426,7 +436,11 @@ export class TransactionResolver {
         ).toDecimalPlaces(2, Decimal.ROUND_HALF_UP)
       }
     })
-    logger.info(`time for process transaction list and fill in decay db: ${new Date().getTime() - profilingTime.getTime()} ms`)
+    logger.info(
+      `time for process transaction list and fill in decay db: ${
+        new Date().getTime() - profilingTime.getTime()
+      } ms`,
+    )
     profilingTime = new Date()
     // Construct Result
     return new TransactionList(await balanceResolver.balance(context), transactions)

--- a/backend/src/graphql/resolver/TransactionResolver.ts
+++ b/backend/src/graphql/resolver/TransactionResolver.ts
@@ -307,7 +307,7 @@ export class TransactionResolver {
       }
     }
     logger.debug(`involvedUserIds=`, involvedUserIds)
-    logger.debug(`involvedRemoteUsers=`, involvedRemoteUsers)    
+    logger.debug(`involvedRemoteUsers=`, involvedRemoteUsers)
 
     // We need to show the name for deleted users for old transactions
     const involvedDbUsers = await dbUser.find({
@@ -317,7 +317,7 @@ export class TransactionResolver {
     })
     const involvedUsers = involvedDbUsers.map((u) => new User(u))
     logger.debug(`involvedUsers=`, involvedUsers)
-    
+
     const self = new User(user)
     const transactions: Transaction[] = []
 

--- a/backend/src/graphql/resolver/TransactionResolver.ts
+++ b/backend/src/graphql/resolver/TransactionResolver.ts
@@ -237,8 +237,6 @@ export class TransactionResolver {
     const lastTransaction = await getLastTransaction(user.id)
     logger.debug(`lastTransaction=${lastTransaction}`)
 
-    logger.info(`time for get last transaction: ${new Date().getTime() - now.getTime()} ms`)
-
     const balanceResolver = new BalanceResolver()
     context.lastTransaction = lastTransaction
 
@@ -257,8 +255,6 @@ export class TransactionResolver {
       order,
     )
     context.transactionCount = userTransactionsCount
-    let profilingTime = new Date()
-    logger.info(`time for getTransactionList: ${profilingTime.getTime() - now.getTime()} ms`)
 
     // find involved users; I am involved
     const involvedUserIds: number[] = [user.id]
@@ -311,14 +307,7 @@ export class TransactionResolver {
       }
     }
     logger.debug(`involvedUserIds=`, involvedUserIds)
-    logger.debug(`involvedRemoteUsers=`, involvedRemoteUsers)
-
-    logger.info(
-      `time for collect involved user and load remote user: ${
-        new Date().getTime() - profilingTime.getTime()
-      } ms`,
-    )
-    profilingTime = new Date()
+    logger.debug(`involvedRemoteUsers=`, involvedRemoteUsers)    
 
     // We need to show the name for deleted users for old transactions
     const involvedDbUsers = await dbUser.find({
@@ -328,23 +317,12 @@ export class TransactionResolver {
     })
     const involvedUsers = involvedDbUsers.map((u) => new User(u))
     logger.debug(`involvedUsers=`, involvedUsers)
-    logger.info(
-      `time for load involved user from db: ${new Date().getTime() - profilingTime.getTime()} ms`,
-    )
-    profilingTime = new Date()
-
+    
     const self = new User(user)
     const transactions: Transaction[] = []
 
     const { sumHoldAvailableAmount, sumAmount, lastDate, firstDate, transactionLinkcount } =
       await transactionLinkSummary(user.id, now)
-
-    logger.debug(
-      `time for load transactionLinkSummary db: ${
-        new Date().getTime() - profilingTime.getTime()
-      } ms`,
-    )
-    profilingTime = new Date()
 
     context.linkCount = transactionLinkcount
     logger.debug(`transactionLinkcount=${transactionLinkcount}`)
@@ -440,12 +418,6 @@ export class TransactionResolver {
         ).toDecimalPlaces(2, Decimal.ROUND_HALF_UP)
       }
     })
-    logger.info(
-      `time for process transaction list and fill in decay db: ${
-        new Date().getTime() - profilingTime.getTime()
-      } ms`,
-    )
-    profilingTime = new Date()
     const balanceGDT = await balanceGDTPromise
     context.balanceGDT = balanceGDT
 

--- a/backend/src/graphql/resolver/TransactionResolver.ts
+++ b/backend/src/graphql/resolver/TransactionResolver.ts
@@ -49,6 +49,7 @@ import {
 import { sendTransactionsToDltConnector } from './util/sendTransactionsToDltConnector'
 import { storeForeignUser } from './util/storeForeignUser'
 import { transactionLinkSummary } from './util/transactionLinkSummary'
+import { GdtResolver } from './GdtResolver'
 
 export const executeTransaction = async (
   amount: Decimal,
@@ -228,6 +229,9 @@ export class TransactionResolver {
 
     logger.addContext('user', user.id)
     logger.info(`transactionList(user=${user.firstName}.${user.lastName}, ${user.emailId})`)
+
+    const gdtResolver = new GdtResolver()
+    const balanceGDTPromise = gdtResolver.gdtBalance(context)
 
     // find current balance
     const lastTransaction = await getLastTransaction(user.id)
@@ -442,6 +446,9 @@ export class TransactionResolver {
       } ms`,
     )
     profilingTime = new Date()
+    const balanceGDT = await balanceGDTPromise
+    context.balanceGDT = balanceGDT
+    
     // Construct Result
     return new TransactionList(await balanceResolver.balance(context), transactions)
   }

--- a/backend/src/graphql/resolver/TransactionResolver.ts
+++ b/backend/src/graphql/resolver/TransactionResolver.ts
@@ -230,7 +230,7 @@ export class TransactionResolver {
     logger.info(`transactionList(user=${user.firstName}.${user.lastName}, ${user.emailId})`)
 
     // find current balance
-    const lastTransaction = await getLastTransaction(user.id, ['contribution'])
+    const lastTransaction = await getLastTransaction(user.id)
     logger.debug(`lastTransaction=${lastTransaction}`)
 
     logger.info(`time for get last transaction: ${new Date().getTime() - now.getTime()} ms`)

--- a/backend/src/graphql/resolver/TransactionResolver.ts
+++ b/backend/src/graphql/resolver/TransactionResolver.ts
@@ -38,6 +38,7 @@ import { calculateBalance } from '@/util/validate'
 import { virtualLinkTransaction, virtualDecayTransaction } from '@/util/virtualTransactions'
 
 import { BalanceResolver } from './BalanceResolver'
+import { GdtResolver } from './GdtResolver'
 import { getCommunityByIdentifier, getCommunityName, isHomeCommunity } from './util/communities'
 import { findUserByIdentifier } from './util/findUserByIdentifier'
 import { getLastTransaction } from './util/getLastTransaction'
@@ -49,7 +50,6 @@ import {
 import { sendTransactionsToDltConnector } from './util/sendTransactionsToDltConnector'
 import { storeForeignUser } from './util/storeForeignUser'
 import { transactionLinkSummary } from './util/transactionLinkSummary'
-import { GdtResolver } from './GdtResolver'
 
 export const executeTransaction = async (
   amount: Decimal,
@@ -448,7 +448,7 @@ export class TransactionResolver {
     profilingTime = new Date()
     const balanceGDT = await balanceGDTPromise
     context.balanceGDT = balanceGDT
-    
+
     // Construct Result
     return new TransactionList(await balanceResolver.balance(context), transactions)
   }

--- a/backend/src/logging/BalanceLogging.view.ts
+++ b/backend/src/logging/BalanceLogging.view.ts
@@ -1,5 +1,6 @@
-import { Balance } from '@/graphql/model/Balance'
 import { AbstractLoggingView } from '@logging/AbstractLogging.view'
+
+import { Balance } from '@/graphql/model/Balance'
 
 export class BalanceLoggingView extends AbstractLoggingView {
   public constructor(private self: Balance) {

--- a/backend/src/logging/BalanceLogging.view.ts
+++ b/backend/src/logging/BalanceLogging.view.ts
@@ -1,0 +1,18 @@
+import { Balance } from '@/graphql/model/Balance'
+import { AbstractLoggingView } from '@logging/AbstractLogging.view'
+
+export class BalanceLoggingView extends AbstractLoggingView {
+  public constructor(private self: Balance) {
+    super()
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public toJSON(): any {
+    return {
+      balance: this.decimalToString(this.self.balance),
+      balanceGDT: this.self.balanceGDT,
+      count: this.self.count,
+      linkCount: this.self.linkCount,
+    }
+  }
+}

--- a/backend/src/logging/DecayLogging.view.ts
+++ b/backend/src/logging/DecayLogging.view.ts
@@ -1,5 +1,6 @@
-import { Decay } from '@/graphql/model/Decay'
 import { AbstractLoggingView } from '@logging/AbstractLogging.view'
+
+import { Decay } from '@/graphql/model/Decay'
 
 export class DecayLoggingView extends AbstractLoggingView {
   public constructor(private self: Decay) {
@@ -14,7 +15,7 @@ export class DecayLoggingView extends AbstractLoggingView {
       roundedDecay: this.decimalToString(this.self.roundedDecay),
       start: this.dateToString(this.self.start),
       end: this.dateToString(this.self.end),
-      duration: this.self.duration
+      duration: this.self.duration,
     }
   }
 }

--- a/backend/src/logging/DecayLogging.view.ts
+++ b/backend/src/logging/DecayLogging.view.ts
@@ -1,0 +1,20 @@
+import { Decay } from '@/graphql/model/Decay'
+import { AbstractLoggingView } from '@logging/AbstractLogging.view'
+
+export class DecayLoggingView extends AbstractLoggingView {
+  public constructor(private self: Decay) {
+    super()
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public toJSON(): any {
+    return {
+      balance: this.decimalToString(this.self.balance),
+      decay: this.decimalToString(this.self.decay),
+      roundedDecay: this.decimalToString(this.self.roundedDecay),
+      start: this.dateToString(this.self.start),
+      end: this.dateToString(this.self.end),
+      duration: this.self.duration
+    }
+  }
+}

--- a/backend/src/server/context.ts
+++ b/backend/src/server/context.ts
@@ -16,6 +16,7 @@ export interface Context {
   gradidoID?: string
   // hack to use less DB calls for Balance Resolver
   lastTransaction?: dbTransaction | null
+  balanceGDT?: number | null
   transactionCount?: number
   linkCount?: number
   sumHoldAvailableAmount?: Decimal

--- a/database/migrations/0082-introduce_gms_registration.ts
+++ b/database/migrations/0082-introduce_gms_registration.ts
@@ -50,5 +50,5 @@ export async function downgrade(queryFn: (query: string, values?: any[]) => Prom
   await queryFn('ALTER TABLE `user_contacts` DROP COLUMN IF EXISTS `gms_publish_email`;')
   await queryFn('ALTER TABLE `user_contacts` DROP COLUMN IF EXISTS `country_code`;')
   await queryFn('ALTER TABLE `user_contacts` DROP COLUMN IF EXISTS `gms_publish_phone`;')
-    await queryFn('ALTER TABLE `communities` DROP COLUMN IF EXISTS `gms_api_key`;')
+  await queryFn('ALTER TABLE `communities` DROP COLUMN IF EXISTS `gms_api_key`;')
 }

--- a/database/migrations/0085-add_index_transactions_user_id.ts
+++ b/database/migrations/0085-add_index_transactions_user_id.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function upgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  await queryFn('CREATE INDEX user_id ON transactions (user_id);')
+}
+
+export async function downgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  await queryFn('DROP INDEX user_id ON transactions;')
+}

--- a/dht-node/src/config/index.ts
+++ b/dht-node/src/config/index.ts
@@ -4,7 +4,7 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 const constants = {
-  DB_VERSION: '0084-introduce_humhub_registration',
+  DB_VERSION: '0085-add_index_transactions_user_id',
   LOG4JS_CONFIG: 'log4js-config.json',
   // default log level on production should be info
   LOG_LEVEL: process.env.LOG_LEVEL ?? 'info',

--- a/federation/src/config/index.ts
+++ b/federation/src/config/index.ts
@@ -10,7 +10,7 @@ Decimal.set({
 })
 
 const constants = {
-  DB_VERSION: '0084-introduce_humhub_registration',
+  DB_VERSION: '0085-add_index_transactions_user_id',
   DECAY_START_TIME: new Date('2021-05-13 17:46:31-0000'), // GMT+0
   LOG4JS_CONFIG: 'log4js-config.json',
   // default log level on production should be info


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
- make TransactionResolver.transactionList faster, improvement on stage2.gradido.net from ~350 ms to ~100 ms with production data set copy
- calling gdt server for gdt sum parallel to rest of transactionList logic
  - calling seems to be needing at least 100 ms, independent of gdt server speed (return balance in 15 ms)
- adding INDEX for transactions.user_id improve speed for getLastTransaction and getTransactionList dramatic
  - getLastTransaction from ~127 ms to 4 ms
  - getTransactionList ~300 ms to 14 ms
- reduce log output from decimal in BalanceResolver.balance with added DecayLoggingView and BalanceLoggingView

