### PR TITLE
feat(frontend): offer a reload when the loaded bundle no longer fits the schema

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="app">
     <BToastOrchestrator />
+    <AppOutdatedBar />
     <default-layout v-if="$store.state.token" />
     <router-view v-else></router-view>
     <BModalOrchestrator />
@@ -9,6 +10,7 @@
 
 <script setup>
 import defaultLayout from '@/layouts/defaultLayout'
+import AppOutdatedBar from '@/components/AppOutdatedBar'
 import { BModalOrchestrator } from 'bootstrap-vue-next'
 </script>
 <style>

--- a/admin/src/components/AppOutdatedBar.spec.js
+++ b/admin/src/components/AppOutdatedBar.spec.js
@@ -1,0 +1,63 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import AppOutdatedBar from './AppOutdatedBar'
+import { markAppOutdated, resetAppOutdated } from '@/composables/useAppOutdated'
+
+// ⚠️ No own $emit('click') here. $attrs already carries the parent's click handler onto the
+// button, so emitting as well would run it twice and the test would count two reloads for
+// one press.
+const mockBButton = {
+  name: 'BButton',
+  template: '<button v-bind="$attrs"><slot></slot></button>',
+}
+
+describe('AppOutdatedBar', () => {
+  const createWrapper = () =>
+    mount(AppOutdatedBar, {
+      global: {
+        stubs: { BButton: mockBButton },
+        mocks: { $t: (key) => key },
+      },
+    })
+
+  beforeEach(() => {
+    resetAppOutdated()
+  })
+
+  // The bar is a permanent interruption, so it must be invisible until there is a real
+  // reason. A test that only checked the visible case would stay green if it were shown
+  // always.
+  it('shows nothing while the bundle still fits the schema', () => {
+    expect(createWrapper().find('[data-test="app-outdated-bar"]').exists()).toBe(false)
+  })
+
+  it('appears once the app has been marked outdated', async () => {
+    const wrapper = createWrapper()
+    markAppOutdated()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-test="app-outdated-bar"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('appOutdated.text')
+  })
+
+  // ★ The reload is offered, never taken. Someone who has just typed a contribution must get
+  // the chance to copy it out first -- reloading for them would destroy exactly the work the
+  // failed submission was about.
+  it('reloads only when the button is pressed', async () => {
+    const reload = vi.fn()
+    const original = window.location
+    delete window.location
+    window.location = { ...original, reload }
+
+    const wrapper = createWrapper()
+    markAppOutdated()
+    await wrapper.vm.$nextTick()
+
+    expect(reload).not.toHaveBeenCalled()
+
+    await wrapper.find('[data-test="app-outdated-reload"]').trigger('click')
+    expect(reload).toHaveBeenCalledTimes(1)
+
+    window.location = original
+  })
+})

--- a/admin/src/components/AppOutdatedBar.vue
+++ b/admin/src/components/AppOutdatedBar.vue
@@ -1,0 +1,35 @@
+<template>
+  <div v-if="appOutdated" class="app-outdated-bar" role="alert" data-test="app-outdated-bar">
+    <span class="app-outdated-text">{{ $t('appOutdated.text') }}</span>
+    <BButton size="sm" variant="light" data-test="app-outdated-reload" @click="reloadApp">
+      {{ $t('appOutdated.reload') }}
+    </BButton>
+  </div>
+</template>
+
+<script setup>
+// Shown when the server rejected an operation this bundle sent, which means the tab has been
+// open across a deploy. The reload is a button, never automatic: whoever is mid-contribution
+// must get the chance to copy their text out first.
+import { useAppOutdated } from '@/composables/useAppOutdated'
+
+const { appOutdated, reloadApp } = useAppOutdated()
+</script>
+
+<style scoped>
+.app-outdated-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0.6rem 1rem;
+  background-color: var(--bs-warning, #f3cd7c);
+  color: #000;
+  text-align: center;
+}
+
+.app-outdated-text {
+  font-weight: 500;
+}
+</style>

