### PR TITLE
feat(database): recalculate all balances migration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -478,6 +478,7 @@
         "@biomejs/biome": "2.0.0",
         "@types/adm-zip": "^0.5.8",
         "adm-zip": "^0.5.16",
+        "decimal.js-light": "^2.5.1",
         "node-api-headers": "^1.8.0",
         "typescript": "^4.9.5",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -478,6 +478,7 @@
         "@biomejs/biome": "2.0.0",
         "@types/adm-zip": "^0.5.8",
         "adm-zip": "^0.5.16",
+        "decimal.js": "^10.6.0",
         "decimal.js-light": "^2.5.1",
         "node-api-headers": "^1.8.0",
         "typescript": "^4.9.5",

--- a/database/migration/index.ts
+++ b/database/migration/index.ts
@@ -46,6 +46,9 @@ const run = async (command: string) => {
     user: CONFIG.DB_USER,
     password: CONFIG.DB_PASSWORD,
     database: CONFIG.DB_DATABASE,
+    supportBigNumbers: true,
+    bigNumberStrings: true,
+    multipleStatements: true
   })
   const migration = new Migration({
     conn: pool,

--- a/database/migration/migrations/0102-recalculate_balances.ts
+++ b/database/migration/migrations/0102-recalculate_balances.ts
@@ -58,7 +58,7 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
   }
   runningRequests.push(
     queryFn(
-      `UPDATE transactions set decay_calculation_type = ${DecayCalculationType.NATIVE_C_FIXED_FACTOR_INTEGER}`,
+      `UPDATE transactions set decay_calculation_type = ?`, [DecayCalculationType.NATIVE_C_FIXED_FACTOR_INTEGER]
     ),
   )
   await Promise.all(runningRequests)

--- a/database/migration/migrations/0102-recalculate_balances.ts
+++ b/database/migration/migrations/0102-recalculate_balances.ts
@@ -23,8 +23,8 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
     let previous = null
     let balance = 0n
     let logEachStep = false
-    if (users[u].id === 764) {
-      logEachStep = true
+    if (users[u].id === 4705) {
+      // logEachStep = true
     }
     const transactionsToUpdate: string[] = []
 
@@ -32,7 +32,7 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
       const transaction = transactions[t]
       const amount = BigInt(transaction.amount_gdd4)
       let decay = 0n
-      if (balance && previous) {
+      if (balance > 0n && previous) {
         const decayedBalance = calculateDecay(
           balance,
           GradidoUnit.effectiveDecayDuration(previous.balance_date, transaction.balance_date)
@@ -49,6 +49,12 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
           )
         }
         balance = decayedBalance
+      } else if (balance <= 0n) {
+        if (balance < 0) {
+          // biome-ignore lint/suspicious/noConsole: no logger in migration
+          console.warn(`set negative balance: ${balance.toString()} for transaction: ${transaction.id} to zero.`)
+        }
+        balance = 0n
       } else {
         if (logEachStep) {
           console.log(
@@ -64,7 +70,9 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
           )
         }
         countDiffs++
-        transactionsToUpdate.push(
+        // transactionsToUpdate.push
+        await queryFn(
+
           `UPDATE transactions
            SET balance_gdd4 = '${balance.toString()}',
                decay_gdd4 = '${decay.toString()}'
@@ -82,7 +90,7 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
       previous = transaction
     }
     if (transactionsToUpdate.length) {
-      runningRequests.push(queryFn(transactionsToUpdate.join('\n')))
+      // runningRequests.push(queryFn(transactionsToUpdate.join('\n')))
       // await queryFn(transactionsToUpdate.join('\n'))
     }
   }

--- a/database/migration/migrations/0102-recalculate_balances.ts
+++ b/database/migration/migrations/0102-recalculate_balances.ts
@@ -22,10 +22,6 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
 
     let previous = null
     let balance = 0n
-    let logEachStep = false
-    if (users[u].id === 4705) {
-      // logEachStep = true
-    }
     const transactionsToUpdate: string[] = []
 
     for (let t = 0; t < transactions.length; t++) {
@@ -38,41 +34,21 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
           GradidoUnit.effectiveDecayDuration(previous.balance_date, transaction.balance_date)
             .seconds,
         )
-        const durationSeconds = GradidoUnit.effectiveDecayDuration(
-          previous.balance_date,
-          transaction.balance_date,
-        ).seconds
         decay = decayedBalance - balance
-        if (logEachStep) {
-          console.log(
-            `previous balance: ${balance.toString()}, decay for: ${durationSeconds.toString()} seconds = ${decayedBalance.toString()}, legacy balance: ${transaction.balance_legacy}`,
-          )
-        }
         balance = decayedBalance
       } else if (balance <= 0n) {
         if (balance < 0) {
           // biome-ignore lint/suspicious/noConsole: no logger in migration
-          console.warn(`set negative balance: ${balance.toString()} for transaction: ${transaction.id} to zero.`)
-        }
-        balance = 0n
-      } else {
-        if (logEachStep) {
-          console.log(
-            `Transaction ${transaction.id}: no previous transaction, balance=${balance.toString()}, decay=${decay.toString()}`,
+          console.warn(
+            `set negative balance: ${balance.toString()} for transaction: ${transaction.id} to zero.`,
           )
         }
+        balance = 0n
       }
       balance += amount
       if (BigInt(transaction.balance_gdd4) !== balance) {
-        if (logEachStep) {
-          console.log(
-            `Transaction ${transaction.id}: balance=${balance.toString()}, decay=${decay.toString()}`,
-          )
-        }
         countDiffs++
-        // transactionsToUpdate.push
-        await queryFn(
-
+        transactionsToUpdate.push(
           `UPDATE transactions
            SET balance_gdd4 = '${balance.toString()}',
                decay_gdd4 = '${decay.toString()}'
@@ -80,18 +56,11 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
            ;
         `,
         )
-      } else {
-        if (logEachStep) {
-          console.log(
-            `Transaction ${transaction.id}: no difference, balance=${balance.toString()}, decay=${decay.toString()}`,
-          )
-        }
+        previous = transaction
       }
-      previous = transaction
     }
     if (transactionsToUpdate.length) {
-      // runningRequests.push(queryFn(transactionsToUpdate.join('\n')))
-      // await queryFn(transactionsToUpdate.join('\n'))
+      runningRequests.push(queryFn(transactionsToUpdate.join('\n')))
     }
   }
   await Promise.all(runningRequests)

--- a/database/migration/migrations/0102-recalculate_balances.ts
+++ b/database/migration/migrations/0102-recalculate_balances.ts
@@ -9,13 +9,16 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
   for (let u = 0; u < users.length; u++) {
     process.stdout.write(`Recalculating balances for user ${u}/${users.length}\r`)
     // find all transactions for a user
-    const transactions = await queryFn(`
+    const transactions = await queryFn(
+      `
        SELECT id, amount_gdd4, balance_gdd4, decay_gdd4, balance_date
        FROM transactions
        WHERE user_id = ?
        ORDER BY balance_date ASC
        ;
-    `, [users[u].id])
+    `,
+      [users[u].id],
+    )
 
     let previous = null
     let balance = 0n

--- a/database/migration/migrations/0102-recalculate_balances.ts
+++ b/database/migration/migrations/0102-recalculate_balances.ts
@@ -38,23 +38,30 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
           GradidoUnit.effectiveDecayDuration(previous.balance_date, transaction.balance_date)
             .seconds,
         )
-        const durationSeconds = GradidoUnit.effectiveDecayDuration(previous.balance_date, transaction.balance_date)
-          .seconds
+        const durationSeconds = GradidoUnit.effectiveDecayDuration(
+          previous.balance_date,
+          transaction.balance_date,
+        ).seconds
         decay = decayedBalance - balance
         if (logEachStep) {
-            console.log(`previous balance: ${balance.toString()}, decay for: ${durationSeconds.toString()} seconds = ${decayedBalance.toString()}, legacy balance: ${transaction.balance_legacy}`)
+          console.log(
+            `previous balance: ${balance.toString()}, decay for: ${durationSeconds.toString()} seconds = ${decayedBalance.toString()}, legacy balance: ${transaction.balance_legacy}`,
+          )
         }
         balance = decayedBalance
-
       } else {
         if (logEachStep) {
-          console.log(`Transaction ${transaction.id}: no previous transaction, balance=${balance.toString()}, decay=${decay.toString()}`)
+          console.log(
+            `Transaction ${transaction.id}: no previous transaction, balance=${balance.toString()}, decay=${decay.toString()}`,
+          )
         }
       }
       balance += amount
       if (BigInt(transaction.balance_gdd4) !== balance) {
         if (logEachStep) {
-          console.log(`Transaction ${transaction.id}: balance=${balance.toString()}, decay=${decay.toString()}`)
+          console.log(
+            `Transaction ${transaction.id}: balance=${balance.toString()}, decay=${decay.toString()}`,
+          )
         }
         countDiffs++
         transactionsToUpdate.push(
@@ -67,7 +74,9 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
         )
       } else {
         if (logEachStep) {
-          console.log(`Transaction ${transaction.id}: no difference, balance=${balance.toString()}, decay=${decay.toString()}`)
+          console.log(
+            `Transaction ${transaction.id}: no difference, balance=${balance.toString()}, decay=${decay.toString()}`,
+          )
         }
       }
       previous = transaction

--- a/database/migration/migrations/0102-recalculate_balances.ts
+++ b/database/migration/migrations/0102-recalculate_balances.ts
@@ -14,7 +14,7 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
        SELECT id, amount_gdd4, balance_gdd4, decay_gdd4, balance_date
        FROM transactions
        WHERE user_id = ?
-       ORDER BY balance_date ASC
+       ORDER BY balance_date ASC, id ASC
        ;
     `,
       [users[u].id],
@@ -44,7 +44,7 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
           `UPDATE transactions
            SET balance_gdd4 = '${balance.toString()}',
                decay_gdd4 = '${decay.toString()}'
-           WHERE id = ${Number(transaction.id)}
+           WHERE id = ${transaction.id}
            ;
         `,
         )
@@ -56,12 +56,10 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
       // await queryFn(transactionsToUpdate.join('\n'))
     }
   }
-  runningRequests.push(
-    queryFn(`UPDATE transactions set decay_calculation_type = ?`, [
-      DecayCalculationType.NATIVE_C_FIXED_FACTOR_INTEGER,
-    ]),
-  )
   await Promise.all(runningRequests)
+  await queryFn(`UPDATE transactions set decay_calculation_type = ?`, [
+    DecayCalculationType.NATIVE_C_FIXED_FACTOR_INTEGER,
+  ])
   process.stdout.write(`\n`)
   // biome-ignore lint/suspicious/noConsole: no logger present
   console.log(`${countDiffs} updated transactions`)

--- a/database/migration/migrations/0102-recalculate_balances.ts
+++ b/database/migration/migrations/0102-recalculate_balances.ts
@@ -12,10 +12,11 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
     const transactions = await queryFn(`
        SELECT id, amount_gdd4, balance_gdd4, decay_gdd4, balance_date
        FROM transactions
-       WHERE user_id = ${users[u].id}
+       WHERE user_id = ?
        ORDER BY balance_date ASC
        ;
-    `)
+    `, [users[u].id])
+
     let previous = null
     let balance = 0n
     const transactionsToUpdate: string[] = []
@@ -40,7 +41,7 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
           `UPDATE transactions
            SET balance_gdd4 = '${balance.toString()}',
                decay_gdd4 = '${decay.toString()}'
-           WHERE id = ${transaction.id}
+           WHERE id = ${Number(transaction.id)}
            ;
         `,
         )

--- a/database/migration/migrations/0102-recalculate_balances.ts
+++ b/database/migration/migrations/0102-recalculate_balances.ts
@@ -57,9 +57,9 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
     }
   }
   runningRequests.push(
-    queryFn(
-      `UPDATE transactions set decay_calculation_type = ?`, [DecayCalculationType.NATIVE_C_FIXED_FACTOR_INTEGER]
-    ),
+    queryFn(`UPDATE transactions set decay_calculation_type = ?`, [
+      DecayCalculationType.NATIVE_C_FIXED_FACTOR_INTEGER,
+    ]),
   )
   await Promise.all(runningRequests)
   process.stdout.write(`\n`)

--- a/database/migration/migrations/0102-recalculate_balances.ts
+++ b/database/migration/migrations/0102-recalculate_balances.ts
@@ -11,7 +11,7 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
     // find all transactions for a user
     const transactions = await queryFn(
       `
-       SELECT id, amount_gdd4, balance_gdd4, decay_gdd4, balance_date
+       SELECT id, amount_gdd4, balance_gdd4, balance_legacy, decay_gdd4, balance_date
        FROM transactions
        WHERE user_id = ?
        ORDER BY balance_date ASC, id ASC
@@ -22,6 +22,10 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
 
     let previous = null
     let balance = 0n
+    let logEachStep = false
+    if (users[u].id === 764) {
+      logEachStep = true
+    }
     const transactionsToUpdate: string[] = []
 
     for (let t = 0; t < transactions.length; t++) {
@@ -34,11 +38,24 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
           GradidoUnit.effectiveDecayDuration(previous.balance_date, transaction.balance_date)
             .seconds,
         )
+        const durationSeconds = GradidoUnit.effectiveDecayDuration(previous.balance_date, transaction.balance_date)
+          .seconds
         decay = decayedBalance - balance
+        if (logEachStep) {
+            console.log(`previous balance: ${balance.toString()}, decay for: ${durationSeconds.toString()} seconds = ${decayedBalance.toString()}, legacy balance: ${transaction.balance_legacy}`)
+        }
         balance = decayedBalance
+
+      } else {
+        if (logEachStep) {
+          console.log(`Transaction ${transaction.id}: no previous transaction, balance=${balance.toString()}, decay=${decay.toString()}`)
+        }
       }
       balance += amount
       if (BigInt(transaction.balance_gdd4) !== balance) {
+        if (logEachStep) {
+          console.log(`Transaction ${transaction.id}: balance=${balance.toString()}, decay=${decay.toString()}`)
+        }
         countDiffs++
         transactionsToUpdate.push(
           `UPDATE transactions
@@ -48,6 +65,10 @@ export async function upgrade(queryFn: (query: string, values?: any[]) => Promis
            ;
         `,
         )
+      } else {
+        if (logEachStep) {
+          console.log(`Transaction ${transaction.id}: no difference, balance=${balance.toString()}, decay=${decay.toString()}`)
+        }
       }
       previous = transaction
     }

