### PR TITLE
feat(other): let a person-to-person message be longer and keep its line breaks

### DIFF
--- a/backend/src/graphql/arg/SendEmailArgs.ts
+++ b/backend/src/graphql/arg/SendEmailArgs.ts
@@ -1,5 +1,5 @@
 import { IsString, MaxLength, MinLength } from 'class-validator'
-import { MEMO_MAX_CHARS, MEMO_MIN_CHARS } from 'shared'
+import { MESSAGE_MAX_CHARS, MESSAGE_MIN_CHARS } from 'shared'
 import { ArgsType, Field } from 'type-graphql'
 
 @ArgsType()
@@ -16,8 +16,10 @@ export class SendEmailArgs {
   @IsString()
   subject: string
 
+  // this memo carries no amount, so it uses the roomier message bounds and not
+  // the memo bounds that a transaction memo has to obey
   @Field(() => String)
-  @MaxLength(MEMO_MAX_CHARS)
-  @MinLength(MEMO_MIN_CHARS)
+  @MaxLength(MESSAGE_MAX_CHARS)
+  @MinLength(MESSAGE_MIN_CHARS)
   memo: string
 }

--- a/core/src/emails/templates/includes/webflow.css
+++ b/core/src/emails/templates/includes/webflow.css
@@ -52,6 +52,10 @@ h2 {
   background-image: linear-gradient(180deg, #f5f5f5, #f5f5f5);
   text-align: left;
   color: #696c72;
+  /* the message is written by a person: keep the line breaks they typed, which
+     html would otherwise collapse into spaces. Only this block, so that the
+     wording of every other mail stays laid out as before. */
+  white-space: pre-wrap;
 }
 
 

--- a/frontend/src/components/GddSend/TransactionForm.spec.js
+++ b/frontend/src/components/GddSend/TransactionForm.spec.js
@@ -303,4 +303,39 @@ describe('TransactionForm', () => {
       })
     })
   })
+
+  // The same textarea serves both send types, but the two are bound by different
+  // rules: a memo travels with a transaction into a varchar(512) column, a message
+  // does not. Sending the message down the memo rules would cut a normal first
+  // contact short, sending the memo down the message rules would let it grow past
+  // the column it has to fit.
+  describe('length rules per send type', () => {
+    const longerThanAMemo = 'x'.repeat(1000)
+    const shortReply = 'Ja'
+
+    beforeEach(async () => {
+      useRoute.mockReturnValue({ params: {}, query: {} })
+      wrapper = createWrapper({ balance: 100.0 })
+      await nextTick()
+    })
+
+    it('lets a message be far longer than a memo may be', async () => {
+      wrapper.vm.radioSelected = SEND_TYPES.email
+      await nextTick()
+      expect(wrapper.vm.validationSchema.fields.memo.isValidSync(longerThanAMemo)).toBe(true)
+    })
+
+    it('lets a message be as short as a two letter reply', async () => {
+      wrapper.vm.radioSelected = SEND_TYPES.email
+      await nextTick()
+      expect(wrapper.vm.validationSchema.fields.memo.isValidSync(shortReply)).toBe(true)
+    })
+
+    it('keeps a transaction memo inside the bounds of its column', async () => {
+      wrapper.vm.radioSelected = SEND_TYPES.send
+      await nextTick()
+      expect(wrapper.vm.validationSchema.fields.memo.isValidSync(longerThanAMemo)).toBe(false)
+      expect(wrapper.vm.validationSchema.fields.memo.isValidSync(shortReply)).toBe(false)
+    })
+  })
 })

--- a/frontend/src/components/GddSend/TransactionForm.vue
+++ b/frontend/src/components/GddSend/TransactionForm.vue
@@ -147,6 +147,7 @@
                   :placeholder="$t('form.message')"
                   :rules="validationSchema.fields.memo"
                   textarea="true"
