### PR TITLE
fix(frontend): email send form

### DIFF
--- a/backend/src/graphql/resolver/TransactionResolver.ts
+++ b/backend/src/graphql/resolver/TransactionResolver.ts
@@ -590,6 +590,11 @@ export class TransactionResolver {
         logger.error(errmsg)
         throw new Error(errmsg)
       }
+      if (senderUser.id === recipientUser.id) {
+        const errmsg = 'You cannot send an email to yourself'
+        logger.error(errmsg)
+        throw new Error(errmsg)
+      }
       logger.addContext('to', recipientUser?.id)
       if (recipientUser.foreign) {
         const errmsg = 'Found foreign recipient user for a local action: ' + recipientUser
@@ -610,6 +615,8 @@ export class TransactionResolver {
         senderLastName: senderUser.lastName,
         subject: subject,
         memo: memo,
+        senderUuid: senderUser.gradidoID,
+        senderCommunityUuid: senderUser.communityUuid,
       })
     } else {
       // sendEmail for foreign communities

--- a/core/src/emails/sendEmailVariants.ts
+++ b/core/src/emails/sendEmailVariants.ts
@@ -200,6 +200,8 @@ export const sendCustomEmail = (
     senderLastName: string
     subject: string
     memo: string
+    senderUuid?: string
+    senderCommunityUuid?: string
   },
 ): Promise<Record<string, unknown> | boolean | null | Error> => {
   const logger = createLogger()

--- a/core/src/emails/templates/customEmail/html.pug
+++ b/core/src/emails/templates/customEmail/html.pug
@@ -1,23 +1,17 @@
 extend ../layout.pug
 
-block content  
-  mixin mailto(email, subject)
-    - var formattedSubject = encodeURIComponent(subject)
-    a(class!=attributes.class href=`mailto:${email}?subject=${formattedSubject}`)
-      block
-
+block content
   .text-block
     include ../includes/salutation.pug
-    p 
-      = t('emails.customEmail.haveReceivedMessageFrom', { senderFirstName, senderLastName })   
+    p
+      = t('emails.customEmail.haveReceivedMessageFrom', { senderFirstName, senderLastName })
 
   .subject-block
     div(class="p_content")= subject
 
   .memo-block
     div(class="p_content")= memo
-    
-  a.button-3(href=`${communityURL}/send`) #{t('emails.general.toAccount')}
-
-  
-
+  if senderCommunityUuid && senderUuid
+    a.button-3(href=`${communityURL}/send/${senderCommunityUuid}/${senderUuid}`) #{t('emails.general.toAccount')}
+  else
+    a.button-3(href=`${communityURL}/send`) #{t('emails.general.toAccount')}

--- a/frontend/src/components/GddSend/SendEmailResultError.vue
+++ b/frontend/src/components/GddSend/SendEmailResultError.vue
@@ -46,6 +46,9 @@
         {{ $t('form.sendemailerror.failedToSendCommandToFederatedCommunity') }}
         {{ errorResult.split('sendCommand failed with response error: ')[1] }}
       </div>
+      <div v-else-if="errorResult.includes('You cannot send an email to yourself')">
+        {{ $t('form.sendemailerror.youCannotSendEmailToYourself') }}
+      </div>
       <div v-else>
         {{ $t('form.sendemailerror.unknownError') }}
         {{ errorResult }}

--- a/frontend/src/components/GddSend/TransactionForm.vue
+++ b/frontend/src/components/GddSend/TransactionForm.vue
@@ -64,7 +64,7 @@
                     <BRow>
                       <BCol class="fw-bold">
                         <community-switch
-                          :disabled="isBalanceEmpty"
+                          :disabled="isFormDisabled"
                           :model-value="form.targetCommunity"
                           :community-identifier="autoCommunityIdentifier"
                           @update:model-value="updateField($event, 'targetCommunity')"
@@ -86,7 +86,7 @@
                         :label="$t('form.recipient')"
                         :placeholder="$t('form.identifier')"
                         :rules="validationSchema.fields.identifier"
-                        :disabled="isBalanceEmpty || isCommunitiesEmpty"
+                        :disabled="isFormDisabled || isCommunitiesEmpty"
                         :disable-smart-valid-state="disableSmartValidState"
                         @update:model-value="updateField"
                       />
@@ -113,7 +113,7 @@
                       :label="$t('form.amount')"
                       :placeholder="'0.01'"
                       :rules="validationSchema.fields.amount"
-                      :disabled="isBalanceEmpty"
+                      :disabled="isFormDisabled"
                       :disable-smart-valid-state="disableSmartValidState"
                       @update:model-value="updateField"
                     />
@@ -147,13 +147,13 @@
                   :placeholder="$t('form.message')"
                   :rules="validationSchema.fields.memo"
                   textarea="true"
-                  :disabled="isBalanceEmpty"
+                  :disabled="isFormDisabled"
                   :disable-smart-valid-state="disableSmartValidState"
                   @update:model-value="updateField"
                 />
               </BCol>
             </BRow>
-            <div v-if="!!isBalanceEmpty" class="text-danger mt-5">
+            <div v-if="!!isFormDisabled" class="text-danger mt-5">
               {{ $t('form.no_gdd_available') }}
             </div>
             <BRow v-else class="test-buttons mt-3">
@@ -350,7 +350,9 @@ const updateField = (newValue, name) => {
   }
 }
 
