### PR TITLE
fix(backend): sort a contribution groups where the sorting is actually read

### DIFF
--- a/admin/src/components/ChangeUserRoleFormular.vue
+++ b/admin/src/components/ChangeUserRoleFormular.vue
@@ -53,6 +53,7 @@ import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { BButton, BFormSelect } from 'bootstrap-vue-next'
 import { useMutation, useQuery } from '@vue/apollo-composable'
+import { groupTagOption } from '@/utils/groupTagLabel'
 import { setUserRole as setUserRoleMutation } from '../graphql/setUserRole'
 import {
   groupTags,
@@ -162,10 +163,7 @@ watch(
 )
 const mainTagSelectOptions = computed(() => [
   { value: '', text: t('userRole.groupTags.none') },
-  ...groupTagOptions.value.map((tag) => ({
-    value: tag.tag,
-    text: tag.name ? `${tag.name} (#${tag.tag})` : `#${tag.tag}`,
-  })),
+  ...groupTagOptions.value.map(groupTagOption),
 ])
 const { mutate: setUserGroupTags } = useMutation(setUserGroupTagsMutation)
 const saveUserMainTag = async () => {
@@ -201,10 +199,7 @@ watch(
 const scopeSelectOptions = computed(() => [
   { value: '*all', text: t('userRole.scope.all') },
   { value: '*untagged', text: t('userRole.scope.untagged') },
-  ...groupTagOptions.value.map((tag) => ({
-    value: tag.tag,
-    text: tag.name ? `${tag.name} (#${tag.tag})` : `#${tag.tag}`,
-  })),
+  ...groupTagOptions.value.map(groupTagOption),
 ])
 const { mutate: setModeratorGroupScope } = useMutation(setModeratorGroupScopeMutation)
 const saveScope = async () => {

--- a/admin/src/components/Tables/OpenCreationsTable.vue
+++ b/admin/src/components/Tables/OpenCreationsTable.vue
@@ -203,6 +203,7 @@ import RowDetails from '../RowDetails'
 import EditCreationFormular from '../EditCreationFormular'
 import ContributionMessagesList from '../ContributionMessages/ContributionMessagesList'
 import { useDateFormatter } from '@/composables/useDateFormatter'
+import { groupTagLabels, groupTagOption } from '@/utils/groupTagLabel'
 
 const iconMap = {
   IN_PROGRESS: 'question-square',
@@ -282,10 +283,7 @@ export default {
     groupSelectOptions() {
       return [
         { value: '', text: this.$t('contribution.noGroup') },
-        ...this.groupTags.map((group) => ({
-          value: group.tag,
-          text: group.name ? `${group.name} (#${group.tag})` : `#${group.tag}`,
-        })),
+        ...this.groupTags.map(groupTagOption),
       ]
     },
   },
@@ -428,12 +426,10 @@ export default {
         delete this.groupSelection[contributionId]
       }
     },
-    // Group functions: "Name (#tag)" for the groups a contribution belongs to, shown above
-    // the text. Several groups are listed one after another.
+    // Group functions: the groups a contribution belongs to, shown above the text. The form
+    // itself is decided once in utils/groupTagLabel.
     groupLabel(item) {
-      return (item.groupTags ?? [])
-        .map((group) => (group.name ? `${group.name} (#${group.tag})` : `#${group.tag}`))
-        .join(', ')
+      return groupTagLabels(item.groupTags)
     },
     isAddCommentToMemo(item) {
       return item.closedBy > 0 || item.moderatorId > 0 || item.updatedBy > 0

--- a/admin/src/pages/CreationConfirm.vue
+++ b/admin/src/pages/CreationConfirm.vue
@@ -120,6 +120,7 @@ import { useQuery, useMutation } from '@vue/apollo-composable'
 import { useStore } from 'vuex'
 import { useI18n } from 'vue-i18n'
 import { useModal } from 'bootstrap-vue-next'
+import { groupTagOption } from '@/utils/groupTagLabel'
 
 import Overlay from '../components/Overlay'
 import OpenCreationsTable from '../components/Tables/OpenCreationsTable'
@@ -333,11 +334,6 @@ const visibleGroupTags = computed(() => store.state.moderator?.visibleGroupTags 
 // ungrouped contributions the moderator is assigned to would have no filter that reaches
 // them. Older sessions predate the field, hence the fallback.
 const seesUntagged = computed(() => store.state.moderator?.seesUntagged ?? false)
-
-const groupTagOption = (groupTagItem) => ({
-  value: groupTagItem.tag,
-  text: groupTagItem.name ? `${groupTagItem.name} (#${groupTagItem.tag})` : `#${groupTagItem.tag}`,
-})
 
 const groupTagFilterOptions = computed(() => {
   const allGroups = groupTagsResult.value?.groupTags ?? []

--- a/admin/src/utils/groupTagLabel.js
+++ b/admin/src/utils/groupTagLabel.js
@@ -1,0 +1,24 @@
+// Group functions: how a group is written in the ADMIN wherever it is named -- the
+// contribution rows, the group dropdowns and the moderator scope form.
+//
+// The admin keeps the tag, unlike the wallet (see frontend/src/utils/groupTagLabel.js, which
+// shows the name alone): here the tag is what identifies a mistyped tag on an old
+// contribution, and what a moderator reads when moving one somewhere else.
+//
+// ⚠️ Written out by hand at five sites until now, which is how the copies started to drift.
+// Anything that names a group in the admin belongs here.
+//
+// The one place that deliberately does NOT use this is the adoption dialog's title
+// (GroupTags.vue): it prints the tag separately on the two lines below, so the long form
+// would say it twice.
+export const groupTagLabel = (groupTag) =>
+  groupTag.name ? `${groupTag.name} (#${groupTag.tag})` : `#${groupTag.tag}`
+
+export const groupTagLabels = (groupTags) => (groupTags ?? []).map(groupTagLabel).join(', ')
+
+// The shape the BFormSelect / ThemedSelect options want. The value is the tag, never the id:
+// the whole feature keys on the canonical tag string.
+export const groupTagOption = (groupTag) => ({
+  value: groupTag.tag,
+  text: groupTagLabel(groupTag),
+})

--- a/admin/src/utils/groupTagLabel.spec.js
+++ b/admin/src/utils/groupTagLabel.spec.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { groupTagLabel, groupTagLabels, groupTagOption } from './groupTagLabel'
+
+// ⚠️ The admin's form differs from the wallet's on purpose: it keeps the tag, because the
+// tag is what identifies a mistyped one on an old contribution. A test on both sides is the
+// only thing stopping the two from being "unified" by someone who sees them side by side.
+describe('groupTagLabel', () => {
+  it('writes name and tag together', () => {
+    expect(groupTagLabel({ tag: 'music', name: 'Musik' })).toBe('Musik (#music)')
+  })
+
+  // An old inline hashtag adopted into a group can have no name yet.
+  it('falls back to the bare tag when there is no name', () => {
+    expect(groupTagLabel({ tag: 'sports', name: null })).toBe('#sports')
+    expect(groupTagLabel({ tag: 'sports', name: '' })).toBe('#sports')
+  })
+})
+
+describe('groupTagLabels', () => {
+  it('lists several groups one after another', () => {
+    expect(
+      groupTagLabels([
+        { tag: 'music', name: 'Musik' },
+        { tag: 'sports', name: null },
+      ]),
+    ).toBe('Musik (#music), #sports')
+  })
+
+  it('survives an empty or missing list', () => {
+    expect(groupTagLabels([])).toBe('')
+    expect(groupTagLabels(null)).toBe('')
+    expect(groupTagLabels(undefined)).toBe('')
+  })
+})
+
+describe('groupTagOption', () => {
+  // ⚠️ The value is the TAG, never the id. The whole feature keys on the canonical tag
+  // string, so an option carrying an id would fail only once someone picks it.
+  it('offers the tag as the value and the full label as the text', () => {
+    expect(groupTagOption({ id: 7, tag: 'music', name: 'Musik' })).toEqual({
+      value: 'music',
+      text: 'Musik (#music)',
+    })
+  })
+})

--- a/backend/src/graphql/resolver/util/attachContributionGroupTags.ts
+++ b/backend/src/graphql/resolver/util/attachContributionGroupTags.ts
@@ -1,6 +1,7 @@
 import { ContributionGroupTag as DbContributionGroupTag, GroupTag as DbGroupTag } from 'database'
 import { In } from 'typeorm'
 import { GroupTag } from '@/graphql/model/GroupTag'
+import { groupTagsByContribution } from './groupTagsByContribution'
 
 // Everything this needs of a contribution. Typed structurally rather than as the
 // Contribution model so callers that only care about the group can hand over the two
@@ -32,20 +33,8 @@ export const attachContributionGroupTags = async (
   }
   const canonical = await DbGroupTag.find({
     where: { id: In(links.map((link) => link.groupTagId)) },
-    order: { tag: 'ASC' },
   })
-  const byId = new Map(canonical.map((tag) => [tag.id, tag]))
-
-  const structured = new Map<number, DbGroupTag[]>()
-  for (const link of links) {
-    const tag = byId.get(link.groupTagId)
-    if (!tag) {
-      continue
-    }
-    const list = structured.get(link.contributionId) ?? []
-    list.push(tag)
-    structured.set(link.contributionId, list)
-  }
+  const structured = groupTagsByContribution(links, canonical)
 
   for (const contribution of contributions) {
     contribution.groupTags = (structured.get(contribution.id) ?? []).map((tag) => new GroupTag(tag))

--- a/backend/src/graphql/resolver/util/groupTagsByContribution.test.ts
+++ b/backend/src/graphql/resolver/util/groupTagsByContribution.test.ts
@@ -1,0 +1,82 @@
+import { groupTagsByContribution } from './groupTagsByContribution'
+
+// No database here on purpose: this is the half that can be wrong, and it is worth being
+// able to run it in half a second.
+
+const tags = [
+  { id: 1, tag: 'music' },
+  { id: 2, tag: 'amstetten' },
+  { id: 3, tag: 'sports' },
+]
+
+describe('groupTagsByContribution', () => {
+  it('groups the links under their contribution', () => {
+    const result = groupTagsByContribution(
+      [
+        { contributionId: 10, groupTagId: 1 },
+        { contributionId: 11, groupTagId: 3 },
+      ],
+      tags,
+    )
+
+    expect(result.get(10)?.map((t) => t.tag)).toEqual(['music'])
+    expect(result.get(11)?.map((t) => t.tag)).toEqual(['sports'])
+  })
+
+  // ★ The point of the whole change. The links arrive in insertion order, so without the
+  // sort a contribution in several groups is displayed in whatever order the rows happen to
+  // carry -- and nothing downstream re-sorts. The old code did ask the database to sort, but
+  // threw that away: those rows went into a Map keyed by id while the output was built by
+  // walking the links.
+  it('sorts the groups of one contribution alphabetically, whatever order the links came in', () => {
+    const result = groupTagsByContribution(
+      [
+        { contributionId: 10, groupTagId: 3 },
+        { contributionId: 10, groupTagId: 1 },
+        { contributionId: 10, groupTagId: 2 },
+      ],
+      tags,
+    )
+
+    expect(result.get(10)?.map((t) => t.tag)).toEqual(['amstetten', 'music', 'sports'])
+  })
+
+  it('sorts every contribution, not just the first', () => {
+    const result = groupTagsByContribution(
+      [
+        { contributionId: 10, groupTagId: 3 },
+        { contributionId: 10, groupTagId: 2 },
+        { contributionId: 11, groupTagId: 1 },
+        { contributionId: 11, groupTagId: 2 },
+      ],
+      tags,
+    )
+
+    expect(result.get(10)?.map((t) => t.tag)).toEqual(['amstetten', 'sports'])
+    expect(result.get(11)?.map((t) => t.tag)).toEqual(['amstetten', 'music'])
+  })
+
+  // A link whose group is gone must be skipped, not rendered as a hole.
+  it('skips a link whose group is not among the canonical rows', () => {
+    const result = groupTagsByContribution(
+      [
+        { contributionId: 10, groupTagId: 1 },
+        { contributionId: 10, groupTagId: 99 },
+      ],
+      tags,
+    )
+
+    expect(result.get(10)?.map((t) => t.tag)).toEqual(['music'])
+  })
+
+  it('returns nothing for a contribution without links', () => {
+    const result = groupTagsByContribution([{ contributionId: 10, groupTagId: 1 }], tags)
+
+    expect(result.get(11)).toBeUndefined()
+  })
+
+  it('survives empty input', () => {
+    expect(groupTagsByContribution([], tags).size).toBe(0)
+    expect(groupTagsByContribution([{ contributionId: 10, groupTagId: 1 }], []).size).toBe(0)
+  })
+})

--- a/backend/src/graphql/resolver/util/groupTagsByContribution.ts
+++ b/backend/src/graphql/resolver/util/groupTagsByContribution.ts
@@ -1,0 +1,50 @@
+// Group functions: which groups each contribution belongs to, given the link rows and the
+// canonical group rows.
+//
+// Kept apart from attachContributionGroupTags, and free of any `database` import, so it can
+// be tested without a database -- the two queries around it are plumbing, this is the part
+// that can be wrong.
+//
+// ⚠️ The sorting lives HERE, per contribution, and used to live on the query instead
+// (`order: { tag: 'ASC' }` when loading the canonical rows). There it did nothing: those
+// rows go into a Map keyed by id, and the per-contribution list is assembled by walking the
+// LINKS, whose query carries no ORDER BY. So the database paid for a sort nobody read, and a
+// contribution in several groups was displayed in link-insertion order -- which reaches the
+// screen, since neither the wallet nor the admin re-sorts before rendering.
+
+// The least this needs to know about a group row.
+interface Taggable {
+  id: number
+  tag: string
+}
+
+interface Link {
+  contributionId: number
+  groupTagId: number
+}
+
+export const groupTagsByContribution = <T extends Taggable>(
+  links: Link[],
+  canonical: T[],
+): Map<number, T[]> => {
+  const byId = new Map(canonical.map((tag) => [tag.id, tag]))
+  const structured = new Map<number, T[]>()
+
+  for (const link of links) {
+    const tag = byId.get(link.groupTagId)
+    // A link whose group is gone is skipped rather than rendered as a hole. It cannot
+    // happen through the app -- nothing deletes a group -- but the read must not depend on
+    // that staying true.
+    if (!tag) {
+      continue
+    }
+    const list = structured.get(link.contributionId) ?? []
+    list.push(tag)
+    structured.set(link.contributionId, list)
+  }
+
+  for (const list of structured.values()) {
+    list.sort((a, b) => a.tag.localeCompare(b.tag))
+  }
+  return structured
+}

--- a/frontend/src/components/Contributions/ContributionList.spec.js
+++ b/frontend/src/components/Contributions/ContributionList.spec.js
@@ -1,4 +1,5 @@
-import { myContributionGroupTags } from '@/graphql/contributions.graphql'
+import { listContributions, myContributionGroupTags } from '@/graphql/contributions.graphql'
+import { print } from 'graphql'
 import { useQuery } from '@vue/apollo-composable'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -41,7 +42,12 @@ const router = createRouter({
 vi.mock('@/components/Contributions/ContributionListItem.vue', () => ({
   default: {
     name: 'ContributionListItem',
-    template: '<div></div>',
+    // ⚠️ The stub declares the group prop and prints it. That is what lets a test see the
+    // seam: the item is handed the whole row with v-bind="item", so a field of the query
+    // becomes a prop by NAME alone -- nothing imports one from the other. A stub that
+    // rendered an empty div could not tell whether the field arrived at all.
+    props: ['groupTags'],
+    template: '<div>{{ (groupTags ?? []).map((g) => g.name).join(", ") }}</div>',
   },
 }))
 
@@ -74,6 +80,9 @@ describe('ContributionList', () => {
           memo: 'Ich habe 10 Stunden die Elbwiesen von Müll befreit.',
           amount: '200',
           status: 'IN_PROGRESS',
+          // A real contribution carries its group. Without it the fixture could not show
+          // that the field survives the trip from the query into the item.
+          groupTags: [{ tag: 'choir', name: 'Choir' }],
         },
         {
           id: 1,
@@ -218,5 +227,21 @@ describe('ContributionList', () => {
         expect(wrapper.emitted('update-contribution-form')).toEqual([[{ item: 'item', page: 1 }]])
       })
     })
+
+    // The seam itself: the group survives the trip from the query result into the item.
+    it('hands the group down to the item', () => {
+      expect(wrapper.text()).toContain('Choir')
+    })
+  })
+
+  // ⚠️ The half a fixture cannot cover: that THIS query asks for the field under that very
+  // name. Rename it in the document alone and the assertion above stays green, because the
+  // fixture supplies the prop regardless.
+  //
+  // ⚠️ print(), not loc.source.body: the latter is the whole .graphql FILE, where four
+  // queries select this field -- so it stayed green even with listContributions renamed.
+  // print() renders just this operation.
+  it('is the field this query actually selects', () => {
+    expect(print(listContributions)).toMatch(/\bgroupTags\s*\{/)
   })
 })

--- a/frontend/src/components/Contributions/ContributionListItem.spec.js
+++ b/frontend/src/components/Contributions/ContributionListItem.spec.js
@@ -83,7 +83,7 @@ describe('ContributionListItem', () => {
     amount: '200',
   }
 
-  const mountWrapper = () => {
+  const mountWrapper = (props = {}) => {
     return mount(ContributionListItem, {
       global: {
         plugins: [i18n],
@@ -110,9 +110,30 @@ describe('ContributionListItem', () => {
           BFormTextarea,
         },
       },
-      props: propsData,
+      props: { ...propsData, ...props },
     })
   }
+
+  // ⚠️ This list had NO group coverage at all, while the near-identical community list next
+  // to it has exactly these two cases. The gap matters because ContributionList wires this
+  // item with v-bind="item", so the prop name has to match the GraphQL selection name
+  // character for character: if one of them were renamed and the other were not, every
+  // contribution here would silently fall back to "(no group)" and every other test in this
+  // file would still pass. These two are what makes that visible.
+  describe('the contribution group', () => {
+    it('shows the group name, without the tag', () => {
+      const wrapper = mountWrapper({ groupTags: [{ tag: 'choir', name: 'Choir' }] })
+
+      expect(wrapper.text()).toContain('Choir')
+      expect(wrapper.text()).not.toContain('#choir')
+    })
+
+    // $t is mocked to return the key here, so this pins the key itself -- which is the
+    // useful half: a renamed locale key with an unrenamed call site renders raw.
+    it('says "no group" when the contribution belongs to none', () => {
+      expect(mountWrapper({ groupTags: [] }).text()).toContain('contribution.groupTag.none')
+    })
+  })
 
   describe('mount', () => {
     beforeEach(() => {


### PR DESCRIPTION
Three findings from the review of the upcoming `CreationGroup` rename, delivered ahead of it. Two of them have to land **before** the rename, or they miss their purpose — see below.

## fix(backend): the sorting was computed and thrown away

The canonical rows were loaded with `order: { tag: 'ASC' }`, and it did nothing: those rows go into a Map keyed by id, while the per-contribution list is assembled by walking the **links**, whose own query carries no ORDER BY. The database paid for a sort nobody read, and a contribution in several groups was displayed in link-insertion order — which reaches the screen, since neither app re-sorts before rendering.

Only older contributions carry more than one group, and those are exactly the ones where an arbitrary order reads as a mistake.

The grouping moved into `groupTagsByContribution`, free of any `database` import, so the half that can be wrong runs in half a second instead of needing a database.

## refactor(admin): one place decides how a group is written

`Name (#tag)` was spelled out by hand at five sites across three files. The copies had already started to drift: the adoption panel builds the *wallet's* short form, so it names a group differently from the dropdown two clicks away.

★ **Why this belongs before the rename:** the rename would otherwise have to touch all five sites. One is cheaper and cannot drift.

⚠️ **One site deliberately not converted** — the adoption dialog's title. It prints the tag separately on the two lines below it, so the long form would say the tag twice. That is intent, not drift, and the code now says so rather than leaving the next reader to rediscover it.

## test(frontend): the member's own contribution list had no group coverage

None at all, while the near-identical community list beside it has exactly these two cases.

The gap matters because `ContributionList` wires the item with `v-bind="item"`, so the prop name must match the GraphQL selection name character for character. Rename one without the other and every contribution in "my contributions" silently falls back to "(no group)" — with every other test in the file still passing.

★ **Why this belongs before the rename:** written against the *current* names, it guards the rename. Written afterwards it would only confirm the result.

## Everything was proved to measure

Each of the three had its defect reintroduced, and in each case exactly the intended tests failed and nothing else:

- sorting removed again → the two sorting tests
- label rule changed to the wallet's short form → 3 new tests **and** 3 pre-existing table tests
- prop renamed without its caller → the two new coverage tests

Frontend 81 files / 733 tests, admin 50 / 415, backend lint + typecheck. All green.

## Not in here, on purpose

Two further findings concern the same operation — renaming a group — and belong solved together rather than patched apart: the moderator scope cached in the browser goes stale after a rename, and `editCreationGroup` commits the new slug before migrating the scopes, without a transaction and with no re-run path. Both are pre-existing. They are queued as their own piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when displaying contribution groups and group-selection options.
  * Group tags are now sorted alphabetically and displayed correctly across contributions.
  * Added fallback labels for contributions without a group or tag.

* **Tests**
  * Expanded coverage for group-label formatting, option generation, tag ordering, missing data, and empty inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->