### PR TITLE
fix(frontend): keep the dark-mode theme across a wallet <-> admin round-trip

### DIFF
--- a/admin/src/store/storage.js
+++ b/admin/src/store/storage.js
@@ -1,0 +1,39 @@
+// Device-local preferences that must outlive a logout.
+//
+// The wallet and the admin interface are served from the same origin and
+// therefore share a single localStorage. A logout in either one must not wipe
+// the other's device-local preferences (e.g. the dark-mode theme). The blunt
+// localStorage.clear() used to do exactly that, and every new preference would
+// have to be hand-listed in BOTH logout paths or it gets lost.
+//
+// New device-local preferences should use PREFERENCE_KEY_PREFIX so they are
+// preserved automatically, without touching this file again. The explicit list
+// below stays frozen at the pre-existing key, which is intentionally NOT renamed
+// onto the prefix so current users keep their already-stored theme.
+//
+// NOTE: keep this file identical in frontend/src/store and admin/src/store.
+export const PREFERENCE_KEY_PREFIX = 'pref.'
+export const PRESERVED_LEGACY_KEYS = ['gradido-theme-mode']
+
+// Drop-in replacement for localStorage.clear() on logout: removes every key
+// EXCEPT device-local preferences. Deleting is the default, so a forgotten
+// sensitive key is cleared rather than accidentally kept.
+export function clearStoragePreservingPreferences() {
+  const preserved = {}
+  for (const key of PRESERVED_LEGACY_KEYS) {
+    const value = localStorage.getItem(key)
+    if (value !== null) {
+      preserved[key] = value
+    }
+  }
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key !== null && key.startsWith(PREFERENCE_KEY_PREFIX)) {
+      preserved[key] = localStorage.getItem(key)
+    }
+  }
+  localStorage.clear()
+  for (const key of Object.keys(preserved)) {
+    localStorage.setItem(key, preserved[key])
+  }
+}

--- a/admin/src/store/storage.test.js
+++ b/admin/src/store/storage.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { clearStoragePreservingPreferences, PREFERENCE_KEY_PREFIX } from './storage'
+
+// Minimal in-memory localStorage with the length/key iteration the helper uses.
+function createLocalStorageMock(initial = {}) {
+  let store = { ...initial }
+  return {
+    get length() {
+      return Object.keys(store).length
+    },
+    key(i) {
+      return Object.keys(store)[i] ?? null
+    },
+    getItem(k) {
+      return k in store ? store[k] : null
+    },
+    setItem(k, v) {
+      store[k] = String(v)
+    },
+    removeItem(k) {
+      delete store[k]
+    },
+    clear() {
+      store = {}
+    },
+  }
+}
+
+describe('clearStoragePreservingPreferences', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'localStorage',
+      createLocalStorageMock({
+        'gradido-theme-mode': 'dark',
+        [`${PREFERENCE_KEY_PREFIX}someFutureSetting`]: 'on',
+        'gradido-admin': '{"token":"secret"}',
+        someAuthKey: 'x',
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps the dark-mode theme key', () => {
+    clearStoragePreservingPreferences()
+    expect(localStorage.getItem('gradido-theme-mode')).toBe('dark')
+  })
+
+  it('keeps any key using the preference prefix', () => {
+    clearStoragePreservingPreferences()
+    expect(localStorage.getItem(`${PREFERENCE_KEY_PREFIX}someFutureSetting`)).toBe('on')
+  })
+
+  it('wipes session and auth keys', () => {
+    clearStoragePreservingPreferences()
+    expect(localStorage.getItem('gradido-admin')).toBeNull()
+    expect(localStorage.getItem('someAuthKey')).toBeNull()
+  })
+
+  it('does not resurrect a preference that was not stored', () => {
+    localStorage.removeItem('gradido-theme-mode')
+    clearStoragePreservingPreferences()
+    expect(localStorage.getItem('gradido-theme-mode')).toBeNull()
+  })
+})

