### PR TITLE
feat(dlt): export communities for dlt gradido node server

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -43,6 +43,7 @@ const DLT_CONNECTOR_PORT = process.env.DLT_CONNECTOR_PORT ?? 6010
 const dltConnector = {
   DLT_CONNECTOR: process.env.DLT_CONNECTOR === 'true' || false,
   DLT_CONNECTOR_URL: process.env.DLT_CONNECTOR_URL ?? `${COMMUNITY_URL}:${DLT_CONNECTOR_PORT}`,
+  DLT_GRADIDO_NODE_SERVER_HOME_FOLDER: process.env.DLT_GRADIDO_NODE_SERVER_HOME_FOLDER ?? '~/.gradido',
 }
 
 const community = {

--- a/backend/src/config/schema.ts
+++ b/backend/src/config/schema.ts
@@ -79,6 +79,10 @@ export const schema = Joi.object({
     .when('DLT_CONNECTOR', { is: true, then: Joi.required() })
     .description('The URL for GDT API endpoint'),
 
+  DLT_GRADIDO_NODE_SERVER_HOME_FOLDER: Joi.string()
+    .default('~/.gradido')
+    .description('The home folder for the gradido dlt node server'),
+
   EMAIL: Joi.boolean()
     .default(false)
     .description('Enable or disable email functionality')

--- a/backend/src/federation/client/1_0/model/PublicCommunityInfo.ts
+++ b/backend/src/federation/client/1_0/model/PublicCommunityInfo.ts
@@ -4,4 +4,5 @@ export interface PublicCommunityInfo {
   creationDate: Date
   publicKey: string
   publicJwtKey: string
+  hieroTopicId: string | null
 }

--- a/deployment/bare_metal/.env.dist
+++ b/deployment/bare_metal/.env.dist
@@ -88,6 +88,7 @@ GDT_ACTIVE=false
 # DLT-Connector (still in develop)
 DLT_CONNECTOR=false
 DLT_CONNECTOR_PORT=6010
+DLT_GRADIDO_NODE_SERVER_HOME_FOLDER=/home/gradido/.gradido
 
 # used for combining a newsletter on klicktipp with this gradido community
 # if used, user will be subscribed on register and can unsubscribe in his account

--- a/federation/src/graphql/api/1_0/model/GetPublicCommunityInfoResult.ts
+++ b/federation/src/graphql/api/1_0/model/GetPublicCommunityInfoResult.ts
@@ -12,6 +12,7 @@ export class GetPublicCommunityInfoResult {
     this.name = dbCom.name
     this.description = dbCom.description
     this.creationDate = dbCom.creationDate
+    this.hieroTopicId = dbCom.hieroTopicId
   }
 
   @Field(() => String)
@@ -28,4 +29,7 @@ export class GetPublicCommunityInfoResult {
 
   @Field(() => String)
   publicJwtKey: string
+
+  @Field(() => String)
+  hieroTopicId: string | null
 }


### PR DESCRIPTION
On each validateCommunities run, write current communities list as communities.json in dlt Gradido Node Home Folder.
Prototype, will changed in future that [gradido_node](https://github.com/gradido/gradido_node) gets a api call for this and manage it themself: https://github.com/gradido/gradido_node/issues/10