### PR TITLE
fix(frontend): complete verifyLogin so token-handoff keeps the GMS/HumHub connection

### DIFF
--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -11,6 +11,12 @@ export const verifyLogin = gql`
       klickTipp {
         newsletterState
       }
+      gmsAllowed
+      humhubAllowed
+      gmsPublishName
+      humhubPublishName
+      gmsPublishLocation
+      userLocation
       hasElopage
       publisherId
       roles

--- a/frontend/src/graphql/queries.test.js
+++ b/frontend/src/graphql/queries.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { print } from 'graphql'
+import { verifyLogin } from './queries'
+
+// Regression guard: the token-handoff re-auth in routes/guards.js feeds the
+// verifyLogin result into the shared `login` store action. If any of these
+// fields is missing from the query, the action overwrites the value with
+// undefined, so the GMS/HumHub connection drops on every wallet <-> admin
+// round-trip. verifyLogin must stay in sync with the login mutation for the
+// fields the login action consumes.
+describe('verifyLogin query', () => {
+  const body = print(verifyLogin)
+
+  it.each([
+    'gmsAllowed',
+    'humhubAllowed',
+    'gmsPublishName',
+    'humhubPublishName',
+    'gmsPublishLocation',
+    'userLocation',
+  ])('requests the "%s" field consumed by the login action', (field) => {
+    expect(body).toContain(field)
+  })
+})


### PR DESCRIPTION
## Problem

The wallet re-authenticates on the token handoff from the admin (`/authenticate?token=`, `frontend/src/routes/guards.js`) by running the `verifyLogin` query and feeding the result into the shared `login` store action. But `verifyLogin` was missing six fields that the `login` action commits:

- `gmsAllowed`, `humhubAllowed`
- `gmsPublishName`, `humhubPublishName`
- `gmsPublishLocation`
- `userLocation`

The action commits these unconditionally, so on the handoff they were overwritten with `undefined` — dropping the GMS and HumHub connection on every **wallet → admin → wallet** round-trip. A fresh login was unaffected because it uses the complete `login` mutation, which already returns all six.

## Fix

Add the six fields to `verifyLogin`. They are all scalars/enums the backend `User` type already exposes (the same type the `login` mutation returns), so this is a frontend-only change — no backend, no migration.

A regression test pins the six fields to the query, guarding against a field silently dropping out again.

## Verification

Verified live on the ki-playground staging: the GMS connection now persists across wallet → admin → wallet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
