### PR TITLE
fix(frontend): boot-render fixes and brand colours for toasts and buttons

### DIFF
--- a/frontend/src/assets/scss/gradido-template.scss
+++ b/frontend/src/assets/scss/gradido-template.scss
@@ -142,40 +142,35 @@ html > body {
   border-color: #f5c6cb;
 }
 
-.b-toast-danger .toast .toast-header {
-  color: #721c24;
-  background-color: rgb(248 215 218 / 85%);
-  border-bottom-color: rgb(245 198 203 / 85%);
-}
-
+// Toasts use the Gradido colours as solid fills in both light and dark mode,
+// replacing the pale Bootstrap pastels: green success, red warning/error, gold
+// info. Success and error carry white text; the gold info toast keeps dark text
+// for readability (matching the gdd-toaster-body / -darken body classes).
+.b-toast-danger .toast .toast-header,
 .b-toast-danger .toast .toast-body {
-  background-color: rgb(252 237 238 / 85%);
-  border-color: rgb(245 198 203 / 85%);
-  color: #721c24;
+  color: #fff;
+  background-color: #c62828;
+  border-color: #a81f1f;
 }
 
-.b-toast-success .toast .toast-header {
-  color: #155724;
-  background-color: rgb(212 237 218 / 58%);
-  border-bottom-color: rgb(195 230 203 / 85%);
-}
-
+.b-toast-success .toast .toast-header,
 .b-toast-success .toast .toast-body {
-  color: #155724;
-  background-color: rgb(212 237 218 / 85%);
-  border-bottom-color: rgb(195 230 203 / 85%);
+  color: #fff;
+  background-color: #047006;
+  border-color: #035c05;
 }
 
-.b-toast-warning .toast .toast-header {
-  color: #fcfcfb;
-  background-color: #c58d38 !important;
-  border-bottom-color: rgb(207 130 14 / 85%);
-}
-
+.b-toast-warning .toast .toast-header,
 .b-toast-warning .toast .toast-body {
-  color: #010602;
-  background-color: rgb(247 248 247 / 85%);
-  border-bottom-color: rgb(207 130 14 / 85%);
+  color: #2c2c2c;
+  background-color: #c58d38;
+  border-color: #a97a2f;
+}
+
+// Close (x) is dark by default; invert it to white on the green/red toasts.
+.b-toast-success .toast .btn-close,
+.b-toast-danger .toast .btn-close {
+  filter: invert(1) grayscale(1) brightness(1.6);
 }
 
 // .btn-primary pim {

--- a/frontend/src/components/GddSend/TransactionResultLink.vue
+++ b/frontend/src/components/GddSend/TransactionResultLink.vue
@@ -11,7 +11,7 @@
     <div class="text-center">
       <div><figure-qr-code :link="link" /></div>
       <div>
-        <BButton variant="secondary" class="mt-4" data-test="close-btn" @click="$emit('on-back')">
+        <BButton variant="gradido" class="mt-4" data-test="close-btn" @click="$emit('on-back')">
           {{ $t('form.close') }}
         </BButton>
       </div>

--- a/frontend/src/components/SuccessMessage.vue
+++ b/frontend/src/components/SuccessMessage.vue
@@ -6,7 +6,7 @@
       {{ message }}
     </div>
     <div class="text-center mt-5">
-      <BButton variant="primary" @click="$emit('on-back')">
+      <BButton variant="gradido" @click="$emit('on-back')">
         {{ $t('form.close') }}
       </BButton>
     </div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -53,6 +53,16 @@ loadAllRules(i18n.global, apolloProvider.defaultClient)
 
 addNavigationGuards(router, store, apolloProvider.defaultClient)
 
+// Restore the persisted UI language before mount. vuex-persistedstate rehydrates
+// state.language without firing the `language` mutation (which is what sets the
+// i18n locale). Previously this was masked by the login layout briefly rendering
+// its language switcher on boot; now that we mount straight into the target route
+// (see router.isReady below), sync the locale here so the app is not stuck on the
+// default language until Settings is opened.
+if (store.state.language) {
+  i18n.global.locale.value = store.state.language
+}
+
 if (!store) {
   setTimeout(
     window.location.assign('https://github.com/gradido/gradido/tree/master/support#cookies'),
@@ -60,13 +70,20 @@ if (!store) {
   )
 }
 
-app.mount('#app', {
-  stub: {
-    ValidationObserver: {
-      template: '<div>Validation Observer MOCK</div>',
+// Wait for the router's initial navigation to resolve before mounting. Otherwise
+// the first render happens on the start location (which has no route meta), so
+// App.vue picks the AuthLayout and the login page flashes for a moment on every
+// reload of an authenticated route before the router lands on it and swaps in the
+// DashboardLayout (also seen when returning from the admin interface).
+router.isReady().then(() => {
+  app.mount('#app', {
+    stub: {
+      ValidationObserver: {
+        template: '<div>Validation Observer MOCK</div>',
+      },
+      ValidationProvider: {
+        template: '<div>Validation Observer MOCK</div>',
+      },
     },
-    ValidationProvider: {
-      template: '<div>Validation Observer MOCK</div>',
-    },
-  },
+  })
 })


### PR DESCRIPTION
Both-mode changes pulled out of the dark-mode work so they can be reviewed and land on their own, ahead of the (purely additive) dark-mode PR that follows. Every change here affects light mode too.

## 1. Boot rendering (bug fixes)

- **Login-page flash:** the app mounted before the router's initial navigation had resolved, so the first render ran on the empty start location and `App.vue` picked the `AuthLayout` — flashing the login page (image slider, community name, coin) for a moment on every reload of an authenticated route, and when returning from the admin interface. Fixed by awaiting `router.isReady()` before mounting.
- **Boot language:** `vuex-persistedstate` rehydrates `state.language` without firing the `language` mutation that syncs the i18n locale — so without the incidental login-layout language switcher (removed by the fix above), the app showed the default language on reload until Settings was opened. The locale is now restored explicitly on boot, mirroring how the theme is applied.

## 2. Brand colours (both modes)

- Toasts use solid Gradido colours instead of the pale Bootstrap pastels: green success, red error, gold info (white text on green/red, dark text on gold, inverted close x).
- The success and link/QR-result confirmation close buttons use the gold `gradido` button variant, matching the other confirmation actions.

Verified against the ki-playground staging build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
