### PR TITLE
refactor(shared-native): update decay algo

### DIFF
--- a/shared-native/build.ts
+++ b/shared-native/build.ts
@@ -26,7 +26,13 @@ async function main() {
     libs.librariesSearch = [getNodePath()]
     libs.libraries = ['node']
   }
-  const libSrcs = ['src/data/unit.c', 'src/utils/converter.c', 'src/utils/duration.c']
+  const libSrcs = [
+    'src/data/unit.c',
+    'src/utils/converter.c',
+    'src/utils/duration.c',
+    'third_party/fp256/src/fp256_mul.c',
+    'third_party/fp256/src/fp256_utils.c',
+  ]
   await build(
     {
       c_core: {

--- a/shared-native/src/data/unit.c
+++ b/shared-native/src/data/unit.c
@@ -2,7 +2,9 @@
 #include "gradido_blockchain_core/utils/converter.h"
 
 #define R128_IMPLEMENTATION
+#define R128_STDC_ONLY
 #include "r128/r128.h"
+#include "fp256/fp256.h"
 
 #include <ctype.h>
 #include <math.h>
@@ -20,6 +22,41 @@ static const uint64_t GROW_FACTOR_PER_SECOND =    405181995575ULL; // for low, a
 
 // precalculated powers of 10 for fast rounding
 static const uint64_t POW10[] = { 1, 10, 100, 1000, 10000 };
+// precalculated decay powers for consistent result across plattforms
+static const uint64_t DECAY_POWERS[] = {
+    18446743668527564940ULL,
+    18446743263345587163ULL,
+    18446742452981658309ULL,
+    18446740832253907398ULL,
+    18446737590798832767ULL,
+    18446731107890392267ULL,
+    18446718142080346313ULL,
+    18446692210487594564ULL,
+    18446640347411451525ULL,
+    18446536621696605848ULL,
+    18446329172016664620ULL,
+    18445914279655690837ULL,
+    18445084522928643346ULL,
+    18443425121448271984ULL,
+    18440106766335414243ULL,
+    18433471847125226169ULL,
+    18420209169759874097ULL,
+    18393712435208807257ULL,
+    18340833254760868098ULL,
+    18235530516106764452ULL,
+    18026735334708307356ULL,
+    17616289656815978922ULL,
+    16823221487369777986ULL,
+    15342587292489394070ULL,
+    12760787697116905635ULL,
+    8827449548832185865ULL,
+    4224261215193812073ULL,
+    967345930690427918ULL,
+    50727550937131514ULL,
+    139498028150492ULL,
+    1054912443ULL,
+    0ULL,
+};
 
 static double round_to_precision(double gdd, uint8_t precision)
 {
@@ -220,6 +257,117 @@ grdd_timestamp_seconds grdd_unit_decay_start_time()
 	return DECAY_START_TIME;
 }
 
+#if defined(__SIZEOF_INT128__)
+// specialized version of r128Mul_precise, with the assumption that b.hi is 0, speedup by ~ 20%
+static void r128Mul_specialized_factor(R128* dst, const R128* a, const R128* b)
+{
+    R128_ASSERT(dst != NULL && a != NULL && b != NULL);
+    // Q64.64 multiplication:
+    // (ahi<<64 + alo) * (bhi<<64 + blo)
+    //
+    // Result after >>64:
+    //   (alo*blo)>>64
+    // + (ahi*blo)
+    //
+    // High-high term contributes above Q64.64 range.
+    __uint128_t p1 = (__uint128_t)a->hi * (__uint128_t)b->lo;
+    __uint128_t low = (((__uint128_t)a->lo * (__uint128_t)b->lo) >> 64) + (uint64_t)p1;
+    dst->lo = (uint64_t)low;
+    dst->hi = (uint64_t)((p1 >> 64) + (low >> 64));
+}
+
+static void r128Mul_precise(R128* dst, const R128* a, const R128* b)
+{
+    R128_ASSERT(dst != NULL && a != NULL && b != NULL);
+    // Q64.64 multiplication:
+    // (ahi<<64 + alo) * (bhi<<64 + blo)
+    //
+    // Result after >>64:
+    //   (alo*blo)>>64
+    // + (ahi*blo)
+    // + (alo*bhi)
+    //
+    // High-high term contributes above Q64.64 range.
+
+//    __uint128_t p0 = (__uint128_t)a->lo * (__uint128_t)b->lo;
+    __uint128_t p1 = (__uint128_t)a->hi * (__uint128_t)b->lo;
+    __uint128_t p2 = (__uint128_t)a->lo * (__uint128_t)b->hi;
+    // __uint128_t p3 = (__uint128_t)a->hi * (__uint128_t)b->hi;
+
+    __uint128_t low = ((((__uint128_t)a->lo * (__uint128_t)b->lo)) >> 64) + (uint64_t)p1 + (uint64_t)p2;
+    dst->lo = (uint64_t)low;
+    dst->hi = (uint64_t)((p1 >> 64) + (p2 >> 64) + (__uint128_t)a->hi * (__uint128_t)b->hi + (low >> 64));
+}
+
+#else
+
+static void r128Mul_precise(R128* dst, const R128* a, const R128* b)
+{
+    R128_ASSERT(dst != NULL && a != NULL && b != NULL);
+    fp256 fa;
+    fp256 fb;
+    fp256 rhi;
+    fp256 rlo;
+
+    // Convert R128 -> fp256
+    // Q64.64 layout:
+    //   hi = integer part
+    //   lo = fractional part
+    //   numeric value: (hi << 64) | lo
+
+    fa.d[0] = a->lo;
+    fa.d[1] = a->hi;
+    fa.d[2] = 0;
+    fa.d[3] = 0;
+
+    fb.d[0] = b->lo;
+    fb.d[1] = b->hi;
+    fb.d[2] = 0;
+    fb.d[3] = 0;
+
+    // Full 256-bit multiplication:
+    // product = fa * fb
+    // result is 512 bit
+    //   rhi:rlo
+    fp256_mul(&rhi, &rlo, &fa, &fb);
+
+    // Q64.64 requires:
+    //   result = (a * b) >> 64
+    //
+    // We therefore extract bits [64..191]
+    // rlo layout after multiplication:
+    //   d[0] = bits   0..63
+    //   d[1] = bits  64..127
+    //   d[2] = bits 128..191
+    //   d[3] = bits 192..255
+    //
+    // Desired Q64.64 result:
+    //
+    //   lo = d[1]
+    //   hi = d[2]
+
+    dst->lo = rlo.d[1];
+    dst->hi = rlo.d[2];
+
+    // Optional rounding:
+    // Round using highest discarded bit.
+    // discarded upper bit:  rlo.d[0] bit 63
+    if (rlo.d[0] & 0x8000000000000000ULL) {
+        dst->lo++;
+
+        if (dst->lo == 0) {
+            dst->hi++;
+        }
+    }
+}
+
+// use intern fp256 for better precision
+inline void r128Mul_specialized_factor(R128* dst, const R128* a, const R128* b)
+{
+    r128Mul_precise(dst, a, b);
+}
+#endif
+
 grdd_unit grdd_unit_calculate_decay(grdd_unit gdd, grdd_duration_seconds duration)
 {
   if (duration == 0) {
@@ -272,30 +420,36 @@ grdd_unit grdd_unit_calculate_decay(grdd_unit gdd, grdd_duration_seconds duratio
 	// https://www.wolframalpha.com/input?i=%28e%5E%28lg%282%29+%2F+31556952%29%29%5Ex&assumption=%7B%22FunClash%22%2C+%22lg%22%7D+-%3E+%7B%22Log%22%7D
 	// from wolframalpha, based on the interest rate formula
 	//return (grdd_unit)((double)gradidoCent * pow(2.0, (double)-duration / (double)SECONDS_PER_YEAR));
-
+	//
+	// r128 Version
 	R128 factor = { .lo = 0, .hi = 1 };
-	R128 base = { .lo = DECAY_FACTOR_PER_SECOND, .hi = 0 };
 	bool negative = false;
 	uint64_t exp = duration;
 
 	if (duration < 0) {
 		negative = true;
 		exp = -duration;
-		base.lo = GROW_FACTOR_PER_SECOND;
-		base.hi = 1;
 	}
 
-	while (exp > 0) {
-			if ((exp & 1) == 1) {
-					r128Mul(&factor, &factor, &base);  // factor *= base
-			}
-			r128Mul(&base, &base, &base);        // base *= base
-			exp >>= 1;
+	int i = 0;
+	while (exp > 0)
+    {
+        if ((exp & 1) == 1) {
+            R128 static_factor =  { .lo = DECAY_POWERS[i], .hi = 0 };
+            r128Mul_specialized_factor(&factor, &factor, &static_factor);
+        }
+        exp >>= 1;
+        ++i;
+    }
+
+	if (negative) {
+	    r128Div(&factor, &R128_one, &factor);
 	}
+
 	R128 gdd128;
 	r128FromInt(&gdd128, gdd_temp);
 	// Final: balance * factor
-	r128Mul(&gdd128, &gdd128, &factor);
+    r128Mul_precise(&gdd128, &gdd128, &factor);
 	r128Round(&gdd128, &gdd128); // round to nearest integer
 	grdd_unit decayed = r128ToInt(&gdd128);
 	if (negative && gdd > 0 && decayed < 0) {

--- a/shared-native/src/data/unit.c
+++ b/shared-native/src/data/unit.c
@@ -289,11 +289,8 @@ static void r128Mul_precise(R128* dst, const R128* a, const R128* b)
     //
     // High-high term contributes above Q64.64 range.
 
-//    __uint128_t p0 = (__uint128_t)a->lo * (__uint128_t)b->lo;
     __uint128_t p1 = (__uint128_t)a->hi * (__uint128_t)b->lo;
     __uint128_t p2 = (__uint128_t)a->lo * (__uint128_t)b->hi;
-    // __uint128_t p3 = (__uint128_t)a->hi * (__uint128_t)b->hi;
-
     __uint128_t low = ((((__uint128_t)a->lo * (__uint128_t)b->lo)) >> 64) + (uint64_t)p1 + (uint64_t)p2;
     dst->lo = (uint64_t)low;
     dst->hi = (uint64_t)((p1 >> 64) + (p2 >> 64) + (__uint128_t)a->hi * (__uint128_t)b->hi + (low >> 64));
@@ -348,17 +345,6 @@ static void r128Mul_precise(R128* dst, const R128* a, const R128* b)
 
     dst->lo = rlo.d[1];
     dst->hi = rlo.d[2];
-
-    // Optional rounding:
-    // Round using highest discarded bit.
-    // discarded upper bit:  rlo.d[0] bit 63
-    if (rlo.d[0] & 0x8000000000000000ULL) {
-        dst->lo++;
-
-        if (dst->lo == 0) {
-            dst->hi++;
-        }
-    }
 }
 
 // use intern fp256 for better precision
@@ -449,7 +435,7 @@ grdd_unit grdd_unit_calculate_decay(grdd_unit gdd, grdd_duration_seconds duratio
 	R128 gdd128;
 	r128FromInt(&gdd128, gdd_temp);
 	// Final: balance * factor
-    r128Mul_precise(&gdd128, &gdd128, &factor);
+	r128Mul_precise(&gdd128, &gdd128, &factor);
 	r128Round(&gdd128, &gdd128); // round to nearest integer
 	grdd_unit decayed = r128ToInt(&gdd128);
 	if (negative && gdd > 0 && decayed < 0) {
@@ -464,17 +450,17 @@ bool grdd_unit_calculate_duration_seconds(grdd_timestamp_seconds startTime, grdd
 	if (!outSeconds) {
 		return false;
 	}
-  if(startTime > endTime) {
+    if(startTime > endTime) {
 		return false;
 	}
 	grdd_timestamp_seconds start = startTime >  DECAY_START_TIME ? startTime : DECAY_START_TIME;
 	grdd_timestamp_seconds end = endTime > DECAY_START_TIME ? endTime : DECAY_START_TIME;
-  if (outSeconds) {
-    if (start == end) {
-      *outSeconds = 0;
-    } else {
-      *outSeconds = end - start;
+    if (outSeconds) {
+        if (start == end) {
+            *outSeconds = 0;
+        } else {
+            *outSeconds = end - start;
+        }
     }
-  }
 	return true;
 }

--- a/shared-native/third_party/fp256/fp256.h
+++ b/shared-native/third_party/fp256/fp256.h
@@ -1,0 +1,118 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright 2020-2021 Jiang Mengshan                                         *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License");            *
+ * you may not use this file except in compliance with the License.           *
+ * You may obtain a copy of the License at                                    *
+ *                                                                            *
+ *    http://www.apache.org/licenses/LICENSE-2.0                              *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ *                                                                            *
+ *****************************************************************************/
+
+/**
+ * @file fp256.h
+ */
+
+#pragma once
+
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+
+/** 64 bit unsigned integer */
+#define u64 unsigned long long
+/** 64 bit signed integer */
+#define s64 signed long long
+/** 32 bit unsigned integer */
+#define u32 unsigned int
+/** 32 bit signed integer */
+#define s32 signed int
+/** 8 bit unsigned character */
+#define u8  unsigned char
+
+/* TODO : error code? */
+#define FP256_OK      0
+#define FP256_ERR    -1
+
+# define FP256_EXPORT
+
+#define ORDER_BIG_ENDIAN     0
+#define ORDER_LITTLE_ENDIAN  1
+
+/* useless emmm */
+#define FP256_LIMBS    4
+#define FP256_BYTES    8
+
+struct fp256;
+
+typedef struct fp256 fp256;
+
+/**
+ * structure for 256 bit integer type.
+ */
+struct fp256 {
+    /** d stores 256 bit integer, it has four 64 bit limbs. */
+    u64 d[4];
+    /** number of limbs used */
+    unsigned int nlimbs;
+};
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+/**
+ * count number of limbs of a.
+ *
+ * @param[in] a           - 256 bit integer.
+ * @return number of limbs.
+ */
+FP256_EXPORT size_t fp256_num_limbs(const fp256 *a);
+
+/**
+ * set r = limbs.
+ *
+ * @param[out] r          - result.
+ * @param[in] limbs       - 64 bit integer array.
+ * @param[in] l           - array length.
+ * @return #FP256_OK if succeeded, #FP256_ERR otherwise.
+ */
+FP256_EXPORT int fp256_set_limbs(fp256 *r, const u64 *limbs, size_t l);
+
+/**
+ * compute a * b, rhi stores upper 256 bit result, rlo stores lower 256 bit result.
+ *
+ * @param[out] rhi        - result.
+ * @param[out] rlo        - result.
+ * @param[in] a           - 256 bit integer.
+ * @param[in] b           - 256 bit integer.
+ * @return #FP256_OK if succeeded, #FP256_ERR otherwise.
+ */
+FP256_EXPORT int fp256_mul(fp256 *rhi, fp256 *rlo, const fp256 *a, const fp256 *b);
+
+/**
+ * compute rem = num % div, quo = floor(num / div). \n
+ * It relpaces division with multiplication by reciprocal,
+ * see https://gmplib.org/~tege/division-paper.pdf.
+ *
+ * @param[out] rem        - remainder.
+ * @param[out] quo        - quotient.
+ * @param[in] num         - numerator.
+ * @param[in] div         - divisor.
+ * @return #FP256_OK if succeeded, #FP256_ERR otherwise.
+ */
+// FP256_EXPORT int fp256_div(fp256 *rem, fp256 *quo, const fp256 *num, const fp256 *div);
+
+
+#ifdef  __cplusplus
+}
+#endif

--- a/shared-native/third_party/fp256/src/fp256_mul.c
+++ b/shared-native/third_party/fp256/src/fp256_mul.c
@@ -1,0 +1,166 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright 2020-2021 Jiang Mengshan                                         *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License");            *
+ * you may not use this file except in compliance with the License.           *
+ * You may obtain a copy of the License at                                    *
+ *                                                                            *
+ *    http://www.apache.org/licenses/LICENSE-2.0                              *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ *                                                                            *
+ *****************************************************************************/
+
+#include <fp256/fp256.h>
+//#include <fp256/fp256_ll.h>
+
+// copied from ll/local.h
+/* very very very slow multiplication */
+# define LL_MUL64(rh, rl, a, b) do { \
+    u64 __t1, __t2, __ah, __al, __bh, __bl; \
+    __ah = (a) >> 32; \
+    __al = (a) & 0xffffffffULL; \
+    __bh = (b) >> 32; \
+    __bl = (b) & 0xffffffffULL; \
+    __t1 = __al * __bh; \
+    __t2 = __ah * __bl; \
+    (rl) = __al * __bl; \
+    (rh) = __ah * __bh; \
+    __t1 += ((rl) >> 32); \
+    (rl) &= 0xffffffffULL; \
+    __t1 += __t2; \
+    if (__t1 < __t2) \
+        (rh) += 0x100000000ULL; \
+    (rl) |= (__t1 << 32); \
+    (rh) += (__t1 >> 32); \
+} while(0);
+
+// copied from ll/ll_u256_mul.c
+void ll_u256_mul(u64 rd[8], const u64 ad[4], const u64 bd[4])
+{
+    u64 hi, lo, t;
+    u64 a0, a1, a2, a3;
+    u64 b;
+    u64 r0, r1, r2, r3;
+
+    a0 = ad[0]; a1 = ad[1]; a2 = ad[2]; a3 = ad[3];
+
+    /* ad * bd[0] */
+    b = bd[0];
+    LL_MUL64(hi, lo, a0, b);
+    rd[0] = lo;
+
+    LL_MUL64(t, r1, a1, b);
+    r1 += hi;
+    t += (r1 < hi);
+
+    LL_MUL64(hi, r2, a2, b);
+    r2 += t;
+    hi += (r2 < t);
+
+    LL_MUL64(r0, r3, a3, b);
+    r3 += hi;
+    r0 += (r3 < hi);
+
+    /* + ad * bd[1] */
+    b = bd[1];
+    LL_MUL64(hi, lo, a0, b);
+    r1 += lo;
+    hi += (r1 < lo);
+    rd[1] = r1;
+
+    LL_MUL64(t, lo, a1, b);
+    r2 += hi;
+    t += (r2 < hi);
+    r2 += lo;
+    t += (r2 < lo);
+
+    LL_MUL64(hi, lo, a2, b);
+    r3 += t;
+    hi += (r3 < t);
+    r3 += lo;
+    hi += (r3 < lo);
+
+    LL_MUL64(r1, lo, a3, b);
+    r0 += hi;
+    r1 += (r0 < hi);
+    r0 += lo;
+    r1 += (r0 < lo);
+
+    /* + ad * bd[2] */
+    b = bd[2];
+    LL_MUL64(hi, lo, a0, b);
+    r2 += lo;
+    hi += (r2 < lo);
+    rd[2] = r2;
+
+    LL_MUL64(t, lo, a1, b);
+    r3 += hi;
+    t += (r3 < hi);
+    r3 += lo;
+    t += (r3 < lo);
+
+    LL_MUL64(hi, lo, a2, b);
+    r0 += t;
+    hi += (r0 < t);
+    r0 += lo;
+    hi += (r0 < lo);
+
+    LL_MUL64(r2, lo, a3, b);
+    r1 += hi;
+    r2 += (r1 < hi);
+    r1 += lo;
+    r2 += (r1 < lo);
+
+    /* + ad * bd[3] */
+    b = bd[3];
+    LL_MUL64(hi, lo, a0, b);
+    r3 += lo;
+    hi += (r3 < lo);
+    rd[3] = r3;
+
+    LL_MUL64(t, lo, a1, b);
+    r0 += hi;
+    t += (r0 < hi);
+    r0 += lo;
+    t += (r0 < lo);
+
+    LL_MUL64(hi, lo, a2, b);
+    r1 += t;
+    hi += (r1 < t);
+    r1 += lo;
+    hi += (r1 < lo);
+
+    LL_MUL64(r3, lo, a3, b);
+    r2 += hi;
+    r3 += (r2 < hi);
+    r2 += lo;
+    r3 += (r2 < lo);
+
+    rd[4] = r0;
+    rd[5] = r1;
+    rd[6] = r2;
+    rd[7] = r3;
+
+    return;
+}
+
+/* rhi:rlo = a * b */
+int fp256_mul(fp256 *rhi, fp256 *rlo, const fp256 *a, const fp256 *b)
+{
+    u64 rd[8];
+
+    if (rhi == NULL || rlo == NULL || a == NULL || b == NULL)
+        return FP256_ERR;
+
+    ll_u256_mul(rd, a->d, b->d);
+
+    fp256_set_limbs(rlo, rd, FP256_LIMBS);
+    fp256_set_limbs(rhi, rd + 4, FP256_LIMBS);
+    return FP256_OK;
+}

--- a/shared-native/third_party/fp256/src/fp256_utils.c
+++ b/shared-native/third_party/fp256/src/fp256_utils.c
@@ -1,0 +1,61 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright 2020-2021 Jiang Mengshan                                         *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License");            *
+ * you may not use this file except in compliance with the License.           *
+ * You may obtain a copy of the License at                                    *
+ *                                                                            *
+ *    http://www.apache.org/licenses/LICENSE-2.0                              *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ *                                                                            *
+ *****************************************************************************/
+
+#include <fp256/fp256.h>
+//#include <fp256/fp256_ll.h>
+//#include "ll/ll_local.h"
+
+// copied from ll/ll_local.h
+/* number of limbs of a(u64 array) */
+# define LL_NUM_LIMBS(a, max, nlimbs) do { \
+    size_t __n = max; \
+    nlimbs = 0; \
+ \
+    while (__n > 0) { \
+        __n--; \
+        if (a[__n] > 0ULL) { \
+            nlimbs = 1; \
+            break; \
+        } \
+    } \
+    nlimbs += __n; \
+} while(0);
+
+
+size_t fp256_num_limbs(const fp256 *a)
+{
+    size_t l;
+    LL_NUM_LIMBS(a->d, 4, l);
+    return l;
+}
+
+int fp256_set_limbs(fp256 *r, const u64 *limbs, size_t l)
+{
+    size_t i;
+
+    if (l > FP256_LIMBS)
+        return FP256_ERR;
+
+    for (i = 0; i < l; i++)
+        r->d[i] = limbs[i];
+    for (i = l; i < FP256_LIMBS; i++)
+        r->d[i] = 0ULL;
+
+    r->nlimbs = fp256_num_limbs(r);
+    return FP256_OK;
+}


### PR DESCRIPTION
Make decay calculation deterministic across platforms and cpu architectures with don't using special CPU instructions only existing on intel and amd but not on arm cpus.
Using fp256 and r128 arithmetic libs for fixed point decimal and precise integer arithmetic.
Using precalculated table for even more deterministic and some speedup. 
Use __int128 type where it exist (because it isn't standard) instead of fp256 for speedup with same results.