### PR TITLE
fix(admin): darken hover color for deleted creation rows

### DIFF
--- a/admin/src/components/Tables/OpenCreationsTable.vue
+++ b/admin/src/components/Tables/OpenCreationsTable.vue
@@ -305,5 +305,6 @@ export default {
 .table-danger {
   --bs-table-bg: #e78d8d;
   --bs-table-striped-bg: #e57373;
+  --bs-table-hover-bg: #e06a6a;
 }
 </style>


### PR DESCRIPTION
## Problem
On Schöpfung → Gelöscht (`admin/creation-confirm`), deleted rows have a red background (`.table-danger`). On hover they become **lighter**, while every other row in this view becomes **darker**.

## Cause
`OpenCreationsTable.vue` overrides the danger base color (`--bs-table-bg: #e78d8d`) but not the hover color, so Bootstrap's lighter default `--bs-table-hover-bg` (`#e5c7ca`) remained — lighter than the customized base.

## Fix
Add `--bs-table-hover-bg: #e06a6a` to `.table-danger`, so deleted rows darken on hover, consistent with the rest.

## Tests
Local: Stylelint OK, ESLint OK, `OpenCreationsTable` unit tests 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
