### PR TITLE
fix(backend): stop reading serialization off the clock in the semaphore test

### DIFF
--- a/backend/src/graphql/resolver/semaphore.test.ts
+++ b/backend/src/graphql/resolver/semaphore.test.ts
@@ -44,38 +44,39 @@ afterAll(async () => {
   await testEnv.db.destroy()
 })
 
-type WorkData = { start: number; end: number }
-async function fakeWork(workData: WorkData[], index: number) {
+// Count how many callers are inside the critical section instead of reading it off
+// wall clock timestamps. `new Date()` resolves to whole milliseconds, so two entries
+// that happen inside the same millisecond carry the same number - and a strict
+// `toBeLessThan` on those numbers then fails on a test that is doing nothing wrong.
+// A counter answers the question the test actually asks, and it cannot tie.
+type Concurrency = { current: number; peak: number; completed: number }
+
+async function fakeWork(concurrency: Concurrency) {
   // const releaseLock = await TRANSACTIONS_LOCK.acquire()
   // create a new mutex for every function call, like in production code
   const mutex = new Mutex(testEnv.db.getRedisClient(), 'TRANSACTIONS_LOCK')
   await mutex.acquire()
 
-  const startDate = new Date()
-  await new Promise((resolve) => setTimeout(resolve, Math.random() * 50))
-  const endDate = new Date()
-  workData[index] = { start: startDate.getTime(), end: endDate.getTime() }
+  concurrency.current++
+  concurrency.peak = Math.max(concurrency.peak, concurrency.current)
+  // hold the lock across an await: without the mutex every caller would sit in here
+  // at the same time and `current` would climb to the number of callers
+  await new Promise((resolve) => setTimeout(resolve, 5))
+  concurrency.current--
+  concurrency.completed++
+
   // releaseLock()
   await mutex.release()
 }
 
 describe('semaphore', () => {
-  it("didn't should run in parallel", async () => {
-    const workData: WorkData[] = []
+  it('lets only one caller into the critical section at a time', async () => {
+    const concurrency: Concurrency = { current: 0, peak: 0, completed: 0 }
 
-    const promises: Promise<void>[] = []
-    for (let i = 0; i < 20; i++) {
-      promises.push(fakeWork(workData, i))
-    }
-    await Promise.all(promises)
-    workData.sort((a, b) => a.start - b.start)
-    workData.forEach((work, index) => {
-      expect(work.start).toBeLessThan(work.end)
-      if (index < workData.length - 1) {
-        expect(work.start).toBeLessThan(workData[index + 1].start)
-        expect(work.end).toBeLessThanOrEqual(workData[index + 1].start)
-      }
-    })
+    await Promise.all(Array.from({ length: 20 }, () => fakeWork(concurrency)))
+
+    expect(concurrency.completed).toBe(20)
+    expect(concurrency.peak).toBe(1)
   })
 })
 


### PR DESCRIPTION
@einhornimmond you said you had looked at this one before without finding where the
problem sits, so here is what I found - and what I could not establish.

## What the test did

It asked whether the mutex serializes its callers, and answered it by comparing wall
clock timestamps: each caller recorded a start and an end with `new Date()`, the
results were sorted by start, and neighbours were compared.

## Why that fails now and then

`new Date()` resolves to whole milliseconds. Two moments inside the same millisecond
therefore carry the same number - and two of the three comparisons were strict:

```ts
expect(work.start).toBeLessThan(work.end)
expect(work.start).toBeLessThan(workData[index + 1].start)
expect(work.end).toBeLessThanOrEqual(workData[index + 1].start)   // this one allows a tie
```

A tie makes one of the first two fail, which is exactly the shape CI reported:

```
Expected: < 1785040257310
Received:   1785040257310
```

The two numbers are identical, so nothing overlapped - two values the test requires to
differ were simply equal.

The waiting time made ties reachable: `Math.random() * 50` lands under one millisecond
in about 2% of draws, so across twenty callers roughly a third of all runs contain one.
That matches the behaviour - rare, but back every so often.

Worth noting: the third comparison already allows a tie. The file knew ties happen in
one place and not in the other two.

**What I could not establish:** I did not reproduce the tie on a development machine
(0 in 300 simulated runs, different runtime and no load), so which of the two strict
comparisons fires in CI is not proven. The mechanism is what it is either way, and the
change removes both.

## What it does now

Rather than loosen a comparison, this drops the clock. A counter is raised on entering
the critical section and lowered on leaving it, and the test asserts that its peak is
one:

```ts
concurrency.current++
concurrency.peak = Math.max(concurrency.peak, concurrency.current)
await new Promise((resolve) => setTimeout(resolve, 5))
concurrency.current--
concurrency.completed++
```

```ts
expect(concurrency.completed).toBe(20)
expect(concurrency.peak).toBe(1)
```

That is the question the test's name asks, it is exact, and it cannot tie. Checked
against a stand-in mutex: with the lock the peak is 1, without it the peak is 20 - so a
mutex that stopped working would fail loudly instead of as a near miss on two
timestamps.

The waiting time stays, so the critical sections would genuinely overlap if the lock
were gone, but it is now a fixed five milliseconds - the randomness served nothing and
was the source of the short work in the first place.

The test name is corrected to what it checks.

`typecheck` and `lint` are green locally; the test itself needs redis and the database,
so CI is the first place it runs.
