### PR TITLE
refactor(frontend): show skeleton only as long as needed

### DIFF
--- a/frontend/src/components/GddTransactionList.spec.js
+++ b/frontend/src/components/GddTransactionList.spec.js
@@ -95,6 +95,9 @@ describe('GddTransactionList', () => {
     })
 
     describe('timestamp property', () => {
+      beforeEach(async () => {
+        await wrapper.setProps({ timestamp: new Date().getTime() })
+      })
       it('emits update-transactions when timestamp changes', async () => {
         await wrapper.setProps({ timestamp: 0 })
         expect(wrapper.emitted('update-transactions')).toBeTruthy()

--- a/frontend/src/components/GddTransactionList.vue
+++ b/frontend/src/components/GddTransactionList.vue
@@ -101,7 +101,7 @@ export default {
       this.updateTransactions()
     },
     timestamp: {
-      immediate: true,
+      immediate: false,
       handler: 'updateTransactions',
     },
   },

--- a/frontend/src/graphql/transactions.graphql
+++ b/frontend/src/graphql/transactions.graphql
@@ -1,0 +1,56 @@
+fragment balanceFields on Balance {
+  balance
+  balanceGDT
+  count
+  linkCount
+}
+
+fragment transactionFields on Transaction {
+  id
+  typeId
+  amount
+  balance
+  previousBalance
+  balanceDate
+  memo
+  linkedUser {
+    firstName
+    lastName
+    communityUuid
+    communityName
+    gradidoID
+    alias
+  }
+  decay {
+    decay
+    start
+    end
+    duration
+  }
+  linkId
+}
+
+query transactionsQuery($currentPage: Int = 1, $pageSize: Int = 25, $order: Order = DESC) {
+  transactionList(currentPage: $currentPage, pageSize: $pageSize, order: $order) {
+    balance {
+      ...balanceFields
+    }
+    transactions {
+      ...transactionFields
+    }
+  }
+}
+
+query transactionsUserCountQuery($currentPage: Int = 1, $pageSize: Int = 25, $order: Order = DESC) {
+  transactionList(currentPage: $currentPage, pageSize: $pageSize, order: $order) {
+    balance {
+      ...balanceFields
+    }
+    transactions {
+      ...transactionFields
+    }
+  }
+  communityStatistics {
+    totalUsers
+  }
+}

--- a/frontend/src/layouts/DashboardLayout.vue
+++ b/frontend/src/layouts/DashboardLayout.vue
@@ -187,7 +187,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 import { useStore } from 'vuex'
 import { useRouter } from 'vue-router'
 import { useQuery, useMutation } from '@vue/apollo-composable'
@@ -231,7 +231,7 @@ const pending = computed(() => {
 })
 
 const totalUsers = computed(() => {
-  return transactionQueryData?.value?.communityStatistics?.totalUsers || 0
+  return transactionQueryData?.value?.communityStatistics?.totalUsers || null
 })
 const transactions = computed(() => {
   return transactionQueryData?.value?.transactionList?.transactions || []

--- a/frontend/src/pages/Community.vue
+++ b/frontend/src/pages/Community.vue
@@ -272,10 +272,6 @@ const handleUpdateContributionForm = (item) => {
   router.push({ params: { tab: 'contribute' } })
 }
 
-const updateTransactions = (pagination) => {
-  emit('update-transactions', pagination)
-}
-
 const updateStatus = (id) => {
   const item = items.value.find((item) => item.id === id)
   if (item) {

--- a/frontend/src/pages/InfoStatistic.vue
+++ b/frontend/src/pages/InfoStatistic.vue
@@ -72,12 +72,4 @@ onContributionLinksError(() => {
 onAdminUsersError(() => {
   toastError('searchAdminUsers has no result, use default data')
 })
-
-const updateTransactions = (pagination) => {
-  emit('update-transactions', pagination)
-}
-
-onMounted(() => {
-  updateTransactions(0)
-})
 </script>

--- a/frontend/src/pages/Send.vue
+++ b/frontend/src/pages/Send.vue
@@ -172,7 +172,4 @@ function onBack() {
 function updateTransactions(pagination) {
   emit('update-transactions', pagination)
 }
-
-// Equivalent to created hook
-updateTransactions({})
 </script>


### PR DESCRIPTION
- remove hardcoded 1.5 seconds wait time for skeleton after finishing the loading of the transaction list 
- combine transaction list and user count request
- remove unnecessary reload call of transaction list on GddTransactionList, InfoStatistics and send