--- a/admin/src/store/store.js
+++ b/admin/src/store/store.js
@@ -1,6 +1,7 @@
 import { createStore } from 'vuex'
 import createPersistedState from 'vuex-persistedstate'
 import CONFIG from '../config'
+import { clearStoragePreservingPreferences } from './storage'
 
 export const mutations = {
   openCreationsPlus: (state, i) => {
@@ -24,10 +25,14 @@ export const mutations = {
 }
 
 export const actions = {
-  logout: ({ commit, state }) => {
+  logout: ({ commit }) => {
     commit('token', null)
     commit('moderator', null)
-    window.localStorage.clear()
+    // Wallet and admin are served from the same origin and share one
+    // localStorage. Preserve device-local preferences (dark-mode theme, any
+    // pref.* key) instead of wiping everything -- otherwise a logout here also
+    // resets the wallet's theme. See store/storage.js.
+    clearStoragePreservingPreferences()
   },
 }
 

--- a/admin/src/store/store.test.js
+++ b/admin/src/store/store.test.js
@@ -19,9 +19,11 @@ describe('Vuex Store', () => {
 
     localStorageMock = {
       clear: vi.fn(),
-      getItem: vi.fn(),
+      getItem: vi.fn(() => null),
       setItem: vi.fn(),
       removeItem: vi.fn(),
+      length: 0,
+      key: vi.fn(() => null),
     }
     Object.defineProperty(window, 'localStorage', {
       value: localStorageMock,
@@ -86,6 +88,17 @@ describe('Vuex Store', () => {
       expect(testStore.state.token).toBeNull()
       expect(testStore.state.moderator).toBeNull()
       expect(localStorageMock.clear).toHaveBeenCalled()
+    })
+
+    it('preserves the wallet dark-mode theme across logout', () => {
+      // The wallet owns 'gradido-theme-mode' but shares this origin's storage;
+      // the admin logout must not wipe it (regression: dark mode lost on
+      // wallet -> admin -> wallet).
+      localStorageMock.getItem = vi.fn((key) => (key === 'gradido-theme-mode' ? 'dark' : null))
+
+      testStore.dispatch('logout')
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith('gradido-theme-mode', 'dark')
     })
   })
 

--- a/frontend/src/store/storage.js
+++ b/frontend/src/store/storage.js
@@ -1,0 +1,39 @@
+// Device-local preferences that must outlive a logout.
+//
+// The wallet and the admin interface are served from the same origin and
+// therefore share a single localStorage. A logout in either one must not wipe
+// the other's device-local preferences (e.g. the dark-mode theme). The blunt
+// localStorage.clear() used to do exactly that, and every new preference would
+// have to be hand-listed in BOTH logout paths or it gets lost.
+//
+// New device-local preferences should use PREFERENCE_KEY_PREFIX so they are
+// preserved automatically, without touching this file again. The explicit list
+// below stays frozen at the pre-existing key, which is intentionally NOT renamed
+// onto the prefix so current users keep their already-stored theme.
+//
+// NOTE: keep this file identical in frontend/src/store and admin/src/store.
+export const PREFERENCE_KEY_PREFIX = 'pref.'
+export const PRESERVED_LEGACY_KEYS = ['gradido-theme-mode']
+
+// Drop-in replacement for localStorage.clear() on logout: removes every key
+// EXCEPT device-local preferences. Deleting is the default, so a forgotten
+// sensitive key is cleared rather than accidentally kept.
+export function clearStoragePreservingPreferences() {
+  const preserved = {}
+  for (const key of PRESERVED_LEGACY_KEYS) {
+    const value = localStorage.getItem(key)
+    if (value !== null) {
+      preserved[key] = value
+    }
+  }
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key !== null && key.startsWith(PREFERENCE_KEY_PREFIX)) {
+      preserved[key] = localStorage.getItem(key)
+    }
+  }
+  localStorage.clear()
+  for (const key of Object.keys(preserved)) {
+    localStorage.setItem(key, preserved[key])
+  }
+}

--- a/frontend/src/store/storage.test.js
+++ b/frontend/src/store/storage.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { clearStoragePreservingPreferences, PREFERENCE_KEY_PREFIX } from './storage'
+
+// Minimal in-memory localStorage with the length/key iteration the helper uses.
+function createLocalStorageMock(initial = {}) {
+  let store = { ...initial }
+  return {
+    get length() {
+      return Object.keys(store).length
+    },
+    key(i) {
+      return Object.keys(store)[i] ?? null
+    },
+    getItem(k) {
+      return k in store ? store[k] : null
+    },
+    setItem(k, v) {
+      store[k] = String(v)
+    },
+    removeItem(k) {
+      delete store[k]
+    },
+    clear() {
+      store = {}
+    },
+  }
+}
+
+describe('clearStoragePreservingPreferences', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'localStorage',
+      createLocalStorageMock({
+        'gradido-theme-mode': 'dark',
+        [`${PREFERENCE_KEY_PREFIX}someFutureSetting`]: 'on',
+        'gradido-frontend': '{"token":"secret"}',
+        someAuthKey: 'x',
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps the dark-mode theme key', () => {
+    clearStoragePreservingPreferences()
+    expect(localStorage.getItem('gradido-theme-mode')).toBe('dark')
+  })
+
+  it('keeps any key using the preference prefix', () => {
+    clearStoragePreservingPreferences()
+    expect(localStorage.getItem(`${PREFERENCE_KEY_PREFIX}someFutureSetting`)).toBe('on')
+  })
+
+  it('wipes session and auth keys', () => {
+    clearStoragePreservingPreferences()
+    expect(localStorage.getItem('gradido-frontend')).toBeNull()
+    expect(localStorage.getItem('someAuthKey')).toBeNull()
+  })
+
+  it('does not resurrect a preference that was not stored', () => {
+    localStorage.removeItem('gradido-theme-mode')
+    clearStoragePreservingPreferences()
+    expect(localStorage.getItem('gradido-theme-mode')).toBeNull()
+  })
+})

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -4,11 +4,28 @@ import createPersistedState from 'vuex-persistedstate'
 
 import jwtDecode from 'jwt-decode'
 import i18n from '../i18n'
+import { clearStoragePreservingPreferences } from './storage'
 
 // Dedicated localStorage key mirroring state.themeMode. The pre-paint script in
 // index.html reads it with a single getItem, so it never has to parse the whole
 // persisted-state blob on the blocking boot path. Kept in sync by applyTheme.
 export const THEME_MODE_STORAGE_KEY = 'gradido-theme-mode'
+
+// Seed themeMode from its dedicated key, which survives a logout (see
+// store/storage.js). It is the source of truth when the persisted-state blob was
+// wiped -- e.g. the admin logout clears the shared localStorage on a wallet <->
+// admin round-trip, leaving only this key. Without it the store boots at 'system'
+// and applyTheme overrides the pre-paint's correct theme (a dark->light flicker).
+// When the blob is present, vuex-persistedstate still restores themeMode from it
+// (both are kept in sync by applyTheme).
+export const readInitialThemeMode = () => {
+  try {
+    const stored = localStorage.getItem(THEME_MODE_STORAGE_KEY)
+    return ['system', 'light', 'dark'].includes(stored) ? stored : 'system'
+  } catch {
+    return 'system'
+  }
+}
 
 export const mutations = {
   language: (state, language) => {
@@ -142,10 +159,14 @@ export const actions = {
     commit('email', '')
     commit('userLocation', null)
     commit('redirectPath', '/overview')
+    // Wallet and admin are served from the same origin and share one
+    // localStorage. Preserve device-local preferences (dark-mode theme, any
+    // pref.* key) instead of the blunt clear(). See store/storage.js.
     const themeMode = state.themeMode
-    localStorage.clear()
-    // localStorage.clear() wiped the persisted theme; keep the device-local
-    // choice so the login page and the next session stay in the chosen theme.
+    clearStoragePreservingPreferences()
+    // The wallet reads its theme from the persisted-state blob on boot, which the
+    // wipe cleared; re-commit it so the blob is rewritten and the login page and
+    // the next session stay in the chosen theme.
     commit('setThemeMode', themeMode)
     dispatch('applyTheme')
   },
@@ -208,7 +229,7 @@ try {
       hideAmountGDT: null,
       email: '',
       darkMode: false,
-      themeMode: 'system',
+      themeMode: readInitialThemeMode(),
       userLocation: null,
       redirectPath: '/overview',
       transactionToHighlightId: '',

--- a/frontend/src/store/store.test.js
+++ b/frontend/src/store/store.test.js
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
-import { mutations, actions, THEME_MODE_STORAGE_KEY } from './store'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { mutations, actions, THEME_MODE_STORAGE_KEY, readInitialThemeMode } from './store'
 import i18n from '../i18n'
 import jwtDecode from 'jwt-decode'
 
@@ -42,6 +42,29 @@ const {
 } = mutations
 
 const { login, logout, applyTheme } = actions
+
+describe('readInitialThemeMode', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('seeds the theme from the dedicated key so it survives a wiped state blob', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: (key) => (key === THEME_MODE_STORAGE_KEY ? 'dark' : null),
+    })
+    expect(readInitialThemeMode()).toBe('dark')
+  })
+
+  it('falls back to system for an unrecognised value', () => {
+    vi.stubGlobal('localStorage', { getItem: () => 'nonsense' })
+    expect(readInitialThemeMode()).toBe('system')
+  })
+
+  it('falls back to system when the key is absent', () => {
+    vi.stubGlobal('localStorage', { getItem: () => null })
+    expect(readInitialThemeMode()).toBe('system')
+  })
+})
 
 describe('Vuex store', () => {
   describe('mutations', () => {
@@ -214,6 +237,10 @@ describe('Vuex store', () => {
         const clearStorageMock = vi.fn()
         vi.stubGlobal('localStorage', {
           clear: clearStorageMock,
+          getItem: vi.fn(() => null),
+          setItem: vi.fn(),
+          length: 0,
+          key: vi.fn(() => null),
         })
         logout({ commit, state, dispatch })
         expect(clearStorageMock).toHaveBeenCalled()


### PR DESCRIPTION
## Problem

The wallet and the admin interface are served from the same origin and share one `localStorage`. The admin logout calls `localStorage.clear()`, which wipes the wallet's persisted theme. Switching **wallet → admin → wallet** therefore resets dark mode to the OS default.

## Fix (two parts, both needed)

1. **Preserve device-local preferences on logout.** Both logout paths (`frontend/src/store/store.js`, `admin/src/store/store.js`) now use a shared helper `clearStoragePreservingPreferences()` (`store/storage.js`, identical in both packages) instead of the blunt `localStorage.clear()`. It clears everything **except** device-local preferences: any key using the reserved `pref.` prefix, plus the pre-existing `gradido-theme-mode` key. Tokens and both persisted-state blobs are still cleared, so logout stays fully sanitizing. New preferences can use the `pref.` prefix and are then covered automatically, so the two logout paths no longer drift apart.

2. **Seed `themeMode` from the dedicated key.** The wallet store read the theme only from the persisted-state blob, which the admin logout wipes — so it booted at `system` and `applyTheme` overrode the pre-paint script's correct theme (a brief dark→light flicker). The store now seeds its initial `themeMode` from the same `gradido-theme-mode` key the pre-paint script reads. When the blob is present it still wins via `vuex-persistedstate`; both stay in sync via `applyTheme`.

## Tests

Unit tests for the helper (preserve prefix + legacy key, wipe auth), the theme-preserving admin logout, and the `themeMode` seed. `frontend` and `admin` vitest + eslint + prettier + build all green locally.

## Verification

Verified live on the ki-playground staging: dark mode now persists across wallet → admin → wallet, with no flicker back to light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
