### PR TITLE
feat(frontend): sprachumschalter als scrollbares Dropdown mit Globus-Icon

### DIFF
--- a/frontend/src/components/LanguageSwitch2.spec.js
+++ b/frontend/src/components/LanguageSwitch2.spec.js
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import LanguageSwitch from './LanguageSwitch2.vue'
 import locales from '@/locales/'
 import { createStore } from 'vuex'
@@ -24,13 +24,20 @@ vi.mock('@vue/apollo-composable', async () => {
 })
 
 const mockToastError = vi.fn()
+const mockToastSuccess = vi.fn()
 vi.mock('@/composables/useToast', () => ({
   useAppToast: vi.fn(() => ({
     toastError: mockToastError,
+    toastSuccess: mockToastSuccess,
   })),
 }))
 
-describe('LanguageSwitch', () => {
+const enabledLocales = locales.filter((lang) => lang.enabled)
+const nameByCode = (code) => locales.find((lang) => lang.code === code).name
+const itemByCode = (wrapper, code) =>
+  wrapper.findAll('.ls-item').find((item) => item.find('.ls-item-name').text() === nameByCode(code))
+
+describe('LanguageSwitch2', () => {
   let wrapper
 
   const store = createStore({
@@ -51,16 +58,14 @@ describe('LanguageSwitch', () => {
     messages: {},
   })
 
-  const globalMocks = {
-    $apollo: {
-      mutate: updateUserInfosMutationMock,
-    },
-  }
-
   const mountOptions = {
     global: {
       plugins: [store, i18n],
-      mocks: globalMocks,
+      mocks: {
+        $apollo: {
+          mutate: updateUserInfosMutationMock,
+        },
+      },
     },
   }
 
@@ -68,109 +73,75 @@ describe('LanguageSwitch', () => {
     return mount(LanguageSwitch, mountOptions)
   }
 
-  describe('mount', () => {
-    beforeEach(() => {
-      wrapper = createWrapper()
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = createWrapper()
+  })
+
+  it('renders the component', () => {
+    expect(wrapper.find('div.language-switch').exists()).toBe(true)
+  })
+
+  describe('current language label (the trigger)', () => {
+    it('defaults to the navigator language English when the store is empty', async () => {
+      const languageGetter = vi.spyOn(navigator, 'language', 'get')
+      languageGetter.mockReturnValue('en-US')
+      store.state.language = null
+      await wrapper.vm.setCurrentLanguage()
+      expect(wrapper.find('.ls-current').text()).toBe('English')
     })
 
-    it('renders the component', () => {
-      expect(wrapper.find('div.language-switch').exists()).toBe(true)
+    it('falls back to English when there is no navigator language', async () => {
+      const languageGetter = vi.spyOn(navigator, 'language', 'get')
+      languageGetter.mockReturnValue(null)
+      store.state.language = null
+      await wrapper.vm.setCurrentLanguage()
+      expect(wrapper.find('.ls-current').text()).toBe('English')
     })
 
-    describe('with locales en, de, es, fr, nl, and it', () => {
-      describe('empty store', () => {
-        describe('navigator language is "en-US"', () => {
-          const languageGetter = vi.spyOn(navigator, 'language', 'get')
+    it('shows the stored language as its autonym', async () => {
+      store.state.language = 'es'
+      await wrapper.vm.setCurrentLanguage()
+      expect(wrapper.find('.ls-current').text()).toBe('Español')
+    })
+  })
 
-          it('shows English as default navigator language', async () => {
-            languageGetter.mockReturnValue('en-US')
-            await wrapper.vm.setCurrentLanguage()
-            expect(wrapper.findAll('span.locales').at(0).text()).toBe('English')
-          })
-        })
-
-        describe('no navigator language', () => {
-          const languageGetter = vi.spyOn(navigator, 'language', 'get')
-
-          it('shows English as language ', async () => {
-            languageGetter.mockReturnValue(null)
-            await wrapper.vm.setCurrentLanguage()
-            expect(wrapper.findAll('span.locales').at(0).text()).toBe('English')
-          })
-        })
-      })
-
-      describe('language "de" in store', () => {
-        it('shows Deutsch as language', async () => {
-          store.state.language = 'de'
-          await wrapper.vm.setCurrentLanguage()
-          expect(wrapper.findAll('span.locales').at(1).text()).toBe('English')
-        })
-      })
-
-      describe('language "es" in store', () => {
-        it('shows Español as language', async () => {
-          store.state.language = 'es'
-          await wrapper.vm.setCurrentLanguage()
-          expect(wrapper.findAll('span.locales').at(2).text()).toBe('Deutsch')
-        })
-      })
-
-      describe('language "fr" in store', () => {
-        it('shows French as language', async () => {
-          store.state.language = 'fr'
-          await wrapper.vm.setCurrentLanguage()
-          expect(wrapper.findAll('span.locales').at(3).text()).toBe('Español')
-        })
-      })
-
-      describe('language "nl" in store', () => {
-        it('shows Nederlands as language', async () => {
-          store.state.language = 'nl'
-          await wrapper.vm.setCurrentLanguage()
-          expect(wrapper.findAll('span.locales').at(4).text()).toBe('Français')
-        })
-      })
-
-      describe('language menu', () => {
-        beforeAll(async () => {
-          store.state.language = 'en'
-          await wrapper.vm.setCurrentLanguage()
-        })
-
-        it('has all configured languages to choose from', () => {
-          expect(wrapper.findAll('span.locales').length).toBe(locales.length)
-        })
-      })
+  describe('the language menu', () => {
+    beforeEach(async () => {
+      store.state.language = 'de'
+      await wrapper.vm.setCurrentLanguage()
     })
 
-    describe('calls the API', () => {
-      it("with locale 'de'", async () => {
-        await wrapper.findAll('span.locales').at(1).trigger('click')
-        await vi.waitFor(() => {
-          expect(updateUserInfosMutationMock).toHaveBeenCalledWith({ locale: 'de' })
-        })
-      })
+    it('offers every enabled language to choose from', () => {
+      expect(wrapper.findAll('.ls-item').length).toBe(enabledLocales.length)
+    })
 
-      it("with locale 'es'", async () => {
-        await wrapper.findAll('span.locales').at(2).trigger('click')
-        await vi.waitFor(() => {
-          expect(updateUserInfosMutationMock).toHaveBeenCalledWith({ locale: 'es' })
-        })
-      })
+    it('puts the current language first and marks it active', () => {
+      const first = wrapper.findAll('.ls-item')[0]
+      expect(first.find('.ls-item-name').text()).toBe('Deutsch')
+      expect(first.classes()).toContain('ls-item--active')
+    })
 
-      it("with locale 'fr'", async () => {
-        await wrapper.findAll('span.locales').at(3).trigger('click')
-        await vi.waitFor(() => {
-          expect(updateUserInfosMutationMock).toHaveBeenCalledWith({ locale: 'fr' })
-        })
-      })
+    it('sorts the remaining languages alphabetically by autonym', () => {
+      const names = wrapper
+        .findAll('.ls-item')
+        .slice(1)
+        .map((item) => item.find('.ls-item-name').text())
+      const expected = [...names].sort((a, b) => a.localeCompare(b))
+      expect(names).toEqual(expected)
+    })
+  })
 
-      it("with locale 'nl'", async () => {
-        await wrapper.findAll('span.locales').at(4).trigger('click')
-        await vi.waitFor(() => {
-          expect(updateUserInfosMutationMock).toHaveBeenCalledWith({ locale: 'nl' })
-        })
+  describe('selecting a language calls the API', () => {
+    beforeEach(async () => {
+      store.state.language = 'en'
+      await wrapper.vm.setCurrentLanguage()
+    })
+
+    it.each([['de'], ['es'], ['fr'], ['nl']])('with locale "%s"', async (code) => {
+      await itemByCode(wrapper, code).trigger('click')
+      await vi.waitFor(() => {
+        expect(updateUserInfosMutationMock).toHaveBeenCalledWith({ locale: code })
       })
     })
   })

--- a/frontend/src/components/LanguageSwitch2.spec.js
+++ b/frontend/src/components/LanguageSwitch2.spec.js
@@ -119,7 +119,7 @@ describe('LanguageSwitch2', () => {
     it('puts the current language first and marks it active', () => {
       const first = wrapper.findAll('.ls-item')[0]
       expect(first.find('.ls-item-name').text()).toBe('Deutsch')
-      expect(first.classes()).toContain('ls-item--active')
+      expect(first.classes()).toContain('ls-item-active')
     })
 
     it('sorts the remaining languages alphabetically by autonym', () => {

--- a/frontend/src/components/LanguageSwitch2.vue
+++ b/frontend/src/components/LanguageSwitch2.vue
@@ -16,7 +16,7 @@
         v-for="lang in sortedLocales"
         :key="lang.code"
         class="ls-item"
-        :class="{ 'ls-item--active': lang.code === store.state.language }"
+        :class="{ 'ls-item-active': lang.code === store.state.language }"
         role="option"
         :aria-selected="lang.code === store.state.language"
         @click="select(lang.code)"
@@ -128,6 +128,7 @@ onUnmounted(() => {
   position: relative;
   display: inline-block;
 }
+
 .ls-trigger {
   display: inline-flex;
   align-items: center;
@@ -140,17 +141,21 @@ onUnmounted(() => {
   line-height: 1.2;
   cursor: pointer;
 }
+
 .ls-trigger:hover .ls-current {
   text-decoration: underline;
 }
+
 .ls-globe {
   font-size: 1.15em;
   opacity: 0.7;
 }
+
 .ls-caret {
   font-size: 0.9em;
   opacity: 0.6;
 }
+
 .ls-menu {
   position: absolute;
   top: calc(100% + 4px);
@@ -162,11 +167,12 @@ onUnmounted(() => {
   margin: 0;
   padding: 4px;
   list-style: none;
-  background: #ffffff;
-  border: 0.5px solid rgba(0, 0, 0, 0.15);
+  background: #fff;
+  border: 0.5px solid rgb(0 0 0 / 15%);
   border-radius: 10px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
 }
+
 .ls-item {
   display: flex;
   align-items: center;
@@ -177,13 +183,16 @@ onUnmounted(() => {
   white-space: nowrap;
   cursor: pointer;
 }
+
 .ls-item:hover {
   background: #f2f4f6;
 }
-.ls-item--active {
+
+.ls-item-active {
   background: #e9f1fb;
   color: #185fa5;
 }
+
 .ls-check {
   font-size: 1em;
 }

--- a/frontend/src/components/LanguageSwitch2.vue
+++ b/frontend/src/components/LanguageSwitch2.vue
@@ -55,7 +55,7 @@ const currentName = computed(() => {
   return current ? current.name : store.state.language || ''
 })
 
-// Aktuelle Sprache oben, der Rest alphabetisch nach Autonym (Eigenname).
+// Current language first, the rest sorted alphabetically by autonym (the language's own name).
 const sortedLocales = computed(() => {
   const enabled = locales.filter((lang) => lang.enabled)
   const current = enabled.find((lang) => lang.code === store.state.language)

--- a/frontend/src/components/LanguageSwitch2.vue
+++ b/frontend/src/components/LanguageSwitch2.vue
@@ -1,41 +1,30 @@
 <template>
-  <div class="language-switch">
-    <div v-b-toggle.collapse-1>
-      <span
-        v-for="lang in locales"
+  <div ref="root" class="language-switch">
+    <button
+      type="button"
+      class="ls-trigger"
+      :aria-expanded="open"
+      aria-haspopup="listbox"
+      @click="toggleOpen"
+    >
+      <IBiGlobe2 class="ls-globe" aria-hidden="true" />
+      <span class="ls-current">{{ currentName }}</span>
+      <IBiCaretDownFill class="ls-caret" aria-hidden="true" />
+    </button>
+    <ul v-show="open" class="ls-menu" role="listbox">
+      <li
+        v-for="lang in sortedLocales"
         :key="lang.code"
-        class="pointer"
-        :class="store.state.language === lang.code ? 'c-grey' : 'c-blau'"
+        class="ls-item"
+        :class="{ 'ls-item--active': lang.code === store.state.language }"
+        role="option"
+        :aria-selected="lang.code === store.state.language"
+        @click="select(lang.code)"
       >
-        <span v-if="lang.code === store.state.language" class="locales me-1">
-          {{ lang.name }}
-        </span>
-      </span>
-      <IBiCaretDownFill />
-    </div>
-    <BCollapse id="collapse-1" class="mt-4">
-      <span
-        v-for="(lang, index) in locales"
-        :key="lang.code"
-        class="pointer"
-        :class="store.state.language === lang.code ? 'c-grey' : 'c-blau'"
-        @click.prevent="saveLocale(lang.code)"
-      >
-        <span v-if="lang.code !== store.state.language" v-b-toggle.collapse-1 class="locales">
-          {{ lang.name }}
-        </span>
-        <span
-          v-if="
-            lang.code !== store.state.language &&
-            (indexOfSelectedLocale !== indexOfLastLocale ||
-              (indexOfSelectedLocale === indexOfLastLocale && index !== indexOfSecondLastLocale))
-          "
-          class="ms-3 me-3"
-        >
-          {{ locales.length - 1 > index ? $t('|') : '' }}
-        </span>
-      </span>
-    </BCollapse>
+        <span class="ls-item-name">{{ lang.name }}</span>
+        <IBiCheck v-if="lang.code === store.state.language" class="ls-check" aria-hidden="true" />
+      </li>
+    </ul>
   </div>
 </template>
 
@@ -45,7 +34,7 @@ import { useI18n } from 'vue-i18n'
 import { useMutation } from '@vue/apollo-composable'
 import { useAppToast } from '@/composables/useToast'
 import locales from '@/locales/'
-import { onMounted, ref, computed } from 'vue'
+import { onMounted, onUnmounted, ref, computed } from 'vue'
 import { updateUserInfos } from '@/graphql/mutations'
 import { setLocale as setValidationI18nLocale } from '@vee-validate/i18n'
 
@@ -54,15 +43,30 @@ const { t, locale } = useI18n()
 const { mutate } = useMutation(updateUserInfos)
 const { toastSuccess, toastError } = useAppToast()
 
-const currentLang = ref({})
+const open = ref(false)
+const root = ref(null)
 
 const getLocaleObject = (localeCode) => {
   return locales.find((lang) => lang.code === localeCode)
 }
 
+const currentName = computed(() => {
+  const current = getLocaleObject(store.state.language)
+  return current ? current.name : store.state.language || ''
+})
+
+// Aktuelle Sprache oben, der Rest alphabetisch nach Autonym (Eigenname).
+const sortedLocales = computed(() => {
+  const enabled = locales.filter((lang) => lang.enabled)
+  const current = enabled.find((lang) => lang.code === store.state.language)
+  const rest = enabled
+    .filter((lang) => lang.code !== store.state.language)
+    .sort((a, b) => a.name.localeCompare(b.name))
+  return current ? [current, ...rest] : rest
+})
+
 const setLocale = (newLocale) => {
   store.commit('language', newLocale)
-  currentLang.value = getLocaleObject(newLocale)
 }
 
 const saveLocale = async (newLocale) => {
@@ -80,6 +84,15 @@ const saveLocale = async (newLocale) => {
   }
 }
 
+const select = (newLocale) => {
+  open.value = false
+  saveLocale(newLocale)
+}
+
+const toggleOpen = () => {
+  open.value = !open.value
+}
+
 const getNavigatorLang = () => {
   const navigatorLang = navigator.language
   if (navigatorLang) return navigatorLang.split('-')[0]
@@ -88,29 +101,90 @@ const getNavigatorLang = () => {
 
 const setCurrentLanguage = () => {
   let newLocale = store.state.language || getNavigatorLang() || 'en'
-  let langObject = getLocaleObject(newLocale)
-  if (!langObject) {
+  if (!getLocaleObject(newLocale)) {
     newLocale = 'en'
-    langObject = getLocaleObject(newLocale)
   }
-
   setLocale(newLocale)
-  currentLang.value = langObject
 }
 
-const indexOfSelectedLocale = computed(() => {
-  return locales.findIndex((element) => element.code === store.state.language)
-})
-
-const indexOfSecondLastLocale = computed(() => {
-  return locales.length - 2
-})
-
-const indexOfLastLocale = computed(() => {
-  return locales.length - 1
-})
+const onDocumentClick = (event) => {
+  if (open.value && root.value && !root.value.contains(event.target)) {
+    open.value = false
+  }
+}
 
 onMounted(() => {
   setCurrentLanguage()
+  document.addEventListener('click', onDocumentClick)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', onDocumentClick)
 })
 </script>
+
+<style scoped>
+.language-switch {
+  position: relative;
+  display: inline-block;
+}
+.ls-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  line-height: 1.2;
+  cursor: pointer;
+}
+.ls-trigger:hover .ls-current {
+  text-decoration: underline;
+}
+.ls-globe {
+  font-size: 1.15em;
+  opacity: 0.7;
+}
+.ls-caret {
+  font-size: 0.9em;
+  opacity: 0.6;
+}
+.ls-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 1060;
+  min-width: 180px;
+  max-height: 280px;
+  overflow-y: auto;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  background: #ffffff;
+  border: 0.5px solid rgba(0, 0, 0, 0.15);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+.ls-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 9px 12px;
+  border-radius: 6px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.ls-item:hover {
+  background: #f2f4f6;
+}
+.ls-item--active {
+  background: #e9f1fb;
+  color: #185fa5;
+}
+.ls-check {
+  font-size: 1em;
+}
+</style>


### PR DESCRIPTION
## Problem
Der Sprachumschalter (`LanguageSwitch2.vue`, genutzt auf **Login und Einstellungen**) klappt die anderen Sprachen als waagerechte, durch „|" getrennte Inline-Zeile auf. Mit den künftig **10 Sprachen** läuft diese Zeile seitlich aus dem Bild — besonders am Handy. Der reine Schriftzug „Deutsch ▾" signalisiert zudem nicht, dass es ein Sprachwähler ist.

## Lösung
- Echtes vertikales **Dropdown** (Button + `role="listbox"`), nach unten, **scrollbar** → skaliert sauber auf 10+ Sprachen.
- **Globus-Icon** als schrift-/sprachunabhängige Affordanz; bewusst **keine Länderflaggen** (Land ≠ Sprache: Español/Português/English wären mehrdeutig).
- **Autonyme** (Eigennamen), **aktuelle Sprache oben + markiert**, Rest **alphabetisch**.
- Klick-außerhalb schließt; nur `enabled`-Sprachen werden gelistet.
- Fachlogik (Vuex-Store, vue-i18n, Apollo `updateUserInfos`, vee-validate, Navigator-Fallback) **unverändert**.

## Wirkung
Eine Komponente → **Login und Einstellungen** zugleich verbessert.

## Tests
- `LanguageSwitch2.spec.js` an die neue Struktur angepasst (11 Tests): Trigger-Autonym, vollständige Sprachliste, aktuelle zuerst + aktiv, Rest alphabetisch, Locale-Wechsel ruft `updateUserInfos`.
- Lokal grün: LanguageSwitch2 **11/11**, AuthLayout **8/8**, Settings **10/10**, ESLint sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