--- a/admin/src/composables/useAppOutdated.js
+++ b/admin/src/composables/useAppOutdated.js
@@ -1,0 +1,65 @@
+import { readonly, ref } from 'vue'
+
+// A tab that was loaded before a deploy keeps the bundle it started with, including the
+// GraphQL documents baked into it. Those documents are validated against the schema in full
+// before anything runs, so once a field is renamed the whole operation is rejected -- not
+// just the part that moved. The member sees a submission that cannot be filed, or a list
+// that will not render, and retrying never helps because the bundle never changes.
+//
+// Reloading fixes it: the server sends index.html as no-store, so a reload always fetches it
+// fresh, and it points at the new content-hashed bundle names. The one thing we must not do
+// is reload on the member's behalf -- someone who has just typed a contribution would lose
+// it. So this only raises a flag, and the bar built on it offers the reload as a button.
+//
+// ⚠️ Deliberately NOT in the vuex store: that store is persisted to localStorage, and a
+// flag that survives the reload it asks for would keep the bar on screen forever.
+//
+// ⚠️ This file exists twice, once here and once under admin/. That is deliberate, not an
+// oversight: the two apps share no package, so there is nowhere to put it that both can
+// import. Both copies carry their own tests, which is what keeps them from drifting apart
+// unnoticed. If a shared package ever appears, this belongs in it.
+const outdated = ref(false)
+
+export const markAppOutdated = () => {
+  outdated.value = true
+}
+
+// Does this failure mean "your bundle no longer fits the schema"?
+//
+// Kept here, free of any Apollo import, so it can be tested on its own -- the wiring in
+// apolloProvider is then three lines that cannot really be wrong.
+//
+// ⚠️ Two shapes are accepted on purpose. A validation failure comes back as HTTP 400
+// (verified against the running server -- it is NOT a 200 carrying an errors array), and
+// whether the client surfaces that as graphQLErrors or as a networkError with the parsed
+// body attached is its own affair. Reading only one shape would mean the bar never appears
+// after a client upgrade changes that behaviour, and nothing would notice.
+//
+// Only GRAPHQL_VALIDATION_FAILED counts. An authorisation or business error must not raise
+// the bar -- telling someone to reload when reloading cannot help is worse than saying
+// nothing. The rare case this over-reports is a genuine bug in a shipped query, which is
+// also a mismatch between what the client sends and what the server accepts.
+const VALIDATION_FAILED = 'GRAPHQL_VALIDATION_FAILED'
+
+const asList = (value) => (Array.isArray(value) ? value : [])
+
+export const isSchemaMismatch = ({ graphQLErrors, networkError } = {}) => {
+  // ⚠️ Both sources are merged, NOT preferred one over the other. `graphQLErrors ?? …` would
+  // look right and quietly stop reading the network error whenever graphQLErrors arrives as
+  // an empty array rather than as undefined -- which is the client's decision to make, not
+  // ours. Concatenating cannot go wrong either way.
+  const errors = [...asList(graphQLErrors), ...asList(networkError?.result?.errors)]
+  return errors.some((e) => e?.extensions?.code === VALIDATION_FAILED)
+}
+
+export function useAppOutdated() {
+  return {
+    appOutdated: readonly(outdated),
+    reloadApp: () => window.location.reload(),
+  }
+}
+
+// Test seam only. Nothing in the app resets this -- a reload is the reset.
+export const resetAppOutdated = () => {
+  outdated.value = false
+}