--- a/database/migration/migrations/0102-recalculate_balances.ts
+++ b/database/migration/migrations/0102-recalculate_balances.ts
@@ -1,0 +1,74 @@
+import { DecayCalculationType, GradidoUnit } from 'shared'
+import { calculateDecay } from 'shared-native'
+
+export async function upgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  // Find all users & loop over them
+  const runningRequests: Promise<Array<any>>[] = []
+  const users = await queryFn('SELECT id FROM users')
+  let countDiffs = 0
+  for (let u = 0; u < users.length; u++) {
+    process.stdout.write(`Recalculating balances for user ${u}/${users.length}\r`)
+    // find all transactions for a user
+    const transactions = await queryFn(`
+       SELECT id, amount_gdd4, balance_gdd4, decay_gdd4, balance_date
+       FROM transactions
+       WHERE user_id = ${users[u].id}
+       ORDER BY balance_date ASC
+       ;
+    `)
+    let previous = null
+    let balance = 0n
+    const transactionsToUpdate: string[] = []
+
+    for (let t = 0; t < transactions.length; t++) {
+      const transaction = transactions[t]
+      const amount = BigInt(transaction.amount_gdd4)
+      let decay = 0n
+      if (balance && previous) {
+        const decayedBalance = calculateDecay(
+          balance,
+          GradidoUnit.effectiveDecayDuration(previous.balance_date, transaction.balance_date)
+            .seconds,
+        )
+        decay = decayedBalance - balance
+        balance = decayedBalance
+      }
+      balance += amount
+      if (BigInt(transaction.balance_gdd4) !== balance) {
+        countDiffs++
+        transactionsToUpdate.push(
+          `UPDATE transactions
+           SET balance_gdd4 = '${balance.toString()}',
+               decay_gdd4 = '${decay.toString()}'
+           WHERE id = ${transaction.id}
+           ;
+        `,
+        )
+      }
+      previous = transaction
+    }
+    if (transactionsToUpdate.length) {
+      runningRequests.push(queryFn(transactionsToUpdate.join('\n')))
+      // await queryFn(transactionsToUpdate.join('\n'))
+    }
+  }
+  runningRequests.push(
+    queryFn(
+      `UPDATE transactions set decay_calculation_type = ${DecayCalculationType.NATIVE_C_FIXED_FACTOR_INTEGER}`,
+    ),
+  )
+  await Promise.all(runningRequests)
+  process.stdout.write(`\n`)
+  // biome-ignore lint/suspicious/noConsole: no logger present
+  console.log(`${countDiffs} updated transactions`)
+}
+
+export async function downgrade(queryFn: (query: string, values?: any[]) => Promise<Array<any>>) {
+  await queryFn(`
+    UPDATE transactions
+    SET balance_gdd4 = CAST(ROUND(balance_legacy * 10000) AS SIGNED),
+        decay_gdd4 = CAST(ROUND(decay_legacy * 10000) AS SIGNED); `)
+  await queryFn(
+    `UPDATE transactions set decay_calculation_type = ${DecayCalculationType.DECIMAL_JS_FIXED_FACTOR}`,
+  )
+}

