### PR TITLE
fix(frontend): make form hints readable in dark mode

### DIFF
--- a/frontend/src/assets/scss/gradido-template-dark.scss
+++ b/frontend/src/assets/scss/gradido-template-dark.scss
@@ -43,8 +43,15 @@ body.dark-mode {
     color: var(--text);
   }
 
+  // .form-text and .text-body-secondary are what a BFormGroup description renders as
+  // (via BFormText, whose default textVariant is "body-secondary"). Bootstrap gives both
+  // --bs-secondary-color, a near-black at 75% opacity meant for white backgrounds — on the
+  // dark surface that lands at a contrast of 1.08:1, which is invisible. Neither class is
+  // ever written by hand in the wallet, so this one rule covers every form hint there is.
   .text-muted,
-  .text-secondary {
+  .text-secondary,
+  .form-text,
+  .text-body-secondary {
     color: var(--text-muted) !important;
   }
 


### PR DESCRIPTION
The hint under a form field is readable in light mode and invisible in dark mode.

## Cause

A `BFormGroup` description renders through `BFormText`, which carries `.form-text` **plus** `.text-body-secondary` — its default `textVariant` is `"body-secondary"`. Bootstrap gives both `--bs-secondary-color`, a near-black at 75% opacity meant for white backgrounds.

The dark overlay remaps `.text-muted` and `.text-secondary`, but neither of these. On the dark surface (`#2a2c30`) the hints land at a contrast of **1.08:1**.

## Fix

Both selectors join the existing muted rule. Neither class is ever written by hand in the wallet — `.text-body-secondary` comes only from `BFormText` — so one rule covers every form hint there is, and every future one.

Contrast afterwards: **5.03:1** (WCAG AA for body text is 4.5:1).

## Affected hints

- the group hint on the contribution form
- the e-mail note in the settings
- the e-mail note in the name field
- the username note

## Checked

Measured in a browser with `getComputedStyle`, not reasoned about from specificity: the rule resolves to `rgb(154, 155, 158)` on `rgb(42, 44, 48)`, so it does win against Bootstrap's `!important` on `.text-body-secondary`.

`frontend/src/assets/css/gradido.css` is generated and not versioned — confirmed that `frontend#build` depends on `compile-scss` and that the rule really lands in the built stylesheet.

Local: stylelint clean, build green. Running on the Akademie staging instance since this afternoon.