-const isBalanceEmpty = computed(() => props.balance <= 0)
+const isFormDisabled = computed(
+  () => (props.balance <= 0 && radioSelected.value === SEND_TYPES.send) || false,
+)
 const isCommunitiesEmpty = computed(() => communities.value.length === 0)
 
 const { result: userResult, error: userError } = useQuery(

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -214,7 +214,8 @@
       "receiverCommunityNotFound": "Die Gemeinschaft deines E-Mail-Empfängers wurde nicht gefunden",
       "receiverDeleted": "Das Nutzerkonto zu deinem E-Mail-Empfänger wurde gelöscht",
       "receiverNotFound": "Zu deinem angegebenen E-Mail-Empfänger existiert kein Nutzerkonto.",
-      "unknownError": "Ein unbekannter Fehler ist aufgetreten: "
+      "unknownError": "Ein unbekannter Fehler ist aufgetreten: ",
+      "youCannotSendEmailToYourself": "Du kannst keine E-Mail an dich selbst senden."
     },
     "sender": "Absender",
     "sorry": "Entschuldigung",
@@ -260,6 +261,11 @@
         "required": "Die Nachricht ist ein Pflichtfeld."
       },
       "requiredField": "{fieldName} ist ein Pflichtfeld",
+      "subject": {
+        "max": "Der Betreff darf höchstens {max} Zeichen lang sein.",
+        "min": "Der Betreff sollte mindestens {min} Zeichen lang sein.",
+        "required": "Der Betreff ist ein Pflichtfeld."
+      },
       "username-allowed-chars": "Der Nutzername darf nur aus Buchstaben (ohne Umlaute), Zahlen, Binde- oder Unterstrichen bestehen.",
       "username-hyphens": "Binde- oder Unterstriche müssen zwischen Buchstaben oder Zahlen stehen.",
       "username-unique": "Der Nutzername ist bereits vergeben."

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -214,7 +214,8 @@
       "receiverCommunityNotFound": "The community of your email recipient was not found",
       "receiverDeleted": "The user account for your email recipient has been deleted",
       "receiverNotFound": "No user account exists for your specified email recipient.",
-      "unknownError": "An unknown error occurred: "
+      "unknownError": "An unknown error occurred: ",
+      "youCannotSendEmailToYourself": "You cannot send an email to yourself."
     },
     "sender": "Sender",
     "sorry": "Sorry",
@@ -260,6 +261,11 @@
         "required": "The message is required."
       },
       "requiredField": "The {fieldName} field is required",
+      "subject": {
+        "max": "The subject should not be longer than {max} characters.",
+        "min": "The subject should be at least {min} characters long.",
+        "required": "The subject is required."
+      },
       "username-allowed-chars": "The username may only contain letters, numbers, hyphens or underscores.",
       "username-hyphens": "Hyphens or underscores must be in between letters or numbers.",
       "username-unique": "This username is already taken."

--- a/frontend/src/pages/Send.spec.js
+++ b/frontend/src/pages/Send.spec.js
@@ -101,6 +101,7 @@ describe('Send', () => {
     expect(wrapper.vm.transactionData).toEqual({
       identifier: '',
       amount: 0,
+      subject: '',
       memo: '',
     })
     expect(wrapper.vm.currentTransactionStep).toBe('transactionForm')
@@ -110,6 +111,7 @@ describe('Send', () => {
     const testData = {
       identifier: 'test@example.com',
       amount: 100,
+      subject: '',
       memo: 'Test transaction',
       selected: 'send',
     }

--- a/frontend/src/pages/Send.vue
+++ b/frontend/src/pages/Send.vue
@@ -280,6 +280,7 @@ const { t } = useI18n()
 const EMPTY_TRANSACTION_DATA = {
   identifier: '',
   amount: 0,
+  subject: '',
   memo: '',
 }
 
@@ -372,6 +373,7 @@ async function sendEmail(data) {
       })
       if (result) {
         currentTransactionStep.value = TRANSACTION_STEPS.sendEmailResultSuccess
+        Object.assign(transactionData, EMPTY_TRANSACTION_DATA)
         // toastSuccess(t('email-sent-success'))
       } else {
         currentTransactionStep.value = TRANSACTION_STEPS.sendEmailResultError


### PR DESCRIPTION
- Added missing translation for empty subject field
- Sending emails is now possible even if you don't have any GDDs
- Sending emails to yourself is prevented
- The form is reset once the email has been sent successfully
- The account link contains the sender's UUID and the community's UUID (local only)