### PR TITLE
fix(backend): humhub username case with initails and empty alias

### DIFF
--- a/backend/src/apis/humhub/model/PostUser.test.ts
+++ b/backend/src/apis/humhub/model/PostUser.test.ts
@@ -1,0 +1,139 @@
+import { User } from '@entity/User'
+import { UserContact } from '@entity/UserContact'
+import { v4 as uuidv4 } from 'uuid'
+
+import { PublishNameType } from '@/graphql/enum/PublishNameType'
+
+import { PostUser as HumhubUser } from './PostUser'
+
+const gradidoUuid = uuidv4()
+let user: User
+
+/*
+export enum PublishNameType {
+  PUBLISH_NAME_ALIAS_OR_INITALS = 0,
+  PUBLISH_NAME_INITIALS = 1,
+  PUBLISH_NAME_FIRST = 2,
+  PUBLISH_NAME_FIRST_INITIAL = 3,
+  PUBLISH_NAME_FULL = 4,
+}
+*/
+
+describe('test creation of a humhub user from db user', () => {
+  beforeEach(() => {
+    const emailContact = new UserContact()
+    emailContact.email = 'john.smith@gradido.de'
+
+    user = new User()
+    user.alias = 'alias'
+    user.firstName = 'John'
+    user.lastName = 'Smith'
+    user.emailContact = emailContact
+    user.gradidoID = gradidoUuid
+  })
+
+  describe('for alias or initials', () => {
+    it('with alias set', () => {
+      user.humhubPublishName = PublishNameType.PUBLISH_NAME_ALIAS_OR_INITALS
+      const humhubUser = new HumhubUser(user)
+
+      expect(humhubUser.account.username).toBe('alias')
+      expect(humhubUser.profile.firstname).toBe('')
+      expect(humhubUser.profile.lastname).toBe('')
+    })
+
+    it('with empty alias', () => {
+      user.alias = ''
+      user.humhubPublishName = PublishNameType.PUBLISH_NAME_ALIAS_OR_INITALS
+      const humhubUser = new HumhubUser(user)
+
+      expect(humhubUser.account.username).toBe(gradidoUuid)
+      expect(humhubUser.profile.firstname).toBe('JoSm')
+      expect(humhubUser.profile.lastname).toBe('')
+    })
+  })
+
+  describe('for initials', () => {
+    it('with alias set', () => {
+      user.humhubPublishName = PublishNameType.PUBLISH_NAME_INITIALS
+      const humhubUser = new HumhubUser(user)
+
+      expect(humhubUser.account.username).toBe(gradidoUuid)
+      expect(humhubUser.profile.firstname).toBe('JoSm')
+      expect(humhubUser.profile.lastname).toBe('')
+    })
+
+    it('with empty alias', () => {
+      user.alias = ''
+      user.humhubPublishName = PublishNameType.PUBLISH_NAME_INITIALS
+      const humhubUser = new HumhubUser(user)
+
+      expect(humhubUser.account.username).toBe(gradidoUuid)
+      expect(humhubUser.profile.firstname).toBe('JoSm')
+      expect(humhubUser.profile.lastname).toBe('')
+    })
+  })
+
+  describe('for first name only', () => {
+    it('with alias set', () => {
+      user.humhubPublishName = PublishNameType.PUBLISH_NAME_FIRST
+      const humhubUser = new HumhubUser(user)
+
+      expect(humhubUser.account.username).toBe(gradidoUuid)
+      expect(humhubUser.profile.firstname).toBe('John')
+      expect(humhubUser.profile.lastname).toBe('')
+    })
+
+    it('with empty alias', () => {
+      user.alias = ''
+      user.humhubPublishName = PublishNameType.PUBLISH_NAME_FIRST
+      const humhubUser = new HumhubUser(user)
+
+      expect(humhubUser.account.username).toBe(gradidoUuid)
+      expect(humhubUser.profile.firstname).toBe('John')
+      expect(humhubUser.profile.lastname).toBe('')
+    })
+  })
+
+  describe('for first name and last name initial', () => {
+    it('with alias set', () => {
+      user.humhubPublishName = PublishNameType.PUBLISH_NAME_FIRST_INITIAL
+      const humhubUser = new HumhubUser(user)
+
+      expect(humhubUser.account.username).toBe(gradidoUuid)
+      expect(humhubUser.profile.firstname).toBe('John')
+      expect(humhubUser.profile.lastname).toBe('S')
+    })
+
+    it('with empty alias', () => {
+      user.alias = ''
+      user.humhubPublishName = PublishNameType.PUBLISH_NAME_FIRST_INITIAL
+      const humhubUser = new HumhubUser(user)
+
+      expect(humhubUser.account.username).toBe(gradidoUuid)
+      expect(humhubUser.profile.firstname).toBe('John')
+      expect(humhubUser.profile.lastname).toBe('S')
+    })
+  })
+
+  describe('for full name', () => {
+    it('with alias set', () => {
+      user.humhubPublishName = PublishNameType.PUBLISH_NAME_FULL
+      const humhubUser = new HumhubUser(user)
+
+      expect(humhubUser.account.username).toBe(gradidoUuid)
+      expect(humhubUser.profile.firstname).toBe('John')
+      expect(humhubUser.profile.lastname).toBe('Smith')
+    })
+
+    it('with empty alias', () => {
+      user.alias = ''
+      user.humhubPublishName = PublishNameType.PUBLISH_NAME_FULL
+      const humhubUser = new HumhubUser(user)
+
+      expect(humhubUser.account.username).toBe(gradidoUuid)
+      expect(humhubUser.profile.firstname).toBe('John')
+      expect(humhubUser.profile.lastname).toBe('Smith')
+    })
+  })
+})