+                  :max-rows="14"
                   :disabled="isFormDisabled"
                   :disable-smart-valid-state="disableSmartValidState"
                   @update:model-value="updateField"
@@ -208,6 +209,7 @@ import CommunitySwitch from '@/components/CommunitySwitch.vue'
 import ValidatedInput from '@/components/Inputs/ValidatedInput.vue'
 import {
   memo as memoSchema,
+  message as messageSchema,
   identifier as identifierSchema,
   subject as subjectSchema,
 } from '@/validationSchemas'
@@ -314,7 +316,8 @@ const validationSchema = computed(() => {
     })
   } else if (radioSelected.value === SEND_TYPES.email) {
     return object({
-      memo: memoSchema,
+      // no amount travels with this one, so it gets the roomier message bounds
+      memo: messageSchema,
       subject: subjectSchema,
       identifier: identifierSchema.test(
         'community-is-reachable',

--- a/frontend/src/components/Inputs/LabeledInput.vue
+++ b/frontend/src/components/Inputs/LabeledInput.vue
@@ -6,8 +6,8 @@
         v-bind="{ ...$attrs, id: labelFor, name }"
         v-model="model"
         trim
-        :rows="4"
-        :max-rows="4"
+        :rows="rows"
+        :max-rows="maxRows"
         no-resize
       />
       <BFormInput v-else v-bind="{ ...$attrs, id: labelFor, name }" v-model="model" />
@@ -35,6 +35,19 @@ const props = defineProps({
     type: String,
     required: false,
     default: 'false',
+  },
+  // Height of the textarea. When maxRows is larger than rows, the field grows with
+  // the text up to maxRows. Both default to the previous fixed height, so callers
+  // that do not ask for more keep the layout they had.
+  rows: {
+    type: [Number, String],
+    required: false,
+    default: 4,
+  },
+  maxRows: {
+    type: [Number, String],
+    required: false,
+    default: 4,
   },
 })
 

--- a/frontend/src/components/Inputs/ValidatedInput.spec.js
+++ b/frontend/src/components/Inputs/ValidatedInput.spec.js
@@ -89,4 +89,23 @@ describe('ValidatedInput', () => {
     expect(value).toBe('hello')
     expect(name).toBe('testInput')
   })
+
+  // ValidatedInput has no say in the height of a textarea, it only hands the
+  // attributes it was given down to LabeledInput. A caller that asks for a taller
+  // field has to arrive at the textarea, or the field silently stays as it was.
+  describe('textarea height', () => {
+    it('stays at the previous fixed height when the caller asks for nothing', () => {
+      wrapper = createWrapper({ textarea: 'true' })
+      const textarea = wrapper.findComponent(BFormTextarea)
+      expect(textarea.props('rows')).toBe(4)
+      expect(textarea.props('maxRows')).toBe(4)
+    })
+
+    it('passes a larger maximum through to the textarea so the field can grow', () => {
+      wrapper = createWrapper({ textarea: 'true', maxRows: 14 })
+      const textarea = wrapper.findComponent(BFormTextarea)
+      expect(textarea.props('rows')).toBe(4)
+      expect(textarea.props('maxRows')).toBe(14)
+    })
+  })
 })

--- a/frontend/src/validationSchemas.js
+++ b/frontend/src/validationSchemas.js
@@ -23,7 +23,7 @@ export const translateYupErrorString = (error, t) => {
 
 // A memo travels with a transaction: it is stored in a varchar(512) column and is
 // re-validated by the dlt-connector. Keep these bounds in step with MEMO_*_CHARS in
-// the shared package - the frontend cannot import from it.
+// the shared package - the frontend cannot yet import from it.
 export const memo = string()
   .required('form.validation.memo.required')
   .min(5, ({ min }) => ({ key: 'form.validation.memo.min', values: { min } }))

--- a/frontend/src/validationSchemas.js
+++ b/frontend/src/validationSchemas.js
@@ -21,10 +21,22 @@ export const translateYupErrorString = (error, t) => {
   }
 }
 
+// A memo travels with a transaction: it is stored in a varchar(512) column and is
+// re-validated by the dlt-connector. Keep these bounds in step with MEMO_*_CHARS in
+// the shared package - the frontend cannot import from it.
 export const memo = string()
   .required('form.validation.memo.required')
   .min(5, ({ min }) => ({ key: 'form.validation.memo.min', values: { min } }))
   .max(512, ({ max }) => ({ key: 'form.validation.memo.max', values: { max } }))
+
+// A person-to-person message carries no amount and is stored in no varchar column,
+// so it may be longer than a memo, and a short reply like "Yes" has to pass as well.
+// Keep in step with MESSAGE_*_CHARS in the shared package. Reuses the memo wording:
+// those texts already say "message" and interpolate the bound.
+export const message = string()
+  .required('form.validation.memo.required')
+  .min(1, ({ min }) => ({ key: 'form.validation.memo.min', values: { min } }))
+  .max(2000, ({ max }) => ({ key: 'form.validation.memo.max', values: { max } }))
 
 export const subject = string()
   .required('form.validation.subject.required')

--- a/frontend/src/validationSchemas.spec.js
+++ b/frontend/src/validationSchemas.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { memo, message } from '@/validationSchemas'
 
-// The frontend cannot import from the shared package, so these bounds are written
+// The frontend cannot import yet from the shared package, so these bounds are written
 // out twice: here and in shared/src/const/index.ts. That makes them easy to widen
 // on one side only, which is exactly what these tests are here to catch.
 //

--- a/frontend/src/validationSchemas.spec.js
+++ b/frontend/src/validationSchemas.spec.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { memo, message } from '@/validationSchemas'
+
+// The frontend cannot import from the shared package, so these bounds are written
+// out twice: here and in shared/src/const/index.ts. That makes them easy to widen
+// on one side only, which is exactly what these tests are here to catch.
+//
+// A memo travels with a transaction. It is stored in a varchar(512) column and the
+// dlt-connector validates it a second time against its own copy of the bounds, so
+// widening it here would be accepted by the form and then fail further down.
+// A message carries no amount and is stored in no varchar column, so it may be
+// longer - and a short reply has to pass, which a memo minimum of 5 would reject.
+const stringOfLength = (length) => 'x'.repeat(length)
+
+describe('validationSchemas', () => {
+  describe('memo (travels with a transaction)', () => {
+    it('accepts the longest memo the column can hold', () => {
+      expect(memo.isValidSync(stringOfLength(512))).toBe(true)
+    })
+
+    it('rejects one character more than the column can hold', () => {
+      expect(memo.isValidSync(stringOfLength(513))).toBe(false)
+    })
+
+    it('rejects a memo shorter than the dlt-connector accepts', () => {
+      expect(memo.isValidSync(stringOfLength(4))).toBe(false)
+    })
+
+    it('accepts the shortest memo the dlt-connector accepts', () => {
+      expect(memo.isValidSync(stringOfLength(5))).toBe(true)
+    })
+  })
+
+  describe('message (person to person, no amount)', () => {
+    it('accepts a message far longer than a memo may be', () => {
+      expect(message.isValidSync(stringOfLength(2000))).toBe(true)
+    })
+
+    it('rejects a message beyond the agreed limit', () => {
+      expect(message.isValidSync(stringOfLength(2001))).toBe(false)
+    })
+
+    it('accepts a short reply such as "Ja"', () => {
+      expect(message.isValidSync('Ja')).toBe(true)
+    })
+
+    it('accepts a single character', () => {
+      expect(message.isValidSync(stringOfLength(1))).toBe(true)
+    })
+
+    it('still requires something to be written', () => {
+      expect(message.isValidSync('')).toBe(false)
+    })
+  })
+
+  it('keeps the two apart - a message must not be validated as a memo', () => {
+    const longerThanAMemo = stringOfLength(1000)
+    expect(memo.isValidSync(longerThanAMemo)).toBe(false)
+    expect(message.isValidSync(longerThanAMemo)).toBe(true)
+  })
+})

--- a/shared/src/const/index.ts
+++ b/shared/src/const/index.ts
@@ -29,8 +29,14 @@ export const MAX_CREATION_AMOUNT = 10000000n
 // input validation
 export const CONTRIBUTIONLINK_NAME_MAX_CHARS = 100
 export const CONTRIBUTIONLINK_NAME_MIN_CHARS = 5
+// memo travels with a transaction: it is stored in a varchar(512) column and is
+// re-validated by the dlt-connector, so these bounds must not be widened here.
 export const MEMO_MAX_CHARS = 512
 export const MEMO_MIN_CHARS = 5
+// a person-to-person message carries no amount and is stored in no varchar column,
+// so it can be roomier than a memo. A short reply like "Yes" has to pass as well.
+export const MESSAGE_MAX_CHARS = 2000
+export const MESSAGE_MIN_CHARS = 1
 
 // authentication
 // 10 minutes


### PR DESCRIPTION
"Send email" in the send form carries a subject and a text from one member to
another. It stores nothing and never reaches the dlt-connector, yet it inherited
the bounds of a transaction memo: at most 512 characters, at least 5, and no
visible line breaks.

## Why those bounds are wrong for a message

**512 is too short.** A first message after a match - greeting, a sentence about
what you read in the other profile, a sentence about yourself, a question, a
closing - runs to roughly 500 characters without being long-winded. The limit is
reached by an ordinary greeting.

**5 is too long.** A reply of "Ja" is two characters and was turned away.

**Line breaks were lost.** The message block renders what a member typed, and
html collapses their line breaks into spaces, so paragraphs arrived as one
run-on block however carefully they were laid out.

## Where the bounds came from, and why they stay

`MEMO_MIN_CHARS` / `MEMO_MAX_CHARS` describe a memo that rides along with a
transaction: it is stored in a `varchar(512)` column and the dlt-connector
validates it a second time against its own copy of the bounds. Widening them
centrally would be accepted by the form and then fail at the column, or be
accepted by the backend and rejected at the dlt layer.

The message path writes to no column and never reaches the dlt-connector, so it
gets bounds of its own: `MESSAGE_MIN_CHARS = 1`, `MESSAGE_MAX_CHARS = 2000`.
2000 is what `contribution_messages.message` already allows - the only other
conversational text in the code base.

## One textarea, two sets of rules

The send form serves all three send types through the same textarea, and all
three used the same `memo` schema. Send and link carry an amount and keep it;
email now uses a separate `message` schema.

Those bounds are written out in the frontend as well as in `shared`, because the
frontend cannot import from `shared`. `validationSchemas.spec.js` holds the two
apart so that widening one side alone is noticed.

## The rest

`white-space: pre-wrap` is set on `.memo-block` rather than on the shared
`.p_content`, so every other mail keeps the layout it has today; `.memo-block` is
used by this template only. Rewriting the breaks as `<br>` would have meant
rendering member text unescaped, which is not worth it for a line break.

The textarea was nailed to four rows and could not be resized, which made 2000
characters a peephole. It now grows with the text up to fourteen rows. The height
is a prop that defaults to the previous fixed value, so the contribution form,
which shares the component, is untouched.

No locale changes were needed: the validation wording already says "message" and
interpolates the bound.

## Verification

Each new test was checked by reintroducing the fault it guards against - the
schema tests fail 4, the send-form wiring tests fail 2, the textarea height test
fails 1. The mail was rendered locally with the same pug and juice versions to
confirm that `white-space: pre-wrap` is inlined onto the block and that the line
breaks survive; `sendCustomEmail` has no snapshot, and the raw css does not reach
the output, so no snapshot changes.

Green locally: typecheck and lint for shared, backend and core; lint, stylelint,
locales, 701 tests and build for the frontend.