--- a/database/migration/scripts/removeCrossGroupTransactions.ts
+++ b/database/migration/scripts/removeCrossGroupTransactions.ts
@@ -39,7 +39,13 @@ function calculateBalance(
     }
   } else {
     // update balance with decay
-    const lastTransactionBalance = GradidoUnit.fromGradidoCent(lastTransaction.balance)
+    let lastTransactionBalance = GradidoUnit.fromGradidoCent(lastTransaction.balance)
+    if (lastTransactionBalance.gddCent <= 0) {
+      return {
+        balance: currentTransaction.amount,
+        decay: 0n
+      }
+    }
     const decay = lastTransactionBalance.calculateDecay(lastTransaction.balanceDate, currentTransaction.balanceDate)
     const newBalance = decay.balance.add(GradidoUnit.fromGradidoCent(currentTransaction.amount))
 

--- a/dlt-connector/bun.lock
+++ b/dlt-connector/bun.lock
@@ -19,7 +19,6 @@
         "@types/uuid": "^8.3.4",
         "adm-zip": "^0.5.16",
         "async-mutex": "^0.5.0",
-        "decimal.js-light": "^2.5.1",
         "dotenv": "^10.0.0",
         "drizzle-orm": "^0.44.7",
         "elysia": "1.3.8",
@@ -446,8 +445,6 @@
     "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
 
     "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
-
-    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 

--- a/dlt-connector/bun.lock
+++ b/dlt-connector/bun.lock
@@ -5,7 +5,7 @@
       "name": "dlt-connector",
       "dependencies": {
         "cross-env": "^7.0.3",
-        "gradido-blockchain-js": "git+https://github.com/gradido/gradido-blockchain-js#61dabaaca680dedbe6911482d5562f103497d86a",
+        "gradido-blockchain-js": "git+https://github.com/gradido/gradido-blockchain-js#08c8dab30103ba3027a2d056df3d1467ed153edb",
       },
       "devDependencies": {
         "@biomejs/biome": "2.0.0",
@@ -578,7 +578,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "gradido-blockchain-js": ["gradido-blockchain-js@github:gradido/gradido-blockchain-js#61dabaa", { "dependencies": { "bindings": "^1.5.0", "nan": "^2.20.0", "node-addon-api": "^7.1.1", "node-gyp-build": "^4.8.1", "prebuildify": "git+https://github.com/einhornimmond/prebuildify#65d94455fab86b902c0d59bb9c06ac70470e56b2" } }, "gradido-gradido-blockchain-js-61dabaa"],
+    "gradido-blockchain-js": ["gradido-blockchain-js@github:gradido/gradido-blockchain-js#08c8dab", { "dependencies": { "bindings": "^1.5.0", "nan": "^2.20.0", "node-addon-api": "^7.1.1", "node-gyp-build": "^4.8.1", "prebuildify": "git+https://github.com/einhornimmond/prebuildify#65d94455fab86b902c0d59bb9c06ac70470e56b2" } }, "gradido-gradido-blockchain-js-08c8dab"],
 
     "graphql": ["graphql@16.11.0", "", {}, "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw=="],
 

--- a/dlt-connector/bunfig.toml
+++ b/dlt-connector/bunfig.toml
@@ -1,1 +1,0 @@
-preload = ["bun-zigar"]

--- a/dlt-connector/package.json
+++ b/dlt-connector/package.json
@@ -10,7 +10,7 @@
     "start": "cross-env TZ=UTC bun run src/index.ts",
     "build": "bun build src/index.ts --outdir=build --target=bun --external=gradido-blockchain-js --minify",
     "dev": "cross-env TZ=UTC bun run --watch src/index.ts",
-    "migrate": "cross-env TZ=UTC bun src/migrations/db-v2.7.0_to_blockchain-v3.7",
+    "migrate": "cross-env TZ=UTC bun src/migrations/db-v2.7.0_to_blockchain-v3.7 --use-only-legacy-ledger-anchor-ids",
     "test": "cross-env TZ=UTC bun test",
     "test:debug": "cross-env TZ=UTC bun test --inspect-brk",
     "typecheck": "tsc --noEmit",

--- a/dlt-connector/package.json
+++ b/dlt-connector/package.json
@@ -33,7 +33,6 @@
     "@types/uuid": "^8.3.4",
     "adm-zip": "^0.5.16",
     "async-mutex": "^0.5.0",
-    "decimal.js-light": "^2.5.1",
     "dotenv": "^10.0.0",
     "drizzle-orm": "^0.44.7",
     "elysia": "1.3.8",

--- a/dlt-connector/package.json
+++ b/dlt-connector/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "cross-env": "^7.0.3",
-    "gradido-blockchain-js": "git+https://github.com/gradido/gradido-blockchain-js#61dabaaca680dedbe6911482d5562f103497d86a"
+    "gradido-blockchain-js": "git+https://github.com/gradido/gradido-blockchain-js#08c8dab30103ba3027a2d056df3d1467ed153edb"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.0",

--- a/dlt-connector/src/config/schema.ts
+++ b/dlt-connector/src/config/schema.ts
@@ -84,7 +84,7 @@ export const configSchema = v.object({
       v.string('The version of the DLT node server, for example: 0.9.0'),
       v.regex(/^\d+\.\d+\.\d+(.\d+)?$/),
     ),
-    '0.9.8.1',
+    '0.9.8.5',
   ),
   DLT_GRADIDO_NODE_SERVER_HOME_FOLDER: v.optional(
     v.string('The home folder for the gradido dlt node server'),

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/Context.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/Context.ts
@@ -21,6 +21,7 @@ export class Context {
   public communities: Map<string, CommunityContext>
   public cache: KeyPairCacheManager
   public nativeDecayCalculationStartDate: Date
+  public useOnlyLegacyLedgerAnchorIds: boolean = false
   private timeUsed: MonotonicTimer
 
   constructor(
@@ -35,6 +36,7 @@ export class Context {
     this.communities = new Map<string, CommunityContext>()
     this.nativeDecayCalculationStartDate = nativeDecayCalculationStartDate
     this.timeUsed = new MonotonicTimer()
+    this.useOnlyLegacyLedgerAnchorIds = process.argv.includes('--use-only-legacy-ledger-anchor-ids')
   }
 
   static async create(): Promise<Context> {

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/data/Balance.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/data/Balance.ts
@@ -1,13 +1,5 @@
-import Decimal from 'decimal.js-light'
 import { AccountBalance, GradidoUnit, MemoryBlockPtr } from 'gradido-blockchain-js'
-import { Amount } from '../../../schemas/typeGuard.schema'
 import { NegativeBalanceError } from '../errors'
-import { legacyCalculateDecay } from '../utils'
-
-Decimal.set({
-  precision: 25,
-  rounding: Decimal.ROUND_HALF_UP,
-})
 
 export class Balance {
   private balance: GradidoUnit
@@ -38,62 +30,6 @@ export class Balance {
 
   getDate(): Date {
     return this.date
-  }
-
-  updateLegacyDecay(amount: GradidoUnit, date: Date, dbBalance?: Amount) {
-    // make sure to copy instead of referencing
-    const previousBalanceString = this.balance.toString()
-    const previousDate = new Date(this.date.getTime())
-
-    if (this.balance.equal(GradidoUnit.zero())) {
-      this.balance = amount
-      this.date = date
-    } else {
-      const decayedBalance = legacyCalculateDecay(
-        new Decimal(this.balance.toString()),
-        this.date,
-        date,
-      ).toDecimalPlaces(4, Decimal.ROUND_CEIL)
-      /*
-        if (!decayedBalance.equals(this.balance.toString())) {
-        console.log({
-          input: this.balance.toString(4),
-          decayed: decayedBalance.toString(),
-          amount: amount.toString(4),
-          date
-        })
-        // throw new Error("Test Exit")
-      }
-      // */
-
-      let newBalance = decayedBalance.add(new Decimal(amount.toString()))
-      // reduce small deviations between db decay and balance calculation with 25 decimal places vs gradido-blockchain with 4
-      if (
-        dbBalance &&
-        new Decimal(newBalance.toString()).minus(dbBalance).abs() < new Decimal(0.01)
-      ) {
-        newBalance = new Decimal(dbBalance)
-      }
-      this.balance = GradidoUnit.fromString(newBalance.toString())
-      this.date = date
-    }
-    if (this.balance.lt(GradidoUnit.zero())) {
-      if (this.balance.lt(GradidoUnit.fromGradidoCent(100n).negated())) {
-        const previousDecayedBalance = legacyCalculateDecay(
-          new Decimal(previousBalanceString),
-          previousDate,
-          date,
-        )
-        throw new NegativeBalanceError(
-          `negative Gradido amount detected in Balance.updateLegacyDecay`,
-          previousBalanceString,
-          amount.toString(),
-          previousDecayedBalance.toString(),
-        )
-      } else {
-        this.balance = GradidoUnit.zero()
-      }
-    }
   }
 
   update(amount: GradidoUnit, date: Date) {

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/drizzle.schema.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/drizzle.schema.ts
@@ -3,7 +3,6 @@ import {
   bigint,
   char,
   datetime,
-  decimal,
   index,
   int,
   mysqlTable,
@@ -78,7 +77,6 @@ export const transactionsTable = mysqlTable(
     transactionLinkId: int('transaction_link_id').default(sql`NULL`),
     amount: bigint('amount_gdd4', { mode: 'bigint' }).default(sql`NULL`),
     balance: bigint('balance_gdd4', { mode: 'bigint' }).default(sql`NULL`),
-    balanceFull: decimal('balance_legacy', { precision: 40, scale: 20 }).default(sql`NULL`),
     balanceDate: datetime('balance_date', { mode: 'string', fsp: 3 })
       .default(sql`current_timestamp(3)`)
       .notNull(),

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/AbstractSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/AbstractSync.role.ts
@@ -2,8 +2,11 @@ import {
   AccountBalances,
   Filter,
   GradidoTransactionBuilder,
+  HieroTransactionId,
   InMemoryBlockchain,
   KeyPairEd25519,
+  LedgerAnchor,
+  LedgerAnchor_Type,
   MemoryBlockPtr,
   MonotonicTimer,
   SearchDirection_DESC,
@@ -11,7 +14,7 @@ import {
 import { getLogger, Logger } from 'log4js'
 import { LOG4JS_BASE_CATEGORY } from '../../../../config/const'
 import { deriveFromKeyPairAndIndex, deriveFromKeyPairAndUuid } from '../../../../data/deriveKeyPair'
-import { Uuidv4 } from '../../../../schemas/typeGuard.schema'
+import { HieroTransactionIdString, Uuidv4 } from '../../../../schemas/typeGuard.schema'
 import { Context } from '../../Context'
 import { Balance } from '../../data/Balance'
 import { CommunityContext } from '../../valibot.schema'
@@ -20,22 +23,31 @@ export type IndexType = {
   date: Date
   id: number
 }
+export interface SyncItem {
+  id: number
+  messageId?: HieroTransactionIdString | null | undefined
+}
 export let nanosBalanceForUser = 0
 const lastBalanceOfUserTimeUsed = new MonotonicTimer()
 
-export abstract class AbstractSyncRole<ItemType> {
+export abstract class AbstractSyncRole<ItemType extends SyncItem> {
   private items: ItemType[] = []
   protected lastIndex: IndexType = { date: new Date(0), id: 0 }
   protected logger: Logger
   protected transactionBuilder: GradidoTransactionBuilder
   protected accountBalances: AccountBalances
+  protected legacyAnchorType: LedgerAnchor_Type
 
-  constructor(protected readonly context: Context) {
+  constructor(
+    protected readonly context: Context,
+    legacyAnchorType: LedgerAnchor_Type,
+  ) {
     this.logger = getLogger(
       `${LOG4JS_BASE_CATEGORY}.migrations.db-v2.7.0_to_blockchain-v3.5.interaction.syncDbWithBlockchain`,
     )
     this.transactionBuilder = new GradidoTransactionBuilder()
     this.accountBalances = new AccountBalances()
+    this.legacyAnchorType = legacyAnchorType
   }
 
   getAccountKeyPair(communityContext: CommunityContext, gradidoId: Uuidv4): KeyPairEd25519 {
@@ -82,6 +94,14 @@ export abstract class AbstractSyncRole<ItemType> {
     )
     nanosBalanceForUser += lastBalanceOfUserTimeUsed.nanos()
     return result
+  }
+
+  getLedgerAnchor(item: ItemType): LedgerAnchor {
+    if (item.messageId && !this.context.useOnlyLegacyLedgerAnchorIds) {
+      return new LedgerAnchor(new HieroTransactionId(item.messageId))
+    } else {
+      return new LedgerAnchor(item.id, this.legacyAnchorType)
+    }
   }
 
   logLastBalanceChangingTransactions(

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/CreationsSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/CreationsSync.role.ts
@@ -6,7 +6,6 @@ import {
   EncryptedMemo,
   Filter,
   GradidoTransactionBuilder,
-  HieroTransactionId,
   KeyPairEd25519,
   LedgerAnchor,
   MemoryBlockPtr,
@@ -31,7 +30,7 @@ import { AbstractSyncRole, IndexType } from './AbstractSync.role'
 
 export class CreationsSyncRole extends AbstractSyncRole<CreationTransactionDb> {
   constructor(context: Context) {
-    super(context)
+    super(context, LedgerAnchor.Type_LEGACY_GRADIDO_DB_CONTRIBUTION_ID)
     this.accountBalances.reserve(3n)
   }
 
@@ -165,22 +164,11 @@ export class CreationsSyncRole extends AbstractSyncRole<CreationTransactionDb> {
     }
 
     try {
-      let ledgerAnchor: LedgerAnchor | undefined
-      if (item.messageId) {
-        ledgerAnchor = new LedgerAnchor(new HieroTransactionId(item.messageId))
-      } else {
-        ledgerAnchor = new LedgerAnchor(
-          item.id,
-          LedgerAnchor.Type_LEGACY_GRADIDO_DB_CONTRIBUTION_ID,
-        )
-      }
       addToBlockchain(
         this.buildTransaction(item, communityContext, recipientKeyPair, signerKeyPair).build(),
         blockchain,
-        ledgerAnchor,
-        !this.context.isDecayCalculationTypeChanged(item.confirmedAt)
-          ? this.calculateAccountBalances(item, communityContext, recipientPublicKey)
-          : undefined,
+        this.getLedgerAnchor(item),
+        this.calculateAccountBalances(item, communityContext, recipientPublicKey),
       )
     } catch (e) {
       const f = new Filter()

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/CreationsSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/CreationsSync.role.ts
@@ -136,10 +136,10 @@ export class CreationsSyncRole extends AbstractSyncRole<CreationTransactionDb> {
       communityContext.communityId,
     )
 
-    // calculate decay since last balance with legacy calculation method
-    balance.updateLegacyDecay(item.amount, item.confirmedAt)
-    communityContext.aufBalance.updateLegacyDecay(item.amount, item.confirmedAt)
-    communityContext.gmwBalance.updateLegacyDecay(item.amount, item.confirmedAt)
+    // calculate decay since last balance
+    balance.update(item.amount, item.confirmedAt)
+    communityContext.aufBalance.update(item.amount, item.confirmedAt)
+    communityContext.gmwBalance.update(item.amount, item.confirmedAt)
 
     this.accountBalances.add(balance.getAccountBalance())
     this.accountBalances.add(communityContext.aufBalance.getAccountBalance())

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/DeletedTransactionLinksSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/DeletedTransactionLinksSync.role.ts
@@ -7,7 +7,6 @@ import {
   GradidoTransactionBuilder,
   GradidoTransfer,
   GradidoUnit,
-  HieroTransactionId,
   KeyPairEd25519,
   LedgerAnchor,
   MemoryBlockPtr,
@@ -31,7 +30,7 @@ import { AbstractSyncRole, IndexType } from './AbstractSync.role'
 
 export class DeletedTransactionLinksSyncRole extends AbstractSyncRole<DeletedTransactionLinkDb> {
   constructor(context: Context) {
-    super(context)
+    super(context, LedgerAnchor.Type_LEGACY_GRADIDO_DB_TRANSACTION_LINK_ID)
     this.accountBalances.reserve(2n)
   }
 
@@ -186,15 +185,6 @@ export class DeletedTransactionLinksSyncRole extends AbstractSyncRole<DeletedTra
     senderLastBalance.updateLegacyDecay(GradidoUnit.zero(), item.deletedAt)
 
     try {
-      let ledgerAnchor: LedgerAnchor
-      if (item.messageId) {
-        ledgerAnchor = new LedgerAnchor(new HieroTransactionId(item.messageId))
-      } else {
-        ledgerAnchor = new LedgerAnchor(
-          item.id,
-          LedgerAnchor.Type_LEGACY_GRADIDO_DB_TRANSACTION_LINK_ID,
-        )
-      }
       addToBlockchain(
         this.buildTransaction(
           communityContext,
@@ -205,7 +195,7 @@ export class DeletedTransactionLinksSyncRole extends AbstractSyncRole<DeletedTra
           linkFundingPublicKey,
         ).build(),
         blockchain,
-        ledgerAnchor,
+        this.getLedgerAnchor(item),
         this.calculateBalances(
           item,
           deferredTransfer,

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/DeletedTransactionLinksSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/DeletedTransactionLinksSync.role.ts
@@ -132,7 +132,7 @@ export class DeletedTransactionLinksSyncRole extends AbstractSyncRole<DeletedTra
       communityContext.blockchain,
       communityContext.communityId,
     )
-    fundingUserLastBalance.updateLegacyDecay(senderLastBalance.getBalance(), item.deletedAt)
+    fundingUserLastBalance.update(senderLastBalance.getBalance(), item.deletedAt)
 
     // account of link is set to zero, gdd will be send back to initiator
     this.accountBalances.add(
@@ -182,7 +182,7 @@ export class DeletedTransactionLinksSyncRole extends AbstractSyncRole<DeletedTra
       communityContext.blockchain,
       communityContext.communityId,
     )
-    senderLastBalance.updateLegacyDecay(GradidoUnit.zero(), item.deletedAt)
+    senderLastBalance.update(GradidoUnit.zero(), item.deletedAt)
 
     try {
       addToBlockchain(

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/LocalTransactionsSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/LocalTransactionsSync.role.ts
@@ -6,7 +6,6 @@ import {
   AuthenticatedEncryption,
   EncryptedMemo,
   GradidoTransactionBuilder,
-  HieroTransactionId,
   KeyPairEd25519,
   LedgerAnchor,
   MemoryBlockPtr,
@@ -31,7 +30,7 @@ import { AbstractSyncRole, IndexType } from './AbstractSync.role'
 
 export class LocalTransactionsSyncRole extends AbstractSyncRole<TransactionDb> {
   constructor(context: Context) {
-    super(context)
+    super(context, LedgerAnchor.Type_LEGACY_GRADIDO_DB_TRANSACTION_ID)
     this.accountBalances.reserve(2n)
   }
 
@@ -181,19 +180,11 @@ export class LocalTransactionsSyncRole extends AbstractSyncRole<TransactionDb> {
     }
 
     try {
-      let ledgerAnchor: LedgerAnchor | undefined
-      if (item.messageId) {
-        ledgerAnchor = new LedgerAnchor(new HieroTransactionId(item.messageId))
-      } else {
-        ledgerAnchor = new LedgerAnchor(item.id, LedgerAnchor.Type_LEGACY_GRADIDO_DB_TRANSACTION_ID)
-      }
       addToBlockchain(
         this.buildTransaction(communityContext, item, senderKeyPair, recipientKeyPair).build(),
         blockchain,
-        ledgerAnchor,
-        item.decayCalculationType === DecayCalculationType.DECIMAL_JS_FIXED_FACTOR
-          ? this.calculateBalances(item, communityContext, senderPublicKey, recipientPublicKey)
-          : undefined,
+        this.getLedgerAnchor(item),
+        this.calculateBalances(item, communityContext, senderPublicKey, recipientPublicKey),
       )
     } catch (e) {
       if (e instanceof NotEnoughGradidoBalanceError) {

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/LocalTransactionsSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/LocalTransactionsSync.role.ts
@@ -1,4 +1,3 @@
-import Decimal from 'decimal.js-light'
 import { and, asc, eq, gt, isNotNull, isNull, or } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/mysql-core'
 import {
@@ -93,9 +92,6 @@ export class LocalTransactionsSyncRole extends AbstractSyncRole<TransactionDb> {
       if (item.amount) {
         item.amount = -item.amount
       }
-      if (item.balanceFull && new Decimal(item.balanceFull).isNegative()) {
-        item.balanceFull = '0'
-      }
       try {
         return v.parse(transactionDbSchema, item)
       } catch (e) {
@@ -147,14 +143,14 @@ export class LocalTransactionsSyncRole extends AbstractSyncRole<TransactionDb> {
     )
 
     try {
-      senderLastBalance.updateLegacyDecay(item.amount.negated(), item.balanceDate, item.balanceFull)
+      senderLastBalance.update(item.amount.negated(), item.balanceDate)
     } catch (e) {
       if (e instanceof NegativeBalanceError) {
         this.logLastBalanceChangingTransactions(senderPublicKey, communityContext.blockchain)
         throw e
       }
     }
-    recipientLastBalance.updateLegacyDecay(item.amount, item.balanceDate)
+    recipientLastBalance.update(item.amount, item.balanceDate)
 
     this.accountBalances.add(senderLastBalance.getAccountBalance())
     this.accountBalances.add(recipientLastBalance.getAccountBalance())

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/RedeemTransactionLinksSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/RedeemTransactionLinksSync.role.ts
@@ -10,7 +10,6 @@ import {
   GradidoTransactionBuilder,
   GradidoTransfer,
   GradidoUnit,
-  HieroTransactionId,
   KeyPairEd25519,
   LedgerAnchor,
   MemoryBlockPtr,
@@ -39,7 +38,7 @@ import { AbstractSyncRole, IndexType } from './AbstractSync.role'
 
 export class RedeemTransactionLinksSyncRole extends AbstractSyncRole<RedeemedTransactionLinkDb> {
   constructor(context: Context) {
-    super(context)
+    super(context, LedgerAnchor.Type_LEGACY_GRADIDO_DB_TRANSACTION_LINK_ID)
     this.accountBalances.reserve(3n)
   }
 
@@ -226,15 +225,6 @@ export class RedeemTransactionLinksSyncRole extends AbstractSyncRole<RedeemedTra
     }
 
     try {
-      let ledgerAnchor: LedgerAnchor | undefined
-      if (item.messageId) {
-        ledgerAnchor = new LedgerAnchor(new HieroTransactionId(item.messageId))
-      } else {
-        ledgerAnchor = new LedgerAnchor(
-          item.id,
-          LedgerAnchor.Type_LEGACY_GRADIDO_DB_TRANSACTION_LINK_ID,
-        )
-      }
       addToBlockchain(
         this.buildTransaction(
           communityContext,
@@ -244,16 +234,14 @@ export class RedeemTransactionLinksSyncRole extends AbstractSyncRole<RedeemedTra
           recipientKeyPair,
         ).build(),
         blockchain,
-        ledgerAnchor,
-        this.context.isDecayCalculationTypeChanged(item.redeemedAt)
-          ? undefined
-          : this.calculateBalances(
-              item,
-              deferredTransfer,
-              communityContext,
-              senderPublicKey,
-              recipientPublicKey,
-            ),
+        this.getLedgerAnchor(item),
+        this.calculateBalances(
+          item,
+          deferredTransfer,
+          communityContext,
+          senderPublicKey,
+          recipientPublicKey,
+        ),
       )
     } catch (e) {
       throw new BlockchainError(`Error adding ${this.itemTypeName()}`, item, e as Error)

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/RedeemTransactionLinksSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/RedeemTransactionLinksSync.role.ts
@@ -177,9 +177,9 @@ export class RedeemTransactionLinksSyncRole extends AbstractSyncRole<RedeemedTra
         `sender has not enough balance (${senderLastBalance.getAccountBalance().getBalance().toString()}) to send ${item.amount.toString()} to ${recipientPublicKey.convertToHex()}`,
       )
     }
-    senderLastBalance.updateLegacyDecay(item.amount.negated(), item.redeemedAt)
-    fundingUserLastBalance.updateLegacyDecay(senderLastBalance.getBalance(), item.redeemedAt)
-    recipientLastBalance.updateLegacyDecay(item.amount, item.redeemedAt)
+    senderLastBalance.update(item.amount.negated(), item.redeemedAt)
+    fundingUserLastBalance.update(senderLastBalance.getBalance(), item.redeemedAt)
+    recipientLastBalance.update(item.amount, item.redeemedAt)
 
     // account of link is set to zero, and change send back to link creator
     this.accountBalances.add(

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/RemoteTransactionsSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/RemoteTransactionsSync.role.ts
@@ -1,4 +1,3 @@
-import Decimal from 'decimal.js-light'
 import { and, asc, eq, gt, inArray, isNull, ne, or } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/mysql-core'
 import {
@@ -91,9 +90,6 @@ export class RemoteTransactionsSyncRole extends AbstractSyncRole<TransactionDb> 
       if (item.typeId === TransactionTypeId.SEND && item.amount) {
         item.amount *= -1n
       }
-      if (item.balanceFull && new Decimal(item.balanceFull).isNegative()) {
-        item.balanceFull = '0'
-      }
       try {
         return v.parse(transactionDbSchema, item)
       } catch (e) {
@@ -167,11 +163,7 @@ export class RemoteTransactionsSyncRole extends AbstractSyncRole<TransactionDb> 
     }
 
     try {
-      if (item.decayCalculationType === DecayCalculationType.DECIMAL_JS_FIXED_FACTOR) {
-        lastBalance.updateLegacyDecay(amount, item.balanceDate, item.balanceFull)
-      } else {
-        lastBalance.update(amount, item.balanceDate)
-      }
+      lastBalance.update(amount, item.balanceDate)
     } catch (e) {
       if (e instanceof NegativeBalanceError) {
         this.logLastBalanceChangingTransactions(publicKey, communityContext.blockchain, 1)

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/RemoteTransactionsSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/RemoteTransactionsSync.role.ts
@@ -32,7 +32,7 @@ import { AbstractSyncRole, IndexType } from './AbstractSync.role'
 
 export class RemoteTransactionsSyncRole extends AbstractSyncRole<TransactionDb> {
   constructor(context: Context) {
-    super(context)
+    super(context, LedgerAnchor.Type_LEGACY_GRADIDO_DB_TRANSACTION_ID)
     this.accountBalances.reserve(1n)
   }
 
@@ -190,10 +190,7 @@ export class RemoteTransactionsSyncRole extends AbstractSyncRole<TransactionDb> 
 
   pushToBlockchain(item: TransactionDb): void {
     const { senderUser, recipientUser } = this.getUser(item)
-    const ledgerAnchor = new LedgerAnchor(
-      item.id,
-      LedgerAnchor.Type_LEGACY_GRADIDO_DB_TRANSACTION_ID,
-    )
+    const ledgerAnchor = this.getLedgerAnchor(item)
 
     if (senderUser.communityUuid === recipientUser.communityUuid) {
       throw new Error(

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/TransactionLinkFundingsSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/TransactionLinkFundingsSync.role.ts
@@ -1,4 +1,3 @@
-import Decimal from 'decimal.js-light'
 import { and, asc, eq, gt, or } from 'drizzle-orm'
 import {
   AccountBalance,
@@ -21,7 +20,7 @@ import { addToBlockchain } from '../../blockchain'
 import { Context } from '../../Context'
 import { dltTransactionsTable, transactionLinksTable, usersTable } from '../../drizzle.schema'
 import { BlockchainError, DatabaseError, NegativeBalanceError } from '../../errors'
-import { reverseLegacyDecay, toMysqlDateTime } from '../../utils'
+import { toMysqlDateTime } from '../../utils'
 import { CommunityContext, TransactionLinkDb, transactionLinkDbSchema } from '../../valibot.schema'
 import { AbstractSyncRole, IndexType } from './AbstractSync.role'
 
@@ -132,7 +131,7 @@ export class TransactionLinkFundingsSyncRole extends AbstractSyncRole<Transactio
       communityContext.communityId,
     )
     try {
-      senderLastBalance.updateLegacyDecay(blockedAmount.negated(), item.createdAt)
+      senderLastBalance.update(blockedAmount.negated(), item.createdAt)
     } catch (e) {
       if (e instanceof NegativeBalanceError) {
         this.logLastBalanceChangingTransactions(senderPublicKey, communityContext.blockchain)
@@ -163,9 +162,7 @@ export class TransactionLinkFundingsSyncRole extends AbstractSyncRole<Transactio
     const duration = new DurationSeconds(
       (item.validUntil.getTime() - item.createdAt.getTime()) / 1000,
     )
-    let blockedAmount = GradidoUnit.fromString(
-      reverseLegacyDecay(new Decimal(item.amount.toString()), duration.getSeconds()).toString(),
-    )
+    let blockedAmount = item.amount.calculateCompoundInterest(duration.getSeconds())
     let accountBalances: AccountBalances | undefined
     try {
       accountBalances = this.calculateBalances(
@@ -182,7 +179,7 @@ export class TransactionLinkFundingsSyncRole extends AbstractSyncRole<Transactio
           communityContext.blockchain,
           communityContext.communityId,
         )
-        senderLastBalance.updateLegacyDecay(GradidoUnit.zero(), item.createdAt)
+        senderLastBalance.update(GradidoUnit.zero(), item.createdAt)
         const oldBlockedAmountString = blockedAmount.toString()
         blockedAmount = senderLastBalance.getBalance()
         accountBalances = this.calculateBalances(

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/TransactionLinkFundingsSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/TransactionLinkFundingsSync.role.ts
@@ -9,7 +9,6 @@ import {
   GradidoTransactionBuilder,
   GradidoTransfer,
   GradidoUnit,
-  HieroTransactionId,
   KeyPairEd25519,
   LedgerAnchor,
   MemoryBlockPtr,
@@ -28,7 +27,7 @@ import { AbstractSyncRole, IndexType } from './AbstractSync.role'
 
 export class TransactionLinkFundingsSyncRole extends AbstractSyncRole<TransactionLinkDb> {
   constructor(context: Context) {
-    super(context)
+    super(context, LedgerAnchor.Type_LEGACY_GRADIDO_DB_TRANSACTION_LINK_ID)
     this.accountBalances.reserve(2n)
   }
   getDate(): Date {
@@ -169,15 +168,13 @@ export class TransactionLinkFundingsSyncRole extends AbstractSyncRole<Transactio
     )
     let accountBalances: AccountBalances | undefined
     try {
-      if (!this.context.isDecayCalculationTypeChanged(item.createdAt)) {
-        accountBalances = this.calculateBalances(
-          item,
-          blockedAmount,
-          communityContext,
-          senderPublicKey,
-          recipientPublicKey,
-        )
-      }
+      accountBalances = this.calculateBalances(
+        item,
+        blockedAmount,
+        communityContext,
+        senderPublicKey,
+        recipientPublicKey,
+      )
     } catch (e) {
       if (item.deletedAt && e instanceof NegativeBalanceError) {
         const senderLastBalance = this.getLastBalanceForUser(
@@ -206,15 +203,6 @@ export class TransactionLinkFundingsSyncRole extends AbstractSyncRole<Transactio
       }
     }
     try {
-      let ledgerAnchor: LedgerAnchor | undefined
-      if (item.messageId) {
-        ledgerAnchor = new LedgerAnchor(new HieroTransactionId(item.messageId))
-      } else {
-        ledgerAnchor = new LedgerAnchor(
-          item.id,
-          LedgerAnchor.Type_LEGACY_GRADIDO_DB_TRANSACTION_LINK_ID,
-        )
-      }
       addToBlockchain(
         this.buildTransaction(
           communityContext,
@@ -225,7 +213,7 @@ export class TransactionLinkFundingsSyncRole extends AbstractSyncRole<Transactio
           recipientKeyPair,
         ).build(),
         blockchain,
-        ledgerAnchor,
+        this.getLedgerAnchor(item),
         accountBalances,
       )
     } catch (e) {

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/UsersSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/UsersSync.role.ts
@@ -5,7 +5,6 @@ import {
   AddressType_COMMUNITY_HUMAN,
   GradidoTransactionBuilder,
   GradidoUnit,
-  HieroTransactionId,
   KeyPairEd25519,
   LedgerAnchor,
   MemoryBlockPtr,
@@ -121,12 +120,6 @@ export class UsersSyncRole extends AbstractSyncRole<UserDb> {
     }
 
     try {
-      let ledgerAnchor: LedgerAnchor | undefined
-      if (item.messageId) {
-        ledgerAnchor = new LedgerAnchor(new HieroTransactionId(item.messageId))
-      } else {
-        ledgerAnchor = new LedgerAnchor(item.id, LedgerAnchor.Type_LEGACY_GRADIDO_DB_USER_ID)
-      }
       addToBlockchain(
         this.buildTransaction(
           communityContext,
@@ -136,7 +129,7 @@ export class UsersSyncRole extends AbstractSyncRole<UserDb> {
           userKeyPair,
         ).build(),
         communityContext.blockchain,
-        ledgerAnchor,
+        this.getLedgerAnchor(item),
         this.calculateAccountBalances(accountPublicKey, communityContext),
       )
     } catch (e) {

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/UsersSync.role.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/interaction/syncDbWithBlockchain/UsersSync.role.ts
@@ -24,7 +24,7 @@ import { AbstractSyncRole, IndexType } from './AbstractSync.role'
 
 export class UsersSyncRole extends AbstractSyncRole<UserDb> {
   constructor(context: Context) {
-    super(context)
+    super(context, LedgerAnchor.Type_LEGACY_GRADIDO_DB_USER_ID)
     this.accountBalances.reserve(1n)
   }
   getDate(): Date {
@@ -137,9 +137,7 @@ export class UsersSyncRole extends AbstractSyncRole<UserDb> {
         ).build(),
         communityContext.blockchain,
         ledgerAnchor,
-        !this.context.isDecayCalculationTypeChanged(item.createdAt)
-          ? this.calculateAccountBalances(accountPublicKey, communityContext)
-          : undefined,
+        this.calculateAccountBalances(accountPublicKey, communityContext),
       )
     } catch (e) {
       throw new BlockchainError(`Error adding ${this.itemTypeName()}`, item, e as Error)

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/utils.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/utils.ts
@@ -26,4 +26,3 @@ export function calculateOneHashStep(hash: Buffer, data: Buffer): Buffer<ArrayBu
   crypto_generichash_batch(outputHash, [hash, data])
   return outputHash
 }
-

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/utils.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/utils.ts
@@ -1,4 +1,3 @@
-import Decimal from 'decimal.js-light'
 import { crypto_generichash_batch, crypto_generichash_KEYBYTES } from 'sodium-native'
 
 export function bytesToMbyte(bytes: number): string {
@@ -28,43 +27,3 @@ export function calculateOneHashStep(hash: Buffer, data: Buffer): Buffer<ArrayBu
   return outputHash
 }
 
-export const DECAY_START_TIME = new Date('2021-05-13T17:46:31Z')
-export const SECONDS_PER_YEAR_GREGORIAN_CALENDER = 31556952.0
-const FACTOR = new Decimal('0.99999997803504048973201202316767079413460520837376')
-
-export function legacyDecayFormula(value: Decimal, seconds: number): Decimal {
-  // TODO why do we need to convert this here to a string to work properly?
-  // chatgpt: We convert to string here to avoid precision loss:
-  //          .pow(seconds) can internally round the result, especially for large values of `seconds`.
-  //          Using .toString() ensures full precision is preserved in the multiplication.
-  return value.mul(FACTOR.pow(seconds).toString())
-}
-
-export function reverseLegacyDecay(result: Decimal, seconds: number): Decimal {
-  return result.div(FACTOR.pow(seconds).toString())
-}
-
-export function legacyCalculateDecay(amount: Decimal, from: Date, to: Date): Decimal {
-  const fromMs = from.getTime()
-  const toMs = to.getTime()
-  const startBlockMs = DECAY_START_TIME.getTime()
-
-  if (toMs < fromMs) {
-    throw new Error(
-      `calculateDecay: to (${to.toISOString()}) < from (${from.toISOString()}), reverse decay calculation is invalid`,
-    )
-  }
-
-  // decay started after end date; no decay
-  if (startBlockMs > toMs) {
-    return amount
-  }
-  // decay started before start date; decay for full duration
-  let duration = (toMs - fromMs) / 1000
-
-  // decay started between start and end date; decay from decay start till end date
-  if (startBlockMs >= fromMs) {
-    duration = (toMs - startBlockMs) / 1000
-  }
-  return legacyDecayFormula(amount, duration)
-}

--- a/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/valibot.schema.ts
+++ b/dlt-connector/src/migrations/db-v2.7.0_to_blockchain-v3.7/valibot.schema.ts
@@ -2,7 +2,6 @@ import { InMemoryBlockchain, KeyPairEd25519 } from 'gradido-blockchain-js'
 import * as v from 'valibot'
 import { booleanSchema, dateSchema } from '../../schemas/typeConverter.schema'
 import {
-  amountSchema,
   gradidoAmountSchema,
   hieroTransactionIdStringSchema,
   identifierSeedSchema,
@@ -22,31 +21,7 @@ export const userDbSchema = v.object({
   createdAt: dateSchema,
   messageId: v.nullish(hieroTransactionIdStringSchema),
 })
-/*
-declare const validLegacyAmount: unique symbol
-export type LegacyAmount = string & { [validLegacyAmount]: true }
 
-export const legacyAmountSchema = v.pipe(
-  v.string(),
-  v.regex(/^-?[0-9]+(\.[0-9]+)?$/),
-  v.transform<string, LegacyAmount>((input: string) => input as LegacyAmount),
-)
-
-declare const validGradidoAmount: unique symbol
-export type GradidoAmount = GradidoUnit & { [validGradidoAmount]: true }
-
-export const gradidoAmountSchema = v.pipe(
-  v.union([legacyAmountSchema, v.instance(GradidoUnit, 'expect GradidoUnit type')]),
-  v.transform<LegacyAmount | GradidoUnit, GradidoAmount>((input: LegacyAmount | GradidoUnit) => {
-    if (input instanceof GradidoUnit) {
-      return input as GradidoAmount
-    }
-    // round floor with decimal js beforehand
-    const rounded = new Decimal(input).toDecimalPlaces(4, Decimal.ROUND_FLOOR).toString()
-    return GradidoUnit.fromString(rounded) as GradidoAmount
-  }),
-)
-*/
 export const transactionBaseSchema = v.object({
   id: positiveNumberSchema,
   amount: gradidoAmountSchema,
@@ -59,7 +34,6 @@ export const transactionDbSchema = v.pipe(
   v.object({
     ...transactionBaseSchema.entries,
     typeId: v.enum(TransactionTypeId),
-    balanceFull: amountSchema,
     balanceDate: dateSchema,
     linkedUser: userDbSchema,
     decayCalculationType: v.enum(DecayCalculationType),

--- a/dlt-connector/src/schemas/typeGuard.schema.ts
+++ b/dlt-connector/src/schemas/typeGuard.schema.ts
@@ -209,7 +209,7 @@ export const timeoutDurationSchema = v.pipe(
 /**
  * type guard for amount
  * create with `v.parse(amountSchema, '123')`
- * amount is a string representing a positive decimal number, compatible with decimal.js
+ * amount is a string representing a positive decimal number
  */
 declare const validAmount: unique symbol
 export type Amount = string & { [validAmount]: true }

--- a/shared-native/bindings/bun/gradidoUnit.ts
+++ b/shared-native/bindings/bun/gradidoUnit.ts
@@ -82,6 +82,9 @@ export function getDecayStartTime(): Date {
 }
 
 export function calculateDecay(value: bigint, seconds: bigint): bigint {
+  if (value < 0) {
+    throw new Error('First Argument must be >= 0')
+  }
   const result = grdd_unit_calculate_decay(value, seconds)
   if (result === INT64_MAX) {
     throw new Error('Decay calculation probably resulted in overflow')

--- a/shared-native/bindings/napi/gradidoUnit.cpp
+++ b/shared-native/bindings/napi/gradidoUnit.cpp
@@ -3,14 +3,14 @@
 #include "gradido_blockchain_core/utils/duration.h"
 
 namespace gradidoUnit {
-    Napi::Value CalculateDecay(const Napi::CallbackInfo& info) 
+    Napi::Value CalculateDecay(const Napi::CallbackInfo& info)
     {
         Napi::Env env = info.Env();
         if (info.Length() != 2) {
             Napi::TypeError::New(env, "Expected two arguments").ThrowAsJavaScriptException();
             return env.Null();
         }
-        
+
         if (!info[0].IsBigInt()) {
             Napi::TypeError::New(env, "Expected first argument to be a bigint").ThrowAsJavaScriptException();
             return env.Null();
@@ -19,11 +19,15 @@ namespace gradidoUnit {
             Napi::TypeError::New(env, "Expected second argument to be a bigint").ThrowAsJavaScriptException();
             return env.Null();
         }
-        
+
         bool lossless = false;
         int64_t amount = info[0].As<Napi::BigInt>().Int64Value(&lossless);
         if (!lossless) {
             Napi::TypeError::New(env, "First Argument is to large for int64").ThrowAsJavaScriptException();
+            return env.Null();
+        }
+        if (amount < 0) {
+            Napi::TypeError::New(env, "First Argument must be >= 0").ThrowAsJavaScriptException();
             return env.Null();
         }
         int64_t duration = info[1].As<Napi::BigInt>().Int64Value(&lossless);
@@ -36,18 +40,18 @@ namespace gradidoUnit {
             Napi::Error::New(env, "Decay calculation probably resulted in overflow").ThrowAsJavaScriptException();
             return env.Null();
         }
-        
+
         return Napi::BigInt::New(env, result);
     }
 
-    
-    Napi::Value GetDecayStartTime(const Napi::CallbackInfo& info) 
+
+    Napi::Value GetDecayStartTime(const Napi::CallbackInfo& info)
     {
         double timestamp = static_cast<double>(grdd_unit_decay_start_time()) * 1000.0;
         return Napi::Date::New(info.Env(), timestamp);
     }
 
-    Napi::Value FromString(const Napi::CallbackInfo& info) 
+    Napi::Value FromString(const Napi::CallbackInfo& info)
     {
         Napi::Env env = info.Env();
         if (info.Length() != 1) {
@@ -66,8 +70,8 @@ namespace gradidoUnit {
         }
         return Napi::BigInt::New(env, unit);
     }
-    
-    Napi::Value ToString(const Napi::CallbackInfo& info) 
+
+    Napi::Value ToString(const Napi::CallbackInfo& info)
     {
         Napi::Env env = info.Env();
         if (info.Length() < 1) {
@@ -125,7 +129,7 @@ namespace gradidoUnit {
             Napi::TypeError::New(env, "Expected second argument to be a number").ThrowAsJavaScriptException();
             return env.Null();
         }
-        
+
         bool lossless = false;
         grdd_unit unit = info[0].As<Napi::BigInt>().Int64Value(&lossless);
         if (!lossless) {
@@ -141,7 +145,7 @@ namespace gradidoUnit {
         return Napi::BigInt::New(env, rounded);
     }
 
-    Napi::Value DurationToString(const Napi::CallbackInfo& info) 
+    Napi::Value DurationToString(const Napi::CallbackInfo& info)
     {
         Napi::Env env = info.Env();
         if (info.Length() < 1) {
@@ -156,7 +160,7 @@ namespace gradidoUnit {
             Napi::TypeError::New(env, "Expected second argument to be a number or undefined").ThrowAsJavaScriptException();
             return env.Null();
         }
-        
+
         bool lossless = false;
         grdu_duration duration = info[0].As<Napi::BigInt>().Int64Value(&lossless);
         if (!lossless) {
@@ -182,10 +186,10 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
     exports.Set("calculateDecay", Napi::Function::New(env, gradidoUnit::CalculateDecay));
     exports.Set("getDecayStartTime", Napi::Function::New(env, gradidoUnit::GetDecayStartTime));
     exports.Set("gradidoUnitFromString", Napi::Function::New(env, gradidoUnit::FromString));
-    exports.Set("gradidoUnitToString", Napi::Function::New(env, gradidoUnit::ToString));   
+    exports.Set("gradidoUnitToString", Napi::Function::New(env, gradidoUnit::ToString));
     exports.Set("toDecimalPlaces", Napi::Function::New(env, gradidoUnit::ToDecimalPlaces));
     exports.Set("durationToString", Napi::Function::New(env, gradidoUnit::DurationToString));
-    
+
     return exports;
 }
 

--- a/shared-native/build.ts
+++ b/shared-native/build.ts
@@ -33,7 +33,6 @@ async function main() {
     '-ffp-contract=off',
     '-ffp-model=strict',
     '-fwrapv',
-    '-fno-strict-overflow'
   ]
   await build(
     {

--- a/shared-native/build.ts
+++ b/shared-native/build.ts
@@ -27,13 +27,7 @@ async function main() {
     libs.libraries = ['node']
   }
   const libSrcs = ['src/data/unit.c', 'src/utils/converter.c', 'src/utils/duration.c']
-  const cflags = [
-    '-O2',
-    '-fno-fast-math',
-    '-ffp-contract=off',
-    '-ffp-model=strict',
-    '-fwrapv',
-  ]
+  const cflags = ['-O2', '-fno-fast-math', '-ffp-contract=off', '-ffp-model=strict', '-fwrapv']
   await build(
     {
       c_core: {

--- a/shared-native/build.ts
+++ b/shared-native/build.ts
@@ -26,7 +26,7 @@ async function main() {
     libs.librariesSearch = [getNodePath()]
     libs.libraries = ['node']
   }
-  const cflags = ['-O2', '-fno-fast-math', '-ffp-contract=off', '-ffp-model=strict', '-fwrapv']
+  const cflags = ['-O2', '-fno-fast-math', '-fwrapv']
   const libSrcs = [
     'src/data/unit.c',
     'src/utils/converter.c',

--- a/shared-native/build.ts
+++ b/shared-native/build.ts
@@ -13,7 +13,7 @@ async function main() {
   const commonConfigs = {
     target: await detectTargetTriple(),
     mode: 'small',
-    cpu: 'native',
+    // cpu: ,
     nodeVersion: nodeVersion().replace(/^v/, ''),
     include: ['include', 'third_party'],
   }
@@ -27,6 +27,14 @@ async function main() {
     libs.libraries = ['node']
   }
   const libSrcs = ['src/data/unit.c', 'src/utils/converter.c', 'src/utils/duration.c']
+  const cflags = [
+    '-O2',
+    '-fno-fast-math',
+    '-ffp-contract=off',
+    '-ffp-model=strict',
+    '-fwrapv',
+    '-fno-strict-overflow'
+  ]
   await build(
     {
       c_core: {
@@ -35,14 +43,14 @@ async function main() {
         sources: libSrcs,
         type: 'shared',
         std: 'c17',
-        cflags: ['-g0', '-s'],
+        cflags: ['-g0', '-s'].concat(cflags),
       } as Target,
       cpp_napi: {
         ...commonConfigs,
         ...libs,
         output: 'build/shared_native.node',
         sources: ['bindings/napi/gradidoUnit.cpp', ...libSrcs],
-        cflags: ['-g0', '-s', '-DNAPI_VERSION=8'],
+        cflags: ['-g0', '-s', '-DNAPI_VERSION=8'].concat(cflags),
       } as Target,
     },
     undefined,

--- a/shared-native/package.json
+++ b/shared-native/package.json
@@ -29,6 +29,7 @@
     "@biomejs/biome": "2.0.0",
     "@types/adm-zip": "^0.5.8",
     "adm-zip": "^0.5.16",
+    "decimal.js": "^10.6.0",
     "decimal.js-light": "^2.5.1",
     "node-api-headers": "^1.8.0",
     "typescript": "^4.9.5"

--- a/shared-native/package.json
+++ b/shared-native/package.json
@@ -29,6 +29,7 @@
     "@biomejs/biome": "2.0.0",
     "@types/adm-zip": "^0.5.8",
     "adm-zip": "^0.5.16",
+    "decimal.js-light": "^2.5.1",
     "node-api-headers": "^1.8.0",
     "typescript": "^4.9.5"
   },

--- a/shared-native/src/data/unit.c
+++ b/shared-native/src/data/unit.c
@@ -16,10 +16,9 @@
 static const grdd_duration_seconds SECONDS_PER_YEAR = 31556952; // seconds in a year in gregorian calender
 static const grdd_timestamp_seconds DECAY_START_TIME = 1620927991;
 // precalculated decay factor for deterministic decay calculation across platforms, 2^64 / SECONDS_PER_YEAR
-//static const uint64_t DECAY_FACTOR_PER_SECOND =   18446743668527564941ULL; // TypeScript Decimal.js
+// static const uint64_t DECAY_FACTOR_PER_SECOND =   18446743668527564941ULL; // TypeScript Decimal.js
 static const uint64_t DECAY_FACTOR_PER_SECOND =   18446743668527564940ULL;
 static const uint64_t GROW_FACTOR_PER_SECOND =    405181995575ULL; // for low, and 1 for hi
-
 
 // precalculated powers of 10 for fast rounding
 static const uint64_t POW10[] = { 1, 10, 100, 1000, 10000 };
@@ -357,9 +356,10 @@ inline void r128Mul_specialized_factor(R128* dst, const R128* a, const R128* b)
 
 grdd_unit grdd_unit_calculate_decay(grdd_unit gdd, grdd_duration_seconds duration)
 {
-  if (duration == 0) {
+    if (duration == 0) {
 		return gdd;
 	}
+    assert(gdd >= 0);
 
 	// decay for one year is 50%
 	/*
@@ -374,8 +374,8 @@ grdd_unit grdd_unit_calculate_decay(grdd_unit gdd, grdd_duration_seconds duratio
 	if (duration >= SECONDS_PER_YEAR) {
 		uint64_t times = (uint64_t)(duration / SECONDS_PER_YEAR);
 		if (times > 63) {
-				// after more than 63 years, all gradidos are decayed
-				return 0;
+			// after more than 63 years, all gradidos are decayed
+			return 0;
 		}
 		duration = duration - times * SECONDS_PER_YEAR;
 		gdd_temp =  gdd >> times; // equivalent to gdd / (2^times)
@@ -417,14 +417,6 @@ grdd_unit grdd_unit_calculate_decay(grdd_unit gdd, grdd_duration_seconds duratio
 		negative = true;
 		exp = -duration;
 	}
- 	for (int i = 0; i < 32; i++) {
-        if (duration & (1ULL << i)) {
-            R128 static_factor = { .lo = DECAY_POWERS[i], .hi = 0 };
-            r128Mul(&factor, &factor, &static_factor);
-        }
-	}
-	//  */
-	/*
 
 	int i = 0;
 	while (exp > 0)

--- a/shared-native/src/data/unit.c
+++ b/shared-native/src/data/unit.c
@@ -2,6 +2,7 @@
 #include "gradido_blockchain_core/utils/converter.h"
 
 #define R128_IMPLEMENTATION
+#define R128_STDC_ONLY
 #include "r128/r128.h"
 
 #include <ctype.h>
@@ -14,12 +15,82 @@
 static const grdd_duration_seconds SECONDS_PER_YEAR = 31556952; // seconds in a year in gregorian calender
 static const grdd_timestamp_seconds DECAY_START_TIME = 1620927991;
 // precalculated decay factor for deterministic decay calculation across platforms, 2^64 / SECONDS_PER_YEAR
-// static const uint64_t DECAY_FACTOR_PER_SECOND =   18446743668527564941ULL; // TypeScript Decimal.js
+//static const uint64_t DECAY_FACTOR_PER_SECOND =   18446743668527564941ULL; // TypeScript Decimal.js
 static const uint64_t DECAY_FACTOR_PER_SECOND =   18446743668527564940ULL;
 static const uint64_t GROW_FACTOR_PER_SECOND =    405181995575ULL; // for low, and 1 for hi
 
+
 // precalculated powers of 10 for fast rounding
 static const uint64_t POW10[] = { 1, 10, 100, 1000, 10000 };
+// precalculated decay powers for more consistent result across plattforms
+static const uint64_t DECAY_POWERS[] = {
+    0xffffffa1a945888dULL,
+    0xffffff43528b33ddULL,
+    0xfffffe86a516f2caULL,
+    0xfffffd0d4a3011d0ULL,
+    0xfffffa1a9468d494ULL,
+    0xfffff43528f46cf5ULL,
+    0xffffe86a5273e91dULL,
+    0xffffd0d4a7140eedULL,
+    0xffffa1a956d90fd7ULL,
+    0xffff4352d075e13dULL,
+    0xfffe86a62bfa9575ULL,
+    0xfffd0d4e842edce8ULL,
+    0xfffa1aa5b937b238ULL,
+    0xfff4356e3570cabcULL,
+    0xffe86b6773b36477ULL,
+    0xffd0d8faf110bbd2ULL,
+    0xffa1baa53bef7e25ULL,
+    0xff43980179510649ULL,
+    0xfe87baabdab6ab02ULL,
+    0xfd119e636f615530ULL,
+    0xfa2bd446f55a1169ULL,
+    0xf479a21b970ff04cULL,
+    0xe97816cf3cb21d4bULL,
+    0xd4ebd1daa0cd667fULL,
+    0xb1176ccd0dbe2022ULL,
+    0x7a81669848170871ULL,
+    0x3a9f9731b34c4f4aULL,
+    0xd6cb3ffae46f7e2ULL,
+    0xb4387055fdce22ULL,
+    0x7edf6a6a43d4ULL,
+    0x3ee0afbbULL,
+    0x0ULL,
+};
+
+/*
+ // table was calculated with this TypeScript Code:
+  import Decimal from 'decimal.js' // "decimal.js": "^10.6.0",
+ 
+ 	Decimal.set({
+		precision: 25,
+			rounding: Decimal.ROUND_HALF_UP,
+		})
+		const SCALE = new Decimal(2).pow(64)
+		const base = new Decimal('0.99999997803504048973201202316767079413460520837376')
+		let current = base
+
+		console.log('static const uint64_t DECAY_POWERS[] = {')
+
+		for (let i = 0; i < 64; i++) {
+			const scaled = current.mul(SCALE)//.floor()
+
+			const value = BigInt(scaled.toFixed(0))
+
+			const lo = value & ((1n << 64n) - 1n)
+
+			console.log(
+				`    0x${lo.toString(16)}ULL,`
+			)
+			if (lo === 0n) {
+				break
+			}
+
+			current = current.mul(current)
+		}
+
+		console.log('};')
+ */
 
 static double round_to_precision(double gdd, uint8_t precision)
 {
@@ -284,6 +355,14 @@ grdd_unit grdd_unit_calculate_decay(grdd_unit gdd, grdd_duration_seconds duratio
 		base.lo = GROW_FACTOR_PER_SECOND;
 		base.hi = 1;
 	}
+ 	for (int i = 0; i < 32; i++) {
+        if (duration & (1ULL << i)) {
+            R128 static_factor = { .lo = DECAY_POWERS[i], .hi = 0 };
+            r128Mul(&factor, &factor, &static_factor);
+        }
+	}
+	//  */
+	/*
 
 	while (exp > 0) {
 			if ((exp & 1) == 1) {
@@ -292,6 +371,7 @@ grdd_unit grdd_unit_calculate_decay(grdd_unit gdd, grdd_duration_seconds duratio
 			r128Mul(&base, &base, &base);        // base *= base
 			exp >>= 1;
 	}
+	//  */
 	R128 gdd128;
 	r128FromInt(&gdd128, gdd_temp);
 	// Final: balance * factor

--- a/shared-native/tests/calculateDecay.test.js
+++ b/shared-native/tests/calculateDecay.test.js
@@ -1,6 +1,6 @@
-const { describe, it } = require('node:test');
-const { strict } = require("node:assert");
-const assert = strict;
+const { describe, it } = require('node:test')
+const { strict } = require("node:assert")
+const assert = strict
 const {
   calculateDecay,
   getDecayStartTime,
@@ -8,10 +8,22 @@ const {
   gradidoUnitToString,
   toDecimalPlaces,
   durationToString
-} = require('../');
+} = require('../')
+
+const { Decimal } = require('decimal.js-light')
+
+// Set precision value
+Decimal.set({
+  precision: 25,
+  rounding: Decimal.ROUND_HALF_UP,
+})
+// legacy decay calculation for comparisation with new decay calculation
+function decayFormula(value, seconds) {
+  return new Decimal(value.toString()).mul(new Decimal('0.99999997803504048973201202316767079413460520837376').pow(seconds))
+}
 
 describe('GradidoUnit', () => {
-  
+
   describe('gradidoUnitFromString', () => {
     it('converts string to GradidoUnit', () => {
       const result = gradidoUnitFromString('10012041')
@@ -163,17 +175,246 @@ describe('GradidoUnit', () => {
       it('1 gdd, 1 second', () => {
         const amount = 10000n
         const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 10000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
       })
       it('100 gdd, 14 days', () => {
         const amount = 1000000n
         const decay = calculateDecay(amount, 14n * 24n * 60n * 60n)
+        const legacyDecay = decayFormula(amount, 14 * 24 * 60 * 60)
         assert.equal(decay, 973781n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
       })
       it('100 gdd, 1 year', () => {
         const amount = 1000000n
         const decay = calculateDecay(amount, 31556952n)
+        const legacyDecay = decayFormula(amount, 31556952)
         assert.equal(decay, 500000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+      it('0.0001 gdd, 1 second', () => {
+          const amount = 1n
+          const decay = calculateDecay(amount, 1n)
+          const legacyDecay = decayFormula(amount, 1)
+          assert.equal(decay, 1n)
+          assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('1 gdd, 1 hour', () => {
+        const amount = 10000n
+        const decay = calculateDecay(amount, 3600n)
+        const legacyDecay = decayFormula(amount, 3600)
+        assert.equal(decay, 9999n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('1 gdd, 1 day', () => {
+        const amount = 10000n
+        const decay = calculateDecay(amount, 86400n)
+        const legacyDecay = decayFormula(amount, 86400)
+        assert.equal(decay, 9981n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('100 gdd, 30 days', () => {
+        const amount = 1000000n
+        const decay = calculateDecay(amount, 30n * 24n * 60n * 60n)
+        const legacyDecay = decayFormula(amount, 30 * 24 * 60 * 60)
+        assert.equal(decay, 944657n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('100 gdd, half year', () => {
+        const amount = 1000000n
+        const decay = calculateDecay(amount, 15778476n)
+        const legacyDecay = decayFormula(amount, 15778476)
+        assert.equal(decay, 707107n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('1000 gdd, 1 year', () => {
+        const amount = 10000000n
+        const decay = calculateDecay(amount, 31556952n)
+        const legacyDecay = decayFormula(amount, 31556952)
+        assert.equal(decay, 5000000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('1000 gdd, 2 years', () => {
+        const amount = 10000000n
+        const decay = calculateDecay(amount, 2n * 31556952n)
+        const legacyDecay = decayFormula(amount, 2 * 31556952)
+        assert.equal(decay, 2500000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('2 gdd, 1 second', () => {
+        const amount = 20000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 20000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('5 gdd, 1 second', () => {
+        const amount = 50000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 50000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('10 gdd, 1 second', () => {
+        const amount = 100000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 100000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('25 gdd, 1 second', () => {
+        const amount = 250000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 250000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('50 gdd, 1 second', () => {
+        const amount = 500000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 500000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('75 gdd, 1 second', () => {
+        const amount = 750000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 750000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('100 gdd, 1 second', () => {
+        const amount = 1000000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 1000000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('250 gdd, 1 second', () => {
+        const amount = 2500000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 2500000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('500 gdd, 1 second', () => {
+        const amount = 5000000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 5000000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('750 gdd, 1 second', () => {
+        const amount = 7500000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 7500000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('1000 gdd, 1 second', () => {
+        const amount = 10000000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 10000000n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('2500 gdd, 1 second', () => {
+        const amount = 25000000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 24999999n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('5000 gdd, 1 second', () => {
+        const amount = 50000000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 49999999n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('10000 gdd, 1 second', () => {
+        const amount = 100000000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 99999998n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('25000 gdd, 1 second', () => {
+        const amount = 250000000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 249999995n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('50000 gdd, 1 second', () => {
+        const amount = 500000000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 499999989n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('100000 gdd, 1 second', () => {
+        const amount = 1000000000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 999999978n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('250000 gdd, 1 second', () => {
+        const amount = 2500000000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 2499999945n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('500000 gdd, 1 second', () => {
+        const amount = 5000000000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 4999999890n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('1000000 gdd, 1 second', () => {
+        const amount = 10000000000n
+        const decay = calculateDecay(amount, 1n)
+        const legacyDecay = decayFormula(amount, 1)
+        assert.equal(decay, 9999999780n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+      })
+
+      it('max-ish value, 1 year', () => {
+        const amount = 9223372036854775807n
+        const decay = calculateDecay(amount, 31556952n)
+        const legacyDecay = decayFormula(amount, 31556952)
+        assert.equal(decay, 4611686018427387903n)
+        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
       })
     })
   })

--- a/shared-native/tests/calculateDecay.test.js
+++ b/shared-native/tests/calculateDecay.test.js
@@ -18,8 +18,17 @@ Decimal.set({
   rounding: Decimal.ROUND_HALF_UP,
 })
 // legacy decay calculation for comparisation with new decay calculation
+// Expect bigint, return bigint
 function decayFormula(value, seconds) {
-  return new Decimal(value.toString()).mul(new Decimal('0.99999997803504048973201202316767079413460520837376').pow(seconds))
+  return BigInt(
+    new Decimal(value.toString())
+      .mul(
+        new Decimal('0.99999997803504048973201202316767079413460520837376')
+        .pow(seconds)
+      )
+      .toDecimalPlaces(0)
+      .toString()
+  )
 }
 
 describe('GradidoUnit', () => {
@@ -177,28 +186,28 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 10000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
       it('100 gdd, 14 days', () => {
         const amount = 1000000n
         const decay = calculateDecay(amount, 14n * 24n * 60n * 60n)
         const legacyDecay = decayFormula(amount, 14 * 24 * 60 * 60)
         assert.equal(decay, 973781n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
       it('100 gdd, 1 year', () => {
         const amount = 1000000n
         const decay = calculateDecay(amount, 31556952n)
         const legacyDecay = decayFormula(amount, 31556952)
         assert.equal(decay, 500000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
       it('0.0001 gdd, 1 second', () => {
           const amount = 1n
           const decay = calculateDecay(amount, 1n)
           const legacyDecay = decayFormula(amount, 1)
           assert.equal(decay, 1n)
-          assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+          assert.equal(legacyDecay, decay)
       })
 
       it('1 gdd, 1 hour', () => {
@@ -206,7 +215,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 3600n)
         const legacyDecay = decayFormula(amount, 3600)
         assert.equal(decay, 9999n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('1 gdd, 1 day', () => {
@@ -214,7 +223,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 86400n)
         const legacyDecay = decayFormula(amount, 86400)
         assert.equal(decay, 9981n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('100 gdd, 30 days', () => {
@@ -222,7 +231,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 30n * 24n * 60n * 60n)
         const legacyDecay = decayFormula(amount, 30 * 24 * 60 * 60)
         assert.equal(decay, 944657n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('100 gdd, half year', () => {
@@ -230,7 +239,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 15778476n)
         const legacyDecay = decayFormula(amount, 15778476)
         assert.equal(decay, 707107n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('1000 gdd, 1 year', () => {
@@ -238,7 +247,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 31556952n)
         const legacyDecay = decayFormula(amount, 31556952)
         assert.equal(decay, 5000000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('1000 gdd, 2 years', () => {
@@ -246,7 +255,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 2n * 31556952n)
         const legacyDecay = decayFormula(amount, 2 * 31556952)
         assert.equal(decay, 2500000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('2 gdd, 1 second', () => {
@@ -254,7 +263,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 20000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('5 gdd, 1 second', () => {
@@ -262,7 +271,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 50000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('10 gdd, 1 second', () => {
@@ -270,7 +279,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 100000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('25 gdd, 1 second', () => {
@@ -278,7 +287,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 250000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('50 gdd, 1 second', () => {
@@ -286,7 +295,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 500000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('75 gdd, 1 second', () => {
@@ -294,7 +303,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 750000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('100 gdd, 1 second', () => {
@@ -302,7 +311,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 1000000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('250 gdd, 1 second', () => {
@@ -310,7 +319,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 2500000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('500 gdd, 1 second', () => {
@@ -318,7 +327,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 5000000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('750 gdd, 1 second', () => {
@@ -326,7 +335,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 7500000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('1000 gdd, 1 second', () => {
@@ -334,7 +343,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 10000000n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('2500 gdd, 1 second', () => {
@@ -342,7 +351,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 24999999n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('5000 gdd, 1 second', () => {
@@ -350,7 +359,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 49999999n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('10000 gdd, 1 second', () => {
@@ -358,7 +367,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 99999998n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('25000 gdd, 1 second', () => {
@@ -366,7 +375,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 249999995n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('50000 gdd, 1 second', () => {
@@ -374,7 +383,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 499999989n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('100000 gdd, 1 second', () => {
@@ -382,7 +391,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 999999978n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('250000 gdd, 1 second', () => {
@@ -390,7 +399,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 2499999945n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('500000 gdd, 1 second', () => {
@@ -398,7 +407,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 4999999890n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('1000000 gdd, 1 second', () => {
@@ -406,7 +415,7 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 1n)
         const legacyDecay = decayFormula(amount, 1)
         assert.equal(decay, 9999999780n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
 
       it('max-ish value, 1 year', () => {
@@ -414,8 +423,50 @@ describe('GradidoUnit', () => {
         const decay = calculateDecay(amount, 31556952n)
         const legacyDecay = decayFormula(amount, 31556952)
         assert.equal(decay, 4611686018427387903n)
-        assert.equal(legacyDecay.toDecimalPlaces(0).toString(), decay.toString())
+        assert.equal(legacyDecay, decay)
       })
+    })
+  })
+
+  describe('GradidoUnit > calculateDecay > monotonic stability over long range', () => {
+    it.skip('TestWithManyDifferentDuration', () => {
+      const amount = 100000000n
+
+      let prevValue = 0n
+      let prevDistance = 0n
+
+      const TWO_YEARS = 31556952 * 2
+
+      for (let i = 1; i < TWO_YEARS; i += 32) {
+        const decayed = decayFormula(amount, i)
+
+        if (prevValue !== 0n) {
+          // monotonicity: value must never increase
+          assert.ok(
+            prevValue >= decayed,
+            `previous value wasn't greater on i: ${i}`
+          )
+
+          const distance = prevValue - decayed
+
+          if (prevDistance !== 0n) {
+            const diff = prevDistance > distance
+              ? prevDistance - distance
+              : distance - prevDistance
+
+            assert.ok(
+              diff <= 1n,
+              `distance increased unexpectedly i: ${i} (diff=${diff})`
+            )
+          }
+
+          prevDistance = distance
+        }
+
+        prevValue = decayed
+        process.stdout.write(`${i}/${TWO_YEARS} = ${i / TWO_YEARS * 100} %\r`)
+      }
+      process.stdout.write(`\n`)
     })
   })
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recalculation migration to recompute user balances with the new decay math.
  * CLI option to restrict processing to legacy ledger anchor IDs.

* **Chores**
  * Improved database connection pool to better handle large numbers and multi-statement queries.
  * Unified ledger-anchor handling across blockchain sync flows and always compute account balances on sync.
  * Removed legacy decimal/decay utilities, legacy balance field, and related legacy workarounds.
  * Removed Bun preload and unused dev dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Discussion with CodeRabbit: https://github.com/einhornimmond/gradido/pull/5