--- a/backend/src/apis/humhub/model/Profile.ts
+++ b/backend/src/apis/humhub/model/Profile.ts
@@ -14,6 +14,18 @@ export class Profile {
     this.gradido_address = `${CONFIG.COMMUNITY_NAME}/${
       publishNameLogic.hasAlias() ? user.alias : user.gradidoID
     }`
+
+    // we need to get our public name to humhub, but the public name isn't always unique,
+    // so in some cases we must cheat and put the public name into first_name, if it isn't unique,
+    // to let the username to be unique either alias or gradido id
+    // in humhub first name is shown if exist else username
+    // if it shows first_name it will also show last_name if exist
+    // if we have public name from alias, we have only 2 character for first name and 2 for last name,
+    // but this isn't searchable in humhub, so we put both into first_name
+    if (publishNameLogic.isUsernameFromInitials(user.humhubPublishName as PublishNameType)) {
+      this.firstname = publishNameLogic.getUsernameFromInitials()
+      this.lastname = ''
+    }
   }
 
   firstname: string

--- a/backend/src/data/PublishName.logic.test.ts
+++ b/backend/src/data/PublishName.logic.test.ts
@@ -28,6 +28,75 @@ describe('test publish name logic', () => {
     user.gradidoID = gradidoUuid
     logic = new PublishNameLogic(user)
   })
+
+  describe('test hasAlias', () => {
+    it('for alias set', () => {
+      expect(logic.hasAlias()).toBe(true)
+    })
+    it('for alias empty string', () => {
+      user.alias = ''
+      expect(logic.hasAlias()).toBe(false)
+    })
+    it('for alias string to short 1', () => {
+      user.alias = 'a'
+      expect(logic.hasAlias()).toBe(false)
+    })
+    it('for alias string to short 2', () => {
+      user.alias = 'ab'
+      expect(logic.hasAlias()).toBe(false)
+    })
+    it('for alias string 3', () => {
+      user.alias = 'abc'
+      expect(logic.hasAlias()).toBe(true)
+    })
+  })
+
+  describe('test isUsernameFromInitials', () => {
+    it('for publish name initials', () => {
+      expect(logic.isUsernameFromInitials(PublishNameType.PUBLISH_NAME_INITIALS)).toBe(true)
+    })
+    it('for publish name alias or initials, with alias set', () => {
+      expect(logic.isUsernameFromInitials(PublishNameType.PUBLISH_NAME_ALIAS_OR_INITALS)).toBe(
+        false,
+      )
+    })
+    it('for publish name alias or initials, with alias not set', () => {
+      user.alias = ''
+      expect(logic.isUsernameFromInitials(PublishNameType.PUBLISH_NAME_ALIAS_OR_INITALS)).toBe(true)
+    })
+    it('for publish name first', () => {
+      expect(logic.isUsernameFromInitials(PublishNameType.PUBLISH_NAME_FIRST)).toBe(false)
+    })
+    it('for publish name first initial', () => {
+      expect(logic.isUsernameFromInitials(PublishNameType.PUBLISH_NAME_FIRST_INITIAL)).toBe(false)
+    })
+    it('for publish name full', () => {
+      expect(logic.isUsernameFromInitials(PublishNameType.PUBLISH_NAME_FULL)).toBe(false)
+    })
+  })
+
+  describe('test isUsernameFromAlias', () => {
+    it('for publish name initials', () => {
+      expect(logic.isUsernameFromAlias(PublishNameType.PUBLISH_NAME_INITIALS)).toBe(false)
+    })
+    it('for publish name alias or initials with alias set', () => {
+      expect(logic.isUsernameFromAlias(PublishNameType.PUBLISH_NAME_ALIAS_OR_INITALS)).toBe(true)
+    })
+    it('for publish name alias or initials with alias empty', () => {
+      user.alias = ''
+      expect(logic.isUsernameFromAlias(PublishNameType.PUBLISH_NAME_ALIAS_OR_INITALS)).toBe(false)
+    })
+    it('for publish name first', () => {
+      expect(logic.isUsernameFromAlias(PublishNameType.PUBLISH_NAME_FIRST)).toBe(false)
+    })
+    it('for publish name first initial', () => {
+      expect(logic.isUsernameFromAlias(PublishNameType.PUBLISH_NAME_FIRST_INITIAL)).toBe(false)
+    })
+    it('for publish name full', () => {
+      expect(logic.isUsernameFromAlias(PublishNameType.PUBLISH_NAME_FULL)).toBe(false)
+    })
+  })
+
   describe('test user identifier ', () => {
     it('for alias or initials with alias set', () => {
       expect(logic.getUserIdentifier(PublishNameType.PUBLISH_NAME_ALIAS_OR_INITALS)).toBe('alias')

--- a/backend/src/data/PublishName.logic.ts
+++ b/backend/src/data/PublishName.logic.ts
@@ -67,7 +67,7 @@ export class PublishNameLogic {
    */
   public getUserIdentifier(publishNameType: PublishNameType): string {
     return this.isUsernameFromAlias(publishNameType)
-      ? this.filterOutInvalidChar(this.user.alias)
+      ? this.getUsernameFromAlias()
       : this.user.gradidoID
   }
 
@@ -82,11 +82,21 @@ export class PublishNameLogic {
    */
   public getPublicName(publishNameType: PublishNameType): string {
     return this.isUsernameFromAlias(publishNameType)
-      ? this.filterOutInvalidChar(this.user.alias)
+      ? this.getUsernameFromAlias()
       : this.isUsernameFromInitials(publishNameType)
-      ? this.firstUpperCaseSecondLowerCase(this.user.firstName) +
-        this.firstUpperCaseSecondLowerCase(this.user.lastName)
+      ? this.getUsernameFromInitials()
       : (this.getFirstName(publishNameType) + ' ' + this.getLastName(publishNameType)).trim()
+  }
+
+  public getUsernameFromInitials(): string {
+    return (
+      this.firstUpperCaseSecondLowerCase(this.user.firstName) +
+      this.firstUpperCaseSecondLowerCase(this.user.lastName)
+    ).trim()
+  }
+
+  public getUsernameFromAlias(): string {
+    return this.filterOutInvalidChar(this.user.alias)
   }
 
   public isUsernameFromInitials(publishNameType: PublishNameType): boolean {


### PR DESCRIPTION
- add more tests
- set first_name to initials if publish name type is PUBLISH_NAME_INITIALS or PUBLISH_NAME_ALIAS_OR_INITALS and alias is empty