### PR TITLE
fix(frontend): remove only the app's own storage blob on logout

### DIFF
--- a/admin/src/store/store.js
+++ b/admin/src/store/store.js
@@ -27,7 +27,10 @@ export const actions = {
   logout: ({ commit, state }) => {
     commit('token', null)
     commit('moderator', null)
-    window.localStorage.clear()
+    // Remove only the admin's own persisted state (its token lives in this blob).
+    // The wallet and admin share one origin, so localStorage.clear() would also wipe
+    // the wallet's session and the shared dark-mode theme key.
+    window.localStorage.removeItem('gradido-admin')
   },
 }
 

--- a/admin/src/store/store.test.js
+++ b/admin/src/store/store.test.js
@@ -85,7 +85,8 @@ describe('Vuex Store', () => {
 
       expect(testStore.state.token).toBeNull()
       expect(testStore.state.moderator).toBeNull()
-      expect(localStorageMock.clear).toHaveBeenCalled()
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith('gradido-admin')
+      expect(localStorageMock.clear).not.toHaveBeenCalled()
     })
   })
 

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -143,9 +143,11 @@ export const actions = {
     commit('userLocation', null)
     commit('redirectPath', '/overview')
     const themeMode = state.themeMode
-    localStorage.clear()
-    // localStorage.clear() wiped the persisted theme; keep the device-local
-    // choice so the login page and the next session stay in the chosen theme.
+    // Remove only this app's own persisted state (session + token live in this blob).
+    // The wallet and admin share one origin, so localStorage.clear() would also wipe
+    // the other app's session and the shared dark-mode theme key. Re-commit the theme
+    // so the recreated blob keeps the device-local choice for the next session.
+    localStorage.removeItem('gradido-frontend')
     commit('setThemeMode', themeMode)
     dispatch('applyTheme')
   },

--- a/frontend/src/store/store.test.js
+++ b/frontend/src/store/store.test.js
@@ -210,13 +210,16 @@ describe('Vuex store', () => {
         expect(commit).toHaveBeenCalledWith('redirectPath', '/overview')
       })
 
-      it('calls localStorage.clear()', () => {
-        const clearStorageMock = vi.fn()
+      it('removes only its own storage blob', () => {
+        const removeItemMock = vi.fn()
+        const clearMock = vi.fn()
         vi.stubGlobal('localStorage', {
-          clear: clearStorageMock,
+          removeItem: removeItemMock,
+          clear: clearMock,
         })
         logout({ commit, state, dispatch })
-        expect(clearStorageMock).toHaveBeenCalled()
+        expect(removeItemMock).toHaveBeenCalledWith('gradido-frontend')
+        expect(clearMock).not.toHaveBeenCalled()
         vi.unstubAllGlobals()
       })
     })


### PR DESCRIPTION
## The bug

The admin logout called `localStorage.clear()`. Because the wallet and the admin interface are served from the same origin and share one `localStorage`, that also wiped the wallet's session **and** the shared dark-mode theme key `gradido-theme-mode`. After a wallet → admin → wallet round-trip the theme fell back to light.

## The fix (per Dario's suggestion, superseding the closed #3677)

Each logout now removes only its **own** persisted-state blob instead of clearing everything:

- frontend logout: `localStorage.removeItem('gradido-frontend')`
- admin logout: `localStorage.removeItem('gradido-admin')`

The auth token lives **inside** that blob (the Apollo links read it from `store.state.token`), and the two persisted blobs plus `gradido-theme-mode` are the only `localStorage` keys these apps set — no `sessionStorage`, no separate token key. So `removeItem` clears the full session (incl. token) while leaving the theme — and the other app's session — untouched. Logout stays fully secure, and each app now clears only its own session instead of also the other's.

Tests updated accordingly (frontend + admin store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