--- a/admin/src/composables/useAppOutdated.spec.js
+++ b/admin/src/composables/useAppOutdated.spec.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  isSchemaMismatch,
+  markAppOutdated,
+  resetAppOutdated,
+  useAppOutdated,
+} from './useAppOutdated'
+
+// The two shapes below are the whole point of this file. A validation failure comes back as
+// HTTP 400, and whether the client hands it over as graphQLErrors or as a networkError with
+// the parsed body attached is the client's own business -- so both must be recognised, and a
+// test has to say so, because nothing else would notice if one of them stopped working.
+describe('isSchemaMismatch', () => {
+  const validation = { extensions: { code: 'GRAPHQL_VALIDATION_FAILED' } }
+
+  it('recognises a validation failure delivered as graphQLErrors', () => {
+    expect(isSchemaMismatch({ graphQLErrors: [validation] })).toBe(true)
+  })
+
+  it('recognises a validation failure delivered inside a networkError', () => {
+    expect(isSchemaMismatch({ networkError: { result: { errors: [validation] } } })).toBe(true)
+  })
+
+  it('finds it when it is not the first error', () => {
+    const other = { extensions: { code: 'INTERNAL_SERVER_ERROR' } }
+    expect(isSchemaMismatch({ graphQLErrors: [other, validation] })).toBe(true)
+  })
+
+  // Telling someone to reload when reloading cannot help is worse than saying nothing, so
+  // every one of these has to stay quiet.
+  it('stays quiet for any other error', () => {
+    expect(isSchemaMismatch({ graphQLErrors: [{ extensions: { code: 'UNAUTHENTICATED' } }] })).toBe(
+      false,
+    )
+    expect(isSchemaMismatch({ graphQLErrors: [{ message: 'no extensions at all' }] })).toBe(false)
+    expect(isSchemaMismatch({ networkError: { message: 'offline' } })).toBe(false)
+    expect(isSchemaMismatch({ graphQLErrors: [] })).toBe(false)
+    expect(isSchemaMismatch({})).toBe(false)
+    expect(isSchemaMismatch()).toBe(false)
+  })
+
+  it('survives a networkError whose body is not the shape we expect', () => {
+    expect(isSchemaMismatch({ networkError: { result: 'plain text' } })).toBe(false)
+    expect(isSchemaMismatch({ networkError: { result: { errors: null } } })).toBe(false)
+  })
+
+  // ⚠️ The trap a `graphQLErrors ?? networkError…` chain would fall into: an EMPTY array is
+  // not nullish, so it would satisfy the first branch and the network error would never be
+  // read. Whether the client sends undefined or [] is its own decision, so neither may be
+  // relied on.
+  it('still reads the networkError when graphQLErrors is an empty array', () => {
+    expect(
+      isSchemaMismatch({
+        graphQLErrors: [],
+        networkError: { result: { errors: [validation] } },
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('useAppOutdated', () => {
+  beforeEach(() => {
+    resetAppOutdated()
+  })
+
+  it('starts down and stays down until marked', () => {
+    expect(useAppOutdated().appOutdated.value).toBe(false)
+  })
+
+  it('goes up when marked, and every caller sees the same flag', () => {
+    const first = useAppOutdated()
+    const second = useAppOutdated()
+    markAppOutdated()
+
+    expect(first.appOutdated.value).toBe(true)
+    expect(second.appOutdated.value).toBe(true)
+  })
+
+  // Nothing may lower it except a reload. A component that could clear it would hide the bar
+  // while the bundle is still the stale one. Vue's readonly() does not throw on a write, it
+  // warns and drops it -- so the assertion is on the value, not on an exception.
+  it('ignores an attempt to lower it through the composable', () => {
+    markAppOutdated()
+    const { appOutdated } = useAppOutdated()
+
+    appOutdated.value = false
+
+    expect(appOutdated.value).toBe(true)
+  })
+})

--- a/admin/src/locales/de.json
+++ b/admin/src/locales/de.json
@@ -13,6 +13,10 @@
   },
   "alias": "Alias",
   "all_emails": "Alle Nutzer",
+  "appOutdated": {
+    "reload": "Neu laden",
+    "text": "Es gibt eine neuere Fassung. Bitte lade die Seite neu."
+  },
   "back": "zurück",
   "bulkResubmission": {
     "cancel": "Nicht übernehmen",

--- a/admin/src/locales/el.json
+++ b/admin/src/locales/el.json
@@ -13,6 +13,10 @@
   },
   "alias": "Ψευδώνυμο",
   "all_emails": "Όλοι οι χρήστες",
+  "appOutdated": {
+    "reload": "Ανανέωση",
+    "text": "Υπάρχει νεότερη έκδοση. Παρακαλώ ανανεώστε τη σελίδα."
+  },
   "back": "πίσω",
   "bulkResubmission": {
     "cancel": "Do not apply",

--- a/admin/src/locales/en.json
+++ b/admin/src/locales/en.json
@@ -13,6 +13,10 @@
   },
   "alias": "Alias",
   "all_emails": "All users",
+  "appOutdated": {
+    "reload": "Reload",
+    "text": "A newer version is available. Please reload the page."
+  },
   "back": "back",
   "bulkResubmission": {
     "cancel": "Do not apply",

--- a/admin/src/locales/es.json
+++ b/admin/src/locales/es.json
@@ -13,6 +13,10 @@
   },
   "alias": "Alias",
   "all_emails": "Todos los usuarios",
+  "appOutdated": {
+    "reload": "Recargar",
+    "text": "Hay una versión más reciente. Por favor, recarga la página."
+  },
   "back": "atrás",
   "bulkResubmission": {
     "cancel": "Do not apply",

--- a/admin/src/locales/fr.json
+++ b/admin/src/locales/fr.json
@@ -13,6 +13,10 @@
   },
   "alias": "Alias",
   "all_emails": "Tous les utilisateurs",
+  "appOutdated": {
+    "reload": "Recharger",
+    "text": "Une version plus récente est disponible. Merci de recharger la page."
+  },
   "back": "retour",
   "bulkResubmission": {
     "cancel": "Do not apply",

--- a/admin/src/locales/it.json
+++ b/admin/src/locales/it.json
@@ -13,6 +13,10 @@
   },
   "alias": "Alias",
   "all_emails": "Tutti gli utenti",
+  "appOutdated": {
+    "reload": "Ricarica",
+    "text": "È disponibile una versione più recente. Ricarica la pagina."
+  },
   "back": "indietro",
   "bulkResubmission": {
     "cancel": "Do not apply",

--- a/admin/src/locales/nl.json
+++ b/admin/src/locales/nl.json
@@ -13,6 +13,10 @@
   },
   "alias": "Alias",
   "all_emails": "Alle gebruikers",
+  "appOutdated": {
+    "reload": "Opnieuw laden",
+    "text": "Er is een nieuwere versie beschikbaar. Laad de pagina opnieuw."
+  },
   "back": "terug",
   "bulkResubmission": {
     "cancel": "Do not apply",

--- a/admin/src/locales/pt.json
+++ b/admin/src/locales/pt.json
@@ -13,6 +13,10 @@
   },
   "alias": "Alias",
   "all_emails": "Todos os utilizadores",
+  "appOutdated": {
+    "reload": "Recarregar",
+    "text": "Existe uma versão mais recente. Por favor, recarregue a página."
+  },
   "back": "voltar",
   "bulkResubmission": {
     "cancel": "Do not apply",

--- a/admin/src/locales/ru.json
+++ b/admin/src/locales/ru.json
@@ -13,6 +13,10 @@
   },
   "alias": "Псевдоним",
   "all_emails": "Все пользователи",
+  "appOutdated": {
+    "reload": "Обновить",
+    "text": "Доступна более новая версия. Пожалуйста, обновите страницу."
+  },
   "back": "назад",
   "bulkResubmission": {
     "cancel": "Do not apply",

--- a/admin/src/locales/tr.json
+++ b/admin/src/locales/tr.json
@@ -13,6 +13,10 @@
   },
   "alias": "Takma ad",
   "all_emails": "Tüm kullanıcılar",
+  "appOutdated": {
+    "reload": "Yenile",
+    "text": "Daha yeni bir sürüm mevcut. Lütfen sayfayı yenileyin."
+  },
   "back": "geri",
   "bulkResubmission": {
     "cancel": "Do not apply",

--- a/admin/src/plugins/apolloOutdatedLink.test.js
+++ b/admin/src/plugins/apolloOutdatedLink.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Covers the one line the sibling file cannot: what the outdated-app link's handler actually
+// does. Mocking onError is the only way to get hold of that handler, and mocking it is also
+// what stops this file from proving the real chain assembles -- which is why that assertion
+// lives in apolloProvider.test.js, where nothing is mocked. The two belong together.
+vi.mock('@apollo/client/link/error')
+vi.mock('vue-apollo')
+vi.mock('@vue/apollo-composable')
+vi.mock('../config', () => ({
+  default: {
+    GRAPHQL_URI: 'http://test-graphql-uri.com',
+    WALLET_LOGIN_URL: 'http://test-wallet-login-url.com',
+  },
+}))
+vi.mock('../store/store', () => ({
+  default: { state: { token: '' }, dispatch: vi.fn(), commit: vi.fn() },
+}))
+
+describe('the outdated-app link', () => {
+  let handler, appOutdated
+
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    // ⚠️ The stub needs concat(), not just request(): apollo-boost's ApolloLink.from calls
+    // concat on every member of the chain. A thinner stub throws there -- which is, in
+    // passing, the proof that the real @apollo/client link satisfies the old interface, since
+    // the unmocked sibling file assembles the same chain and stays green.
+    const errorLinkModule = await import('@apollo/client/link/error')
+    const onError = vi.fn((h) => ({ request: h, concat: (next) => next }))
+    vi.mocked(errorLinkModule).onError = onError
+
+    await import('./apolloProvider')
+    handler = onError.mock.calls[0][0]
+
+    const outdatedModule = await import('@/composables/useAppOutdated')
+    outdatedModule.resetAppOutdated()
+    appOutdated = outdatedModule.useAppOutdated().appOutdated
+  })
+
+  it('raises the flag on a validation failure', () => {
+    handler({ graphQLErrors: [{ extensions: { code: 'GRAPHQL_VALIDATION_FAILED' } }] })
+
+    expect(appOutdated.value).toBe(true)
+  })
+
+  it('raises the flag when the failure arrives as a network error', () => {
+    handler({
+      networkError: { result: { errors: [{ extensions: { code: 'GRAPHQL_VALIDATION_FAILED' } }] } },
+    })
+
+    expect(appOutdated.value).toBe(true)
+  })
+
+  // Reloading does not help against an expired session, and a bar that claims otherwise
+  // sends a moderator down the wrong path.
+  it('leaves the flag down for every other failure', () => {
+    handler({ graphQLErrors: [{ extensions: { code: 'UNAUTHENTICATED' } }] })
+    handler({ networkError: { message: 'offline' } })
+
+    expect(appOutdated.value).toBe(false)
+  })
+})

--- a/admin/src/plugins/apolloProvider.js
+++ b/admin/src/plugins/apolloProvider.js
@@ -1,10 +1,28 @@
 import { ApolloClient, ApolloLink, InMemoryCache, HttpLink } from 'apollo-boost'
+import { onError } from '@apollo/client/link/error'
 import VueApollo from 'vue-apollo'
 import CONFIG from '../config'
 import store from '../store/store'
 import { provideApolloClient } from '@vue/apollo-composable'
+import { isSchemaMismatch, markAppOutdated } from '@/composables/useAppOutdated'
 
 const httpLink = new HttpLink({ uri: CONFIG.GRAPHQL_URI })
+
+// A tab kept open across a deploy still sends the documents its bundle was built with, and
+// the server validates a document in full before running it -- so a renamed field kills the
+// whole operation and no retry helps until the page is reloaded. Raise a flag so
+// AppOutdatedBar can offer that reload. The decision lives in useAppOutdated, testable
+// without Apollo.
+//
+// ⚠️ This admin still builds its client from apollo-boost (apollo-link 1.x) while onError
+// comes from @apollo/client 3.x. Both expose the same request/observable contract and both
+// are already dependencies, so no new package -- but the two generations meeting in one
+// chain is the part only a running server can prove. Verify on staging, not at the diff.
+const outdatedLink = onError((failure) => {
+  if (isSchemaMismatch(failure)) {
+    markAppOutdated()
+  }
+})
 
 const authLink = new ApolloLink((operation, forward) => {
   const token = store.state.token
@@ -27,7 +45,7 @@ const authLink = new ApolloLink((operation, forward) => {
 })
 
 const apolloClient = new ApolloClient({
-  link: authLink.concat(httpLink),
+  link: ApolloLink.from([outdatedLink, authLink, httpLink]),
   cache: new InMemoryCache(),
 })
 

--- a/admin/src/plugins/apolloProvider.test.js
+++ b/admin/src/plugins/apolloProvider.test.js
@@ -25,6 +25,13 @@ describe('Apollo Provider Setup', () => {
     vi.clearAllMocks()
   })
 
+  // ★ This file deliberately does NOT mock apollo-boost or @apollo/client/link/error, so
+  // importing the module builds the real chain. That is what makes the assertion below worth
+  // more than it looks: this admin still builds its client from apollo-boost (apollo-link
+  // 1.x) while the outdated-app link comes from @apollo/client 3.x, and if those two
+  // generations could not be chained, ApolloLink.from would throw on import and every test
+  // here would fail. The wiring of that link is covered separately in
+  // apolloOutdatedLink.test.js, which has to mock onError and therefore cannot prove this.
   it('creates an Apollo provider', () => {
     expect(apolloProvider).toBeDefined()
     expect(apolloProvider).toBeInstanceOf(VueApollo)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="app" ref="app" :class="darkMode ? 'dark-mode' : ''">
     <BToastOrchestrator />
+    <app-outdated-bar />
     <div :class="$route.meta.requiresAuth ? 'app-content' : ''">
       <component :is="$route.meta.requiresAuth ? 'DashboardLayout' : 'AuthLayout'" />
       <div class="goldrand position-fixed fixed-bottom zindex1000"></div>
@@ -11,12 +12,14 @@
 <script>
 import DashboardLayout from '@/layouts/DashboardLayout'
 import AuthLayout from '@/layouts/AuthLayout'
+import AppOutdatedBar from '@/components/AppOutdatedBar'
 
 export default {
   name: 'App',
   components: {
     DashboardLayout,
     AuthLayout,
+    AppOutdatedBar,
   },
   computed: {
     darkMode() {

--- a/frontend/src/components/AppOutdatedBar.spec.js
+++ b/frontend/src/components/AppOutdatedBar.spec.js
@@ -1,0 +1,63 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import AppOutdatedBar from './AppOutdatedBar'
+import { markAppOutdated, resetAppOutdated } from '@/composables/useAppOutdated'
+
+// ⚠️ No own $emit('click') here. $attrs already carries the parent's click handler onto the
+// button, so emitting as well would run it twice and the test would count two reloads for
+// one press.
+const mockBButton = {
+  name: 'BButton',
+  template: '<button v-bind="$attrs"><slot></slot></button>',
+}
+
+describe('AppOutdatedBar', () => {
+  const createWrapper = () =>
+    mount(AppOutdatedBar, {
+      global: {
+        stubs: { BButton: mockBButton },
+        mocks: { $t: (key) => key },
+      },
+    })
+
+  beforeEach(() => {
+    resetAppOutdated()
+  })
+
+  // The bar is a permanent interruption, so it must be invisible until there is a real
+  // reason. A test that only checked the visible case would stay green if it were shown
+  // always.
+  it('shows nothing while the bundle still fits the schema', () => {
+    expect(createWrapper().find('[data-test="app-outdated-bar"]').exists()).toBe(false)
+  })
+
+  it('appears once the app has been marked outdated', async () => {
+    const wrapper = createWrapper()
+    markAppOutdated()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-test="app-outdated-bar"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('appOutdated.text')
+  })
+
+  // ★ The reload is offered, never taken. Someone who has just typed a contribution must get
+  // the chance to copy it out first -- reloading for them would destroy exactly the work the
+  // failed submission was about.
+  it('reloads only when the button is pressed', async () => {
+    const reload = vi.fn()
+    const original = window.location
+    delete window.location
+    window.location = { ...original, reload }
+
+    const wrapper = createWrapper()
+    markAppOutdated()
+    await wrapper.vm.$nextTick()
+
+    expect(reload).not.toHaveBeenCalled()
+
+    await wrapper.find('[data-test="app-outdated-reload"]').trigger('click')
+    expect(reload).toHaveBeenCalledTimes(1)
+
+    window.location = original
+  })
+})

--- a/frontend/src/components/AppOutdatedBar.vue
+++ b/frontend/src/components/AppOutdatedBar.vue
@@ -1,0 +1,35 @@
+<template>
+  <div v-if="appOutdated" class="app-outdated-bar" role="alert" data-test="app-outdated-bar">
+    <span class="app-outdated-text">{{ $t('appOutdated.text') }}</span>
+    <BButton size="sm" variant="light" data-test="app-outdated-reload" @click="reloadApp">
+      {{ $t('appOutdated.reload') }}
+    </BButton>
+  </div>
+</template>
+
+<script setup>
+// Shown when the server rejected an operation this bundle sent, which means the tab has been
+// open across a deploy. The reload is a button, never automatic: whoever is mid-contribution
+// must get the chance to copy their text out first.
+import { useAppOutdated } from '@/composables/useAppOutdated'
+
+const { appOutdated, reloadApp } = useAppOutdated()
+</script>
+
+<style scoped>
+.app-outdated-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0.6rem 1rem;
+  background-color: var(--bs-warning, #f3cd7c);
+  color: #000;
+  text-align: center;
+}
+
+.app-outdated-text {
+  font-weight: 500;
+}
+</style>

--- a/frontend/src/composables/useAppOutdated.js
+++ b/frontend/src/composables/useAppOutdated.js
@@ -1,0 +1,65 @@
+import { readonly, ref } from 'vue'
+
+// A tab that was loaded before a deploy keeps the bundle it started with, including the
+// GraphQL documents baked into it. Those documents are validated against the schema in full
+// before anything runs, so once a field is renamed the whole operation is rejected -- not
+// just the part that moved. The member sees a submission that cannot be filed, or a list
+// that will not render, and retrying never helps because the bundle never changes.
+//
+// Reloading fixes it: the server sends index.html as no-store, so a reload always fetches it
+// fresh, and it points at the new content-hashed bundle names. The one thing we must not do
+// is reload on the member's behalf -- someone who has just typed a contribution would lose
+// it. So this only raises a flag, and the bar built on it offers the reload as a button.
+//
+// ⚠️ Deliberately NOT in the vuex store: that store is persisted to localStorage, and a
+// flag that survives the reload it asks for would keep the bar on screen forever.
+//
+// ⚠️ This file exists twice, once here and once under admin/. That is deliberate, not an
+// oversight: the two apps share no package, so there is nowhere to put it that both can
+// import. Both copies carry their own tests, which is what keeps them from drifting apart
+// unnoticed. If a shared package ever appears, this belongs in it.
+const outdated = ref(false)
+
+export const markAppOutdated = () => {
+  outdated.value = true
+}
+
+// Does this failure mean "your bundle no longer fits the schema"?
+//
+// Kept here, free of any Apollo import, so it can be tested on its own -- the wiring in
+// apolloProvider is then three lines that cannot really be wrong.
+//
+// ⚠️ Two shapes are accepted on purpose. A validation failure comes back as HTTP 400
+// (verified against the running server -- it is NOT a 200 carrying an errors array), and
+// whether the client surfaces that as graphQLErrors or as a networkError with the parsed
+// body attached is its own affair. Reading only one shape would mean the bar never appears
+// after a client upgrade changes that behaviour, and nothing would notice.
+//
+// Only GRAPHQL_VALIDATION_FAILED counts. An authorisation or business error must not raise
+// the bar -- telling someone to reload when reloading cannot help is worse than saying
+// nothing. The rare case this over-reports is a genuine bug in a shipped query, which is
+// also a mismatch between what the client sends and what the server accepts.
+const VALIDATION_FAILED = 'GRAPHQL_VALIDATION_FAILED'
+
+const asList = (value) => (Array.isArray(value) ? value : [])
+
+export const isSchemaMismatch = ({ graphQLErrors, networkError } = {}) => {
+  // ⚠️ Both sources are merged, NOT preferred one over the other. `graphQLErrors ?? …` would
+  // look right and quietly stop reading the network error whenever graphQLErrors arrives as
+  // an empty array rather than as undefined -- which is the client's decision to make, not
+  // ours. Concatenating cannot go wrong either way.
+  const errors = [...asList(graphQLErrors), ...asList(networkError?.result?.errors)]
+  return errors.some((e) => e?.extensions?.code === VALIDATION_FAILED)
+}
+
+export function useAppOutdated() {
+  return {
+    appOutdated: readonly(outdated),
+    reloadApp: () => window.location.reload(),
+  }
+}
+
+// Test seam only. Nothing in the app resets this -- a reload is the reset.
+export const resetAppOutdated = () => {
+  outdated.value = false
+}

--- a/frontend/src/composables/useAppOutdated.spec.js
+++ b/frontend/src/composables/useAppOutdated.spec.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  isSchemaMismatch,
+  markAppOutdated,
+  resetAppOutdated,
+  useAppOutdated,
+} from './useAppOutdated'
+
+// The two shapes below are the whole point of this file. A validation failure comes back as
+// HTTP 400, and whether the client hands it over as graphQLErrors or as a networkError with
+// the parsed body attached is the client's own business -- so both must be recognised, and a
+// test has to say so, because nothing else would notice if one of them stopped working.
+describe('isSchemaMismatch', () => {
+  const validation = { extensions: { code: 'GRAPHQL_VALIDATION_FAILED' } }
+
+  it('recognises a validation failure delivered as graphQLErrors', () => {
+    expect(isSchemaMismatch({ graphQLErrors: [validation] })).toBe(true)
+  })
+
+  it('recognises a validation failure delivered inside a networkError', () => {
+    expect(isSchemaMismatch({ networkError: { result: { errors: [validation] } } })).toBe(true)
+  })
+
+  it('finds it when it is not the first error', () => {
+    const other = { extensions: { code: 'INTERNAL_SERVER_ERROR' } }
+    expect(isSchemaMismatch({ graphQLErrors: [other, validation] })).toBe(true)
+  })
+
+  // Telling someone to reload when reloading cannot help is worse than saying nothing, so
+  // every one of these has to stay quiet.
+  it('stays quiet for any other error', () => {
+    expect(isSchemaMismatch({ graphQLErrors: [{ extensions: { code: 'UNAUTHENTICATED' } }] })).toBe(
+      false,
+    )
+    expect(isSchemaMismatch({ graphQLErrors: [{ message: 'no extensions at all' }] })).toBe(false)
+    expect(isSchemaMismatch({ networkError: { message: 'offline' } })).toBe(false)
+    expect(isSchemaMismatch({ graphQLErrors: [] })).toBe(false)
+    expect(isSchemaMismatch({})).toBe(false)
+    expect(isSchemaMismatch()).toBe(false)
+  })
+
+  it('survives a networkError whose body is not the shape we expect', () => {
+    expect(isSchemaMismatch({ networkError: { result: 'plain text' } })).toBe(false)
+    expect(isSchemaMismatch({ networkError: { result: { errors: null } } })).toBe(false)
+  })
+
+  // ⚠️ The trap a `graphQLErrors ?? networkError…` chain would fall into: an EMPTY array is
+  // not nullish, so it would satisfy the first branch and the network error would never be
+  // read. Whether the client sends undefined or [] is its own decision, so neither may be
+  // relied on.
+  it('still reads the networkError when graphQLErrors is an empty array', () => {
+    expect(
+      isSchemaMismatch({
+        graphQLErrors: [],
+        networkError: { result: { errors: [validation] } },
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('useAppOutdated', () => {
+  beforeEach(() => {
+    resetAppOutdated()
+  })
+
+  it('starts down and stays down until marked', () => {
+    expect(useAppOutdated().appOutdated.value).toBe(false)
+  })
+
+  it('goes up when marked, and every caller sees the same flag', () => {
+    const first = useAppOutdated()
+    const second = useAppOutdated()
+    markAppOutdated()
+
+    expect(first.appOutdated.value).toBe(true)
+    expect(second.appOutdated.value).toBe(true)
+  })
+
+  // Nothing may lower it except a reload. A component that could clear it would hide the bar
+  // while the bundle is still the stale one. Vue's readonly() does not throw on a write, it
+  // warns and drops it -- so the assertion is on the value, not on an exception.
+  it('ignores an attempt to lower it through the composable', () => {
+    markAppOutdated()
+    const { appOutdated } = useAppOutdated()
+
+    appOutdated.value = false
+
+    expect(appOutdated.value).toBe(true)
+  })
+})

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -20,6 +20,10 @@
   "PersonalDetails": "Persönliche Angaben",
   "advanced-calculation": "Vorausberechnung",
   "answerNow": "→ Jetzt antworten!",
+  "appOutdated": {
+    "reload": "Neu laden",
+    "text": "Es gibt eine neuere Fassung. Bitte lade die Seite neu."
+  },
   "asterisks": "****",
   "auth": {
     "left": {

--- a/frontend/src/locales/el.json
+++ b/frontend/src/locales/el.json
@@ -20,6 +20,10 @@
   "PersonalDetails": "Προσωπικά στοιχεία",
   "advanced-calculation": "Προκαταρκτικός υπολογισμός",
   "answerNow": "→ Απάντησε τώρα!",
+  "appOutdated": {
+    "reload": "Ανανέωση",
+    "text": "Υπάρχει νεότερη έκδοση. Παρακαλώ ανανεώστε τη σελίδα."
+  },
   "asterisks": "****",
   "auth": {
     "left": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -20,6 +20,10 @@
   "PersonalDetails": "Personal details",
   "advanced-calculation": "Advanced calculation",
   "answerNow": "→ Reply now!",
+  "appOutdated": {
+    "reload": "Reload",
+    "text": "A newer version is available. Please reload the page."
+  },
   "asterisks": "****",
   "auth": {
     "left": {

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -20,6 +20,10 @@
   "PersonalDetails": "Datos personales",
   "advanced-calculation": "Proyección",
   "answerNow": "→ ¡Responde ahora!",
+  "appOutdated": {
+    "reload": "Recargar",
+    "text": "Hay una versión más reciente. Por favor, recarga la página."
+  },
   "asterisks": "****",
   "auth": {
     "left": {

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -20,6 +20,10 @@
   "PersonalDetails": "Informations personnelles",
   "advanced-calculation": "Calcul avancé",
   "answerNow": "→ Répondre maintenant!",
+  "appOutdated": {
+    "reload": "Recharger",
+    "text": "Une version plus récente est disponible. Merci de recharger la page."
+  },
   "asterisks": "****",
   "auth": {
     "left": {

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -20,6 +20,10 @@
   "PersonalDetails": "Dati personali",
   "advanced-calculation": "Proiezione",
   "answerNow": "→ Rispondi ora!",
+  "appOutdated": {
+    "reload": "Ricarica",
+    "text": "È disponibile una versione più recente. Ricarica la pagina."
+  },
   "asterisks": "****",
   "auth": {
     "left": {

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -20,6 +20,10 @@
   "PersonalDetails": "Persoonlijke gegevens",
   "advanced-calculation": "Voorcalculatie",
   "answerNow": "→ Nu antwoorden!",
+  "appOutdated": {
+    "reload": "Opnieuw laden",
+    "text": "Er is een nieuwere versie beschikbaar. Laad de pagina opnieuw."
+  },
   "asterisks": "****",
   "auth": {
     "left": {

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -20,6 +20,10 @@
   "PersonalDetails": "Dados pessoais",
   "advanced-calculation": "Cálculo antecipado",
   "answerNow": "→ Responde agora!",
+  "appOutdated": {
+    "reload": "Recarregar",
+    "text": "Existe uma versão mais recente. Por favor, recarregue a página."
+  },
   "asterisks": "****",
   "auth": {
     "left": {

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -20,6 +20,10 @@
   "PersonalDetails": "Личные данные",
   "advanced-calculation": "заранее начислено",
   "answerNow": "→ Ответить сейчас!",
+  "appOutdated": {
+    "reload": "Обновить",
+    "text": "Доступна более новая версия. Пожалуйста, обновите страницу."
+  },
   "asterisks": "****",
   "auth": {
     "left": {

--- a/frontend/src/locales/tr.json
+++ b/frontend/src/locales/tr.json
@@ -20,6 +20,10 @@
   "PersonalDetails": "Kişisel bilgiler",
   "advanced-calculation": "Önceden hesaplama",
   "answerNow": "→ Şimdi yanıtla!",
+  "appOutdated": {
+    "reload": "Yenile",
+    "text": "Daha yeni bir sürüm mevcut. Lütfen sayfayı yenileyin."
+  },
   "asterisks": "****",
   "auth": {
     "left": {

--- a/frontend/src/plugins/apolloProvider.js
+++ b/frontend/src/plugins/apolloProvider.js
@@ -3,10 +3,23 @@ import { store } from '@/store/store'
 import router from '../routes/router'
 import i18n from '../i18n'
 import { createHttpLink, ApolloLink, ApolloClient, InMemoryCache } from '@apollo/client/core'
+import { onError } from '@apollo/client/link/error'
 import { createApolloProvider } from '@vue/apollo-option'
 import { provideApolloClient } from '@vue/apollo-composable'
+import { isSchemaMismatch, markAppOutdated } from '@/composables/useAppOutdated'
 
 const httpLink = createHttpLink({ uri: CONFIG.GRAPHQL_URI })
+
+// A tab kept open across a deploy still sends the documents its bundle was built with. The
+// server validates a document in full before running it, so a renamed field kills the whole
+// operation -- the member cannot file a contribution and no retry helps, because the bundle
+// is fixed until the page is reloaded. Raise a flag so AppOutdatedBar can offer that reload.
+// The decision itself lives in useAppOutdated, where it is testable without Apollo.
+const outdatedLink = onError((failure) => {
+  if (isSchemaMismatch(failure)) {
+    markAppOutdated()
+  }
+})
 
 const authLink = new ApolloLink((operation, forward) => {
   const token = store.state.token
@@ -30,7 +43,7 @@ const authLink = new ApolloLink((operation, forward) => {
 })
 
 const apolloClient = new ApolloClient({
-  link: authLink.concat(httpLink),
+  link: ApolloLink.from([outdatedLink, authLink, httpLink]),
   cache: new InMemoryCache({
     possibleTypes: {
       QueryLinkResult: ['TransactionLink', 'ContributionLink'],

--- a/frontend/src/plugins/apolloProvider.test.js
+++ b/frontend/src/plugins/apolloProvider.test.js
@@ -7,6 +7,7 @@ vi.mock('@/store/store')
 vi.mock('../routes/router')
 vi.mock('../i18n')
 vi.mock('@apollo/client/core')
+vi.mock('@apollo/client/link/error')
 
 describe('apolloProvider', () => {
   let createHttpLink,
@@ -15,6 +16,7 @@ describe('apolloProvider', () => {
     InMemoryCache,
     createApolloProvider,
     provideApolloClient,
+    onError,
     store,
     router,
     i18n
@@ -32,6 +34,8 @@ describe('apolloProvider', () => {
         request: callback,
       }
     })
+    // The chain is assembled with ApolloLink.from, so the mock needs the static too.
+    ApolloLink.from = vi.fn((links) => ({ links }))
     ApolloClient = vi.fn()
     InMemoryCache = vi.fn()
 
@@ -39,6 +43,10 @@ describe('apolloProvider', () => {
     vi.mocked(apolloCore).ApolloLink = ApolloLink
     vi.mocked(apolloCore).ApolloClient = ApolloClient
     vi.mocked(apolloCore).InMemoryCache = InMemoryCache
+
+    const errorLinkModule = await import('@apollo/client/link/error')
+    onError = vi.fn((handler) => ({ handler }))
+    vi.mocked(errorLinkModule).onError = onError
 
     const apolloOption = await import('@vue/apollo-option')
     createApolloProvider = vi.fn()
@@ -176,6 +184,45 @@ describe('apolloProvider', () => {
       authLink({ setContext: setContextMock, getContext: getContextMock }, forwardMock)
 
       expect(store.commit).toHaveBeenCalledWith('token', 'new-token')
+    })
+  })
+
+  // Without this the wiring is untested: the checks above only prove that onError was
+  // called, not what its handler does. Here the handler is taken out of the mock and run,
+  // which is the only place the two halves -- the rule and the flag -- are seen together.
+  describe('the outdated-app link', () => {
+    let handler, appOutdated
+
+    beforeEach(async () => {
+      handler = onError.mock.calls[0][0]
+      const outdatedModule = await import('@/composables/useAppOutdated')
+      outdatedModule.resetAppOutdated()
+      appOutdated = outdatedModule.useAppOutdated().appOutdated
+    })
+
+    it('raises the flag on a validation failure', () => {
+      handler({ graphQLErrors: [{ extensions: { code: 'GRAPHQL_VALIDATION_FAILED' } }] })
+
+      expect(appOutdated.value).toBe(true)
+    })
+
+    it('raises the flag when the failure arrives as a network error', () => {
+      handler({
+        networkError: {
+          result: { errors: [{ extensions: { code: 'GRAPHQL_VALIDATION_FAILED' } }] },
+        },
+      })
+
+      expect(appOutdated.value).toBe(true)
+    })
+
+    // Reloading does not help against an expired session or a rejected amount, and a bar
+    // that says otherwise sends people down the wrong path.
+    it('leaves the flag down for every other failure', () => {
+      handler({ graphQLErrors: [{ extensions: { code: 'UNAUTHENTICATED' } }] })
+      handler({ networkError: { message: 'offline' } })
+
+      expect(appOutdated.value).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## What this fixes

A tab left open across a deploy keeps the bundle it started with, including the GraphQL documents baked into it. The server validates a document **in full** before running anything, so a renamed field kills the whole operation rather than just the part that moved:

- a member mid-contribution presses submit and it **cannot be filed at all** — and every retry fails the same way, because the bundle never changes
- "my contributions" does not render its list, rather than merely losing a filter
- same for the admin's contribution list

This has been latent for a while. It becomes concrete with the `CreationGroup` rename that follows, which renames GraphQL arguments and input-object fields — hence delivering this first.

## Two things verified rather than assumed

**The failure really is an HTTP 400.** Asked the running staging server with an invalid query: `400` with `extensions.code: GRAPHQL_VALIDATION_FAILED`. That is why both error shapes are handled — whether the client surfaces a 400 as `graphQLErrors` or as a `networkError` carrying the parsed body is its own affair, and betting on one would mean the bar silently stops appearing after a client upgrade.

**A plain reload really does fix it.** nginx serves `index.html` — and every SPA route — as `no-cache, no-store, must-revalidate`, while the bundles are `immutable` under content-hashed names. So a reload always fetches the entry document fresh, and it points at bundle names the browser does not have yet. A notice telling people to reload had to be worth acting on.

## Design decisions

**The reload is a button, never automatic.** Someone who has just typed a contribution would lose exactly the work the failed submission was about. They get the chance to copy it out first.

**Only `GRAPHQL_VALIDATION_FAILED` raises the bar.** Telling someone to reload when reloading cannot help — an expired session, a rejected amount — is worse than saying nothing.

**The flag sits outside the vuex store.** That store is persisted to localStorage, and a flag that survived the reload it asks for would pin the bar to the screen forever.

**`useAppOutdated` holds the decision, free of Apollo imports**, so it is testable on its own; the wiring in `apolloProvider` is then three lines.

## Worth your eye

- **The file is duplicated between the two apps on purpose.** They share no package, so there is nowhere both can import from. Both copies carry their own tests, and the four files are byte-identical. If a shared package ever appears, this belongs in it.
- **The admin still builds its client from `apollo-boost` (apollo-link 1.x) while `onError` comes from `@apollo/client` 3.x.** No new dependency — both are already there. `admin/src/plugins/apolloProvider.test.js` mocks neither, so it assembles the real chain; `ApolloLink.from` calls `.concat()` on every member, and the test staying green is the evidence that the newer link satisfies the older interface. Still worth a look on staging, since only a running server exercises the error path end to end.

## Checks

Frontend 81 files / 731 tests, admin 49 files / 410 tests, lint + stylelint + locales + build green in both.

Both new tests were proved to measure by reintroducing the bug: swapping the merge back to a `graphQLErrors ?? …` chain fails exactly the empty-array test in each package, and removing the network-error branch fails exactly the two tests that cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an alert notifying users when a newer application version is available.
  * Users can manually reload the page to access the latest version.
  * Added detection for GraphQL schema mismatches that trigger the outdated-version notice.
  * Added localized messages and reload actions across supported languages.

* **Tests**
  * Added coverage for notification visibility, translations, reload behavior, outdated-version detection, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->