### PR TITLE
refactor(frontend): draw the separators as a line and re-enable no-missing-keys

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -59,7 +59,7 @@ module.exports = {
     'vue/v-on-event-hyphenation': 0, // TODO remove at the end of migration and fix
     'vue/require-default-prop': 0, // TODO remove at the end of migration and fix
     'vue/no-computed-properties-in-data': 0, // TODO remove at the end of migration and fix
-    '@intlify/vue-i18n/no-missing-keys': 0, // TODO remove at the end of migration and fix
+    '@intlify/vue-i18n/no-missing-keys': 'error',
     '@intlify/vue-i18n/no-unused-keys': [
       'error',
       {

--- a/frontend/src/assets/scss/gradido-template.scss
+++ b/frontend/src/assets/scss/gradido-template.scss
@@ -29,6 +29,15 @@ html > body {
   word-break: break-word;
 }
 
+// A separator between two neighbouring entries, drawn on the one that follows. It is a
+// line, not a character: nothing lands in the text, so a screen reader passes over it
+// instead of announcing a pipe between every menu entry. currentColor makes it take the
+// colour of whatever text surrounds it, so the same class fits the light footer and the
+// dark size popover without a value to keep in sync.
+.separator-start {
+  border-left: 1px solid color-mix(in srgb, currentcolor 40%, transparent);
+}
+
 .shadow-default {
   box-shadow: rgb(0 0 0 / 14%) 0 4px 10px;
 }

--- a/frontend/src/components/Auth/AuthNavbar.vue
+++ b/frontend/src/components/Auth/AuthNavbar.vue
@@ -11,8 +11,7 @@
           <NavItem :to="routeWithParamsAndQuery('Register')" class="auth-navbar ms-lg-5">
             {{ $t('signup') }}
           </NavItem>
-          <span class="d-none d-lg-block py-1">{{ $t('|') }}</span>
-          <NavItem :to="routeWithParamsAndQuery('Login')" class="auth-navbar">
+          <NavItem :to="routeWithParamsAndQuery('Login')" class="auth-navbar separator-start">
             {{ $t('signin') }}
           </NavItem>
         </BNavbarNav>

--- a/frontend/src/components/Auth/AuthNavbarSmall.vue
+++ b/frontend/src/components/Auth/AuthNavbarSmall.vue
@@ -5,8 +5,7 @@
         <NavItem :to="routeWithParamsAndQuery('Register')" class="auth-navbar">
           {{ $t('signup') }}
         </NavItem>
-        <span class="mt-1">{{ $t('|') }}</span>
-        <NavItem :to="routeWithParamsAndQuery('Login')" class="auth-navbar">
+        <NavItem :to="routeWithParamsAndQuery('Login')" class="auth-navbar separator-start">
           {{ $t('signin') }}
         </NavItem>
       </BNavbarNav>

--- a/frontend/src/components/ContentFooter.vue
+++ b/frontend/src/components/ContentFooter.vue
@@ -7,8 +7,11 @@
           <a :href="`https://gradido.net/${$i18n.locale}`" class="fw-bold ms-1" target="_blank">
             {{ $t('footer.copyright.link') }}
           </a>
-          {{ $t('|') }}
-          <a :href="'https://github.com/gradido/gradido/commit/' + hash" target="_blank">
+          <a
+            :href="'https://github.com/gradido/gradido/commit/' + hash"
+            target="_blank"
+            class="separator-start ms-2 ps-2"
+          >
             {{ $t('footer.app_version', { version }) }}
           </a>
         </div>

--- a/frontend/src/layouts/AuthLayout.vue
+++ b/frontend/src/layouts/AuthLayout.vue
@@ -61,10 +61,12 @@
                   >
                     <div class="text-light">
                       <span class="pointer" @click="setTextSize(0.85)">{{ $t('85') }}</span>
-                      {{ $t('|') }}
-                      <span class="pointer" @click="setTextSize(1)">{{ $t('100') }}</span>
-                      {{ $t('|') }}
-                      <span class="pointer" @click="setTextSize(1.25)">{{ $t('125') }}</span>
+                      <span class="pointer separator-start ms-2 ps-2" @click="setTextSize(1)">
+                        {{ $t('100') }}
+                      </span>
+                      <span class="pointer separator-start ms-2 ps-2" @click="setTextSize(1.25)">
+                        {{ $t('125') }}
+                      </span>
                     </div>
                   </BPopover>
                 </BCol>


### PR DESCRIPTION
Five places asked the translation function for a `"|"` to print a separator. There is no such entry in the language files, so vue-i18n fell back to printing the key — it produced the pipe **by accident**. It was written that way to get past `no-raw-text`, and it is the reason `no-missing-keys` had to be switched off for `.vue` files.

Two rules were standing in each other's way, and the one that lost is the one that catches a real class of bug: a `$t()` pointing at a key that does not exist renders the raw key name to the user.

## What changes

The separator is decoration, so it is drawn as one: a border on the entry that follows, via a `.separator-start` class.

- `currentColor` makes it take the colour of whatever text surrounds it, so **one** class fits the light footer and the dark font-size popover with no value to keep in sync. Bootstrap's own `border-start` was not enough — its `#e9ecef` is close to invisible on white.
- A line stays **out of the accessibility tree**. The old pipe was announced between every menu entry; a border is not. This is also why it is a border and not generated content — screen readers do read `::before` content.
- It **cannot dangle**: it belongs to the entry it precedes, so the hand-managed visibility classes on the separator span in the auth layout fall away.

With the five calls gone, `no-missing-keys` reports nothing and goes back to `'error'`.

## Checked

- The rule was verified in both directions: clean on the current tree, and **failing** against a deliberately broken key reference — so it is a net, not a formality.
- `frontend/src/assets/css/gradido.css` is generated and not versioned. Confirmed that `frontend#build` depends on `compile-scss` in `turbo.json`, and that `.separator-start` really lands in the built stylesheet — without that step the separators would have disappeared entirely, including on the login screen.
- Local: eslint clean (0 problems), stylelint clean, locales sorted, vitest 686 passed, build green.

This has been running on the Akademie staging instance since this morning.

@einhornimmond — as agreed.