### PR TITLE
fix(backend): accept all 10 wallet languages when saving user locale

### DIFF
--- a/backend/src/graphql/resolver/UserResolver.test.ts
+++ b/backend/src/graphql/resolver/UserResolver.test.ts
@@ -320,7 +320,7 @@ describe('UserResolver', () => {
       it('sets "de" as default language', async () => {
         await mutate({
           mutation: createUser,
-          variables: { ...variables, email: 'bibi@bloxberg.de', language: 'it' },
+          variables: { ...variables, email: 'bibi@bloxberg.de', language: 'xx' },
         })
         await expect(
           UserContact.findOne({ where: { email: 'bibi@bloxberg.de' }, relations: ['user'] }),

--- a/backend/src/graphql/resolver/UserResolver.ts
+++ b/backend/src/graphql/resolver/UserResolver.ts
@@ -102,7 +102,7 @@ import { deleteUserRole, setUserRole } from './util/modifyUserRole'
 import { sendUserToGms } from './util/sendUserToGms'
 import { syncHumhub } from './util/syncHumhub'
 
-const LANGUAGES = ['de', 'en', 'es', 'fr', 'nl']
+const LANGUAGES = ['de', 'en', 'es', 'fr', 'nl', 'it', 'tr', 'ru', 'pt', 'el']
 const DEFAULT_LANGUAGE = 'de'
 const db = AppDatabase.getInstance()
 const createLogger = () => getLogger(`${LOG4JS_BASE_CATEGORY_NAME}.graphql.resolver.UserResolver`)


### PR DESCRIPTION
## The bug
`UserResolver.ts` had `const LANGUAGES = ['de', 'en', 'es', 'fr', 'nl']`. The five languages added to the frontend in June (it, tr, ru, pt, el) were never added here. Switching the UI to one of them changed the interface but the save failed: the backend rejected the locale with *"Given language is not a valid language or not supported"*, so the user saw an error toast and the choice was lost on reload. The original five worked.

## The fix
```ts
-const LANGUAGES = ['de', 'en', 'es', 'fr', 'nl']
+const LANGUAGES = ['de', 'en', 'es', 'fr', 'nl', 'it', 'tr', 'ru', 'pt', 'el']
```
These are the codes the frontend already sends (`frontend/src/locales/index.js`) and that the i18n / vee-validate registrations already cover for all 10 languages.

## Scope
One line in `backend/src/graphql/resolver/UserResolver.ts`. No test change: the "language is not valid" test uses `'not-valid'`, which stays invalid.