### PR TITLE
fix(frontend): correct send page title (singular Gradido + email)

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -370,7 +370,7 @@
     "gdt": "Deine GDT Transaktionen",
     "information": "{community}",
     "overview": "Willkommen {name}",
-    "send": "Sende Gradidos",
+    "send": "Gradido und E-Mail senden",
     "settings": "Einstellungen",
     "transactions": "Deine Transaktionen",
     "usersearch": "Geografische Mitgliedssuche (beta)"

--- a/frontend/src/locales/el.json
+++ b/frontend/src/locales/el.json
@@ -370,7 +370,7 @@
     "gdt": "Οι συναλλαγές σου GDT",
     "information": "{community}",
     "overview": "Καλώς ήρθες {name}",
-    "send": "Αποστολή Gradidos",
+    "send": "Αποστολή Gradido και email",
     "settings": "Ρυθμίσεις",
     "transactions": "Οι συναλλαγές σου",
     "usersearch": "Γεωγραφική αναζήτηση μελών (beta)"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -370,7 +370,7 @@
     "gdt": "Your GDT transactions",
     "information": "{community}",
     "overview": "Welcome {name}",
-    "send": "Send Gradidos",
+    "send": "Send Gradido and email",
     "settings": "Settings",
     "transactions": "Your transactions",
     "usersearch": "Geographic member search (beta)"

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -370,7 +370,7 @@
     "gdt": "Tu GDT Transacciones",
     "information": "{community}",
     "overview": "Welcome {name}",
-    "send": "Enviar Gradidos",
+    "send": "Enviar Gradido y correo electrónico",
     "settings": "Soporte",
     "transactions": "Tu Transacciones",
     "usersearch": "Búsqueda geográfica de miembros (beta)"

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -370,7 +370,7 @@
     "gdt": "Tes transactions GDT",
     "information": "{community}",
     "overview": "Bienvenue {name}",
-    "send": "Envoyé Gradidos",
+    "send": "Envoyer Gradido et e-mail",
     "settings": "Configuration",
     "transactions": "Tes transactions",
     "usersearch": "Recherche géographique de membres (bèta)"

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -370,7 +370,7 @@
     "gdt": "Le tue transazioni GDT",
     "information": "{community}",
     "overview": "Benvenuto {name}",
-    "send": "Invia Gradido",
+    "send": "Invia Gradido ed e-mail",
     "settings": "Impostazioni",
     "transactions": "Le tue transazioni",
     "usersearch": "Ricerca geografica dei membri (beta)"

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -370,7 +370,7 @@
     "gdt": "Your GDT transactions",
     "information": "{community}",
     "overview": "Welcome {name}",
-    "send": "Send Gradidos",
+    "send": "Gradido en e-mail versturen",
     "settings": "Settings",
     "transactions": "Your transactions",
     "usersearch": "Geografisch leden zoeken (bèta)"

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -370,7 +370,7 @@
     "gdt": "As tuas transações GDT",
     "information": "{community}",
     "overview": "Bem-vindo {name}",
-    "send": "Enviar Gradidos",
+    "send": "Enviar Gradido e e-mail",
     "settings": "Definições",
     "transactions": "As tuas transações",
     "usersearch": "Pesquisa geográfica de membros (beta)"

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -370,7 +370,7 @@
     "gdt": "Ваши транзакции GDT",
     "information": "{community}",
     "overview": "Добро пожаловать, {name}",
-    "send": "Отправить Gradido",
+    "send": "Отправить Gradido и e-mail",
     "settings": "Настройки",
     "transactions": "Ваши транзакции",
     "usersearch": "Географический поиск участников (бета)"

--- a/frontend/src/locales/tr.json
+++ b/frontend/src/locales/tr.json
@@ -370,7 +370,7 @@
     "gdt": "GDT işlemlerin",
     "information": "{community}",
     "overview": "Hoş geldin {name}",
-    "send": "Gradido gönder",
+    "send": "Gradido ve e-posta gönder",
     "settings": "Ayarlar",
     "transactions": "İşlemlerin",
     "usersearch": "Coğrafi üye arama (beta)"


### PR DESCRIPTION
## What
Corrects `pageTitle.send` from "Sende Gradidos" to "Gradido und E-Mail senden", and the equivalent in all 10 locales.

## Why
- "Gradido" is a currency name, so singular — like "Euro senden" (no plural "s"). The infinitive also matches the "Senden" menu item.
- The `/send` page has three tabs: **GDD senden** and **GDD Link erzeugen** (both send Gradido — directly or via a link) and **E-Mail senden** (recipient + subject + message, **no amount** = a plain email). The page therefore does two distinct things — send Gradido and send an email — and the title should name both. The link stays out of the title (it is just another way to send Gradido).

## Scope
Only `pageTitle.send`, one line per locale (10 files). `scripts/locales.py audit` is green (407 keys each, consistent, canonical).

## Note for review
de and en are solid. The other eight values (es, fr, it, nl, pt, tr, el, ru) are AI translations and would benefit from a native-speaker check. This also fixes an untranslated English value in nl and a participle slip in fr ("Envoye" -> "Envoyer").