### PR TITLE
refactor(workflow): increaste artifact version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           docker build --target production -t "gradido/frontend:latest" -t "gradido/frontend:production" -t "gradido/frontend:${VERSION}" -t "gradido/frontend:${BUILD_VERSION}" frontend/
           docker save "gradido/frontend" > /tmp/frontend.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docker-frontend-production
           path: /tmp/frontend.tar
@@ -75,7 +75,7 @@ jobs:
           docker build -f ./backend/Dockerfile --target production -t "gradido/backend:latest" -t "gradido/backend:production" -t "gradido/backend:${VERSION}" -t "gradido/backend:${BUILD_VERSION}" .
           docker save "gradido/backend" > /tmp/backend.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docker-backend-production
           path: /tmp/backend.tar
@@ -101,7 +101,7 @@ jobs:
           docker build --target production_up -t "gradido/database:production_up" database/
           docker save "gradido/database:production_up" > /tmp/database_up.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docker-database-production_up
           path: /tmp/database_up.tar
@@ -138,7 +138,7 @@ jobs:
           docker build -t "gradido/mariadb:latest" -t "gradido/mariadb:production" -t "gradido/mariadb:${VERSION}" -t "gradido/mariadb:${BUILD_VERSION}" -f ./mariadb/Dockerfile ./
           docker save "gradido/mariadb" > /tmp/mariadb.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docker-mariadb-production
           path: /tmp/mariadb.tar
@@ -175,7 +175,7 @@ jobs:
           docker build -t "gradido/nginx:latest" -t "gradido/nginx:production" -t "gradido/nginx:${VERSION}" -t "gradido/nginx:${BUILD_VERSION}" nginx/
           docker save "gradido/nginx" > /tmp/nginx.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docker-nginx-production
           path: /tmp/nginx.tar
@@ -200,35 +200,35 @@ jobs:
       # DOWNLOAD DOCKER IMAGES #################################################
       ##########################################################################
       - name: Download Docker Image (Frontend)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: docker-frontend-production
           path: /tmp
       - name: Load Docker Image
         run: docker load < /tmp/frontend.tar
       - name: Download Docker Image (Backend)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: docker-backend-production
           path: /tmp
       - name: Load Docker Image
         run: docker load < /tmp/backend.tar
       - name: Download Docker Image (Database)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: docker-database-production_up
           path: /tmp
       - name: Load Docker Image
         run: docker load < /tmp/database_up.tar
       - name: Download Docker Image (MariaDB)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: docker-mariadb-production
           path: /tmp
       - name: Load Docker Image
         run: docker load < /tmp/mariadb.tar
       - name: Download Docker Image (Nginx)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: docker-nginx-production
           path: /tmp

--- a/.github/workflows/test_dht_node.yml
+++ b/.github/workflows/test_dht_node.yml
@@ -36,7 +36,7 @@ jobs:
           docker save "gradido/dht-node:test" > /tmp/dht-node.tar
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-dht-node-test
           path: /tmp/dht-node.tar
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Download Docker Image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docker-dht-node-test
           path: /tmp

--- a/.github/workflows/test_dlt_connector.yml
+++ b/.github/workflows/test_dlt_connector.yml
@@ -35,7 +35,7 @@ jobs:
           docker save "gradido/dlt-connector:test" > /tmp/dlt-connector.tar
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-dlt-connector-test
           path: /tmp/dlt-connector.tar

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -59,7 +59,7 @@ jobs:
       - name: End-to-end tests | if tests failed, upload report
         id: e2e-report
         if: ${{ failure() && steps.e2e-tests.conclusion == 'failure' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-report-pr-#${{ steps.pr.outputs.number }}
           path: /home/runner/work/gradido/gradido/e2e-tests/cypress/reports/cucumber_html_report

--- a/.github/workflows/test_federation.yml
+++ b/.github/workflows/test_federation.yml
@@ -35,7 +35,7 @@ jobs:
           docker save "gradido/federation:test" > /tmp/federation.tar
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-federation-test
           path: /tmp/federation.tar
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Download Docker Image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docker-federation-test
           path: /tmp


### PR DESCRIPTION
github download- and upload artifact v3 and below are depracted and randomly don't work, so we must update to v4