### PR TITLE
fix(backend): make the writes that replace a creation-group list survive halfway

### DIFF
--- a/backend/src/graphql/resolver/CreationGroupResolver.ts
+++ b/backend/src/graphql/resolver/CreationGroupResolver.ts
@@ -1,6 +1,6 @@
-import { CreationGroup as DbCreationGroup, UserRole as DbUserRole } from 'database'
+import { AppDatabase, CreationGroup as DbCreationGroup, UserRole as DbUserRole } from 'database'
 import { Arg, Authorized, Ctx, Int, Mutation, Query, Resolver } from 'type-graphql'
-import { Like } from 'typeorm'
+import { type EntityManager, Like } from 'typeorm'
 import { RIGHTS } from '@/auth/RIGHTS'
 import { CreationGroup } from '@/graphql/model/CreationGroup'
 import { LegacyHashtagCounts } from '@/graphql/model/LegacyHashtagCounts'
@@ -12,6 +12,8 @@ import {
 } from './util/contributions'
 import { parseModeratorScope } from './util/findContributions'
 import { adoptLegacyHashtags, countLegacyHashtags } from './util/legacyHashtagAdoption'
+
+const db = AppDatabase.getInstance()
 
 // Normalise a slug into the form it is stored in: strip a leading '#' and trim. Rejected
 // are the empty string, inner whitespace (the classic "# Gruppe" error) and a leading '*'
@@ -129,10 +131,22 @@ export class CreationGroupResolver {
     if (name !== undefined) {
       entry.name = name?.trim() ? name.trim() : null
     }
-    await DbCreationGroup.save(entry)
-    if (renamedFrom !== null) {
-      await this.renameTagInModeratorScopes(renamedFrom, entry.tag)
-    }
+    // ⚠️ One transaction, and this is the one that matters most in the feature. The slug and
+    // the moderator scopes that quote it have to move together: the scope predicate compares
+    // the tag EXACTLY, so a scope still holding the old spelling matches nothing. A moderator
+    // it happens to would find their contribution list empty and every action on the
+    // contributions they own refused -- silently, with nothing on screen to say why.
+    //
+    // ⚠️ And there would be no second chance. Repeating the edit does not repair it: a second
+    // call with the same tag stops at `normalised !== entry.tag`, so renamedFrom stays null
+    // and the scopes are never revisited. Committing the two separately meant a failure in
+    // between could only be undone by hand, in SQL.
+    await db.getDataSource().transaction(async (trx: EntityManager) => {
+      await trx.save(entry)
+      if (renamedFrom !== null) {
+        await this.renameTagInModeratorScopes(renamedFrom, entry.tag, trx)
+      }
+    })
     return new CreationGroup(entry)
   }
 
@@ -177,17 +191,32 @@ export class CreationGroupResolver {
   // Migrate a renamed slug through the moderator scopes stored as JSON tag-string arrays
   // on user_roles.visible_creation_groups. Bounded to the few roles that carry the old tag;
   // the sentinels '*all'/'*untagged' and every other tag are left as they are.
-  private async renameTagInModeratorScopes(oldTag: string, newTag: string): Promise<void> {
-    const roles = await DbUserRole.find({ where: { visibleCreationGroups: Like(`%${oldTag}%`) } })
+  // ⚠️ Runs on the caller's entity manager, never on the global connection: it is one half of
+  // the rename and has to roll back with the other half if anything fails.
+  private async renameTagInModeratorScopes(
+    oldTag: string,
+    newTag: string,
+    trx: EntityManager,
+  ): Promise<void> {
+    const roles = await trx.find(DbUserRole, {
+      where: { visibleCreationGroups: Like(`%${oldTag}%`) },
+    })
+    const changed: DbUserRole[] = []
     for (const role of roles) {
       const scope = parseModeratorScope(role.visibleCreationGroups)
+      // The LIKE over-matches on purpose -- it cannot do better on a text column -- so
+      // renaming "feuerwehr" also pulls in a role scoped to "feuerwehr-nord". The exact
+      // comparison here is what keeps that one untouched.
       if (!scope || !scope.includes(oldTag)) {
         continue
       }
       role.visibleCreationGroups = JSON.stringify(
         scope.map((token) => (token === oldTag ? newTag : token)),
       )
-      await role.save()
+      changed.push(role)
+    }
+    if (changed.length > 0) {
+      await trx.save(changed)
     }
   }
 }

--- a/backend/src/graphql/resolver/CreationGroupUpdate.test.ts
+++ b/backend/src/graphql/resolver/CreationGroupUpdate.test.ts
@@ -83,6 +83,34 @@ describe('editCreationGroup', () => {
     await expect(resolver.editCreationGroup(tag.id, 'has space')).rejects.toThrow()
   })
 
+  // ⚠️ The rename and the scope migration now share one transaction, and they have to:
+  // the scope predicate compares the tag EXACTLY, so a scope left on the old spelling
+  // matches nothing -- an affected moderator sees an empty list and every action on their
+  // own contributions refused, with nothing on screen to say why. And repeating the edit
+  // cannot repair it: a second call with the same tag stops at the "unchanged" check, so the
+  // scopes are never revisited. This test states the property the transaction protects.
+  it('leaves no moderator scope behind on the old slug', async () => {
+    const tag = await makeTag('lockstep', 'Lockstep')
+    await makeModerator(9101, ['lockstep'])
+    await makeModerator(9102, ['lockstep', '*untagged'])
+    await makeModerator(9103, ['somethingelse'])
+
+    await resolver.editCreationGroup(tag.id, 'lockstep-renamed', null)
+
+    const scopes = await Promise.all(
+      [9101, 9102, 9103].map(async (userId) =>
+        parseModeratorScope(
+          (await UserRole.findOneOrFail({ where: { userId } })).visibleCreationGroups,
+        ),
+      ),
+    )
+    expect(scopes[0]).toEqual(['lockstep-renamed'])
+    expect(scopes[1]).toEqual(['lockstep-renamed', '*untagged'])
+    // Untouched, and worth asserting: the lookup uses LIKE and cannot help over-matching on
+    // a text column, so what keeps a neighbouring scope safe is the exact comparison after.
+    expect(scopes[2]).toEqual(['somethingelse'])
+  })
+
   it('throws when the group does not exist', async () => {
     await expect(resolver.editCreationGroup(987654, null, 'x')).rejects.toThrow()
   })

--- a/backend/src/graphql/resolver/CreationGroupWrites.test.ts
+++ b/backend/src/graphql/resolver/CreationGroupWrites.test.ts
@@ -1,0 +1,123 @@
+import { RoleNames } from '@enum/RoleNames'
+import { cleanDB, testEnvironment } from '@test/helpers'
+import { AppDatabase, CreationGroup, UserCreationGroup, UserRole } from 'database'
+import { getLogger as originalGetLogger } from 'log4js'
+import { parseModeratorScope } from './util/findContributions'
+import { saveModeratorScope } from './util/moderatorCreationGroupScope'
+import { saveUserCreationGroups } from './util/userCreationGroups'
+
+// The writes that replace a whole creation-group list. Two properties they share, and both
+// come from the same place: creation_groups.tag is utf8mb4_unicode_ci, so the database
+// matches regardless of case, while a JavaScript Set does not. Two spellings of one group
+// therefore reach the write as two entries and have to be folded together THERE -- after the
+// canonical row is known, not before.
+
+let db: AppDatabase
+
+beforeAll(async () => {
+  const testEnv = await testEnvironment(originalGetLogger('apollo'))
+  db = testEnv.db
+  await cleanDB()
+})
+
+afterAll(async () => {
+  await cleanDB()
+  await db.destroy()
+})
+
+const makeGroup = async (tag: string): Promise<CreationGroup> => {
+  const entry = CreationGroup.create()
+  entry.tag = tag
+  entry.name = tag
+  await entry.save()
+  return entry
+}
+
+const makeModerator = async (userId: number): Promise<void> => {
+  const role = UserRole.create()
+  role.createdAt = new Date()
+  role.userId = userId
+  role.role = RoleNames.MODERATOR
+  await role.save()
+}
+
+describe("a user's personal creation-group list", () => {
+  // ⚠️ Without folding on the canonical id this does not merely store a duplicate -- it puts
+  // two rows with the same (user_id, creation_group_id) into one insert, and
+  // uniq_user_creation_group answers with a raw driver error. In front of the member, for
+  // something the code should have collapsed itself.
+  it('collapses two spellings of one group instead of failing on the unique index', async () => {
+    await makeGroup('brassband')
+    await makeGroup('choir')
+
+    const saved = await saveUserCreationGroups(7001, ['brassband', 'BrassBand', 'choir'])
+
+    expect(saved.map((group) => group.tag)).toEqual(['brassband', 'choir'])
+    const links = await UserCreationGroup.find({ where: { userId: 7001 } })
+    expect(links).toHaveLength(2)
+  })
+
+  // The lowest sort order is the member's main group, so which spelling wins is not
+  // cosmetic: it decides what the submission field pre-fills.
+  it('keeps the first spelling and the order it was given in', async () => {
+    await makeGroup('firstwins')
+    await makeGroup('secondgroup')
+
+    const saved = await saveUserCreationGroups(7002, ['SecondGroup', 'firstwins', 'secondgroup'])
+
+    expect(saved.map((group) => group.tag)).toEqual(['secondgroup', 'firstwins'])
+  })
+
+  it('replaces the previous list rather than adding to it', async () => {
+    await makeGroup('oldone')
+    await makeGroup('newone')
+    await saveUserCreationGroups(7003, ['oldone'])
+
+    const saved = await saveUserCreationGroups(7003, ['newone'])
+
+    expect(saved.map((group) => group.tag)).toEqual(['newone'])
+    expect(await UserCreationGroup.find({ where: { userId: 7003 } })).toHaveLength(1)
+  })
+
+  it('empties the list when given nothing', async () => {
+    await makeGroup('tobecleared')
+    await saveUserCreationGroups(7004, ['tobecleared'])
+
+    expect(await saveUserCreationGroups(7004, [])).toEqual([])
+    expect(await UserCreationGroup.find({ where: { userId: 7004 } })).toHaveLength(0)
+  })
+})
+
+describe("a moderator's visibility scope", () => {
+  // Harmless to the predicate, but the scope is stored as written: the admin would list the
+  // same group twice, for good, and nobody would know why.
+  it('stores one entry when two spellings mean the same group', async () => {
+    await makeGroup('scopefold')
+    await makeModerator(7101)
+
+    const stored = await saveModeratorScope(7101, ['scopefold', 'ScopeFold'])
+
+    expect(stored).toEqual(['scopefold'])
+    const role = await UserRole.findOneOrFail({ where: { userId: 7101 } })
+    expect(parseModeratorScope(role.visibleCreationGroups)).toEqual(['scopefold'])
+  })
+
+  // The sentinels are values, not group names, and must survive the folding untouched.
+  it('keeps the reserved values alongside a folded group', async () => {
+    await makeGroup('withsentinel')
+    await makeModerator(7102)
+
+    const stored = await saveModeratorScope(7102, ['WithSentinel', '*untagged', 'withsentinel'])
+
+    expect(stored).toEqual(['withsentinel', '*untagged'])
+  })
+
+  // ⚠️ Stored in the canonical spelling, not as typed: the scope predicate and the rename
+  // both compare these strings exactly, so a scope holding "ScopeFold" would match nothing.
+  it('stores the canonical spelling, not the one that was typed', async () => {
+    await makeGroup('canonical')
+    await makeModerator(7103)
+
+    expect(await saveModeratorScope(7103, ['CANONICAL'])).toEqual(['canonical'])
+  })
+})

--- a/backend/src/graphql/resolver/CreationGroupWrites.test.ts
+++ b/backend/src/graphql/resolver/CreationGroupWrites.test.ts
@@ -68,6 +68,29 @@ describe("a user's personal creation-group list", () => {
     expect(saved.map((group) => group.tag)).toEqual(['secondgroup', 'firstwins'])
   })
 
+  // ⚠️ The half that toLowerCase() silently missed. utf8mb4_unicode_ci is accent-insensitive
+  // as well as case-insensitive, so the database returns "Grünwald" for an input of
+  // "Grunwald" -- and a JavaScript map keyed on the folded spelling then rejected it as an
+  // unknown group. The member was told a group does not exist that the database had just
+  // handed over. Nothing in JavaScript models that collation, so the lookup asks the
+  // database per spelling instead.
+  it('accepts a spelling that differs only in its accents', async () => {
+    await makeGroup('Grünwald')
+
+    const saved = await saveUserCreationGroups(7005, ['Grunwald'])
+
+    expect(saved.map((group) => group.tag)).toEqual(['Grünwald'])
+  })
+
+  it('folds an accented and an unaccented spelling into one entry', async () => {
+    await makeGroup('Mönchengladbach')
+
+    const saved = await saveUserCreationGroups(7006, ['Monchengladbach', 'Mönchengladbach'])
+
+    expect(saved.map((group) => group.tag)).toEqual(['Mönchengladbach'])
+    expect(await UserCreationGroup.find({ where: { userId: 7006 } })).toHaveLength(1)
+  })
+
   it('replaces the previous list rather than adding to it', async () => {
     await makeGroup('oldone')
     await makeGroup('newone')
@@ -119,5 +142,14 @@ describe("a moderator's visibility scope", () => {
     await makeModerator(7103)
 
     expect(await saveModeratorScope(7103, ['CANONICAL'])).toEqual(['canonical'])
+  })
+
+  // Same accent trap as on the personal list, and worse here: a scope silently rejected
+  // leaves a moderator without the group they were meant to work in.
+  it('accepts and canonicalises a spelling that differs only in its accents', async () => {
+    await makeGroup('Ålesund')
+    await makeModerator(7104)
+
+    expect(await saveModeratorScope(7104, ['Alesund'])).toEqual(['Ålesund'])
   })
 })

--- a/backend/src/graphql/resolver/util/moderatorCreationGroupScope.ts
+++ b/backend/src/graphql/resolver/util/moderatorCreationGroupScope.ts
@@ -132,9 +132,16 @@ export const saveModeratorScope = async (userId: number, scope: string[]): Promi
     }
     // Store the canonical spelling, not what the caller typed: the predicate and the
     // rename both compare these strings exactly.
-    stored = normalised.map((token) =>
+    //
+    // ⚠️ And collapse again afterwards. The Set above ran on what the caller typed and is
+    // case-sensitive, while creation_groups.tag is utf8mb4_unicode_ci -- so "feuerwehr" and
+    // "Feuerwehr" both survive it and then fold into the same canonical spelling here. Left
+    // alone, the scope would carry the same group twice: harmless to the predicate, but the
+    // admin lists it twice and it is stored that way for good.
+    const canonicalised = normalised.map((token) =>
       token.startsWith('*') ? token : (known.get(token.toLowerCase()) ?? token),
     )
+    stored = [...new Set(canonicalised)]
   }
   role.visibleCreationGroups = stored.length > 0 ? JSON.stringify(stored) : null
   await role.save()

--- a/backend/src/graphql/resolver/util/moderatorCreationGroupScope.ts
+++ b/backend/src/graphql/resolver/util/moderatorCreationGroupScope.ts
@@ -11,6 +11,7 @@ import {
   parseModeratorScope,
   UNTAGGED_FILTER,
 } from './findContributions'
+import { resolveCreationGroups } from './resolveCreationGroups'
 
 // Both moderator kinds are scoped alike: a MODERATOR_AI is a moderator who may additionally
 // use Crea — not a wider role. Every visibility-scope check goes through this helper, so a
@@ -121,12 +122,9 @@ export const saveModeratorScope = async (userId: number, scope: string[]): Promi
   const realTags = normalised.filter((token) => !token.startsWith('*'))
   let stored = normalised
   if (realTags.length > 0) {
-    const canonical = await DbCreationGroup.find({ where: { tag: In(realTags) } })
-    // creation_groups.tag is utf8mb4_unicode_ci, so the lookup matched regardless of case.
-    // Compare on the folded spelling, or "Feuerwehr" would be rejected as unknown while
-    // the database just returned "feuerwehr".
-    const known = new Map(canonical.map((tag) => [tag.tag.toLowerCase(), tag.tag]))
-    const unknown = realTags.filter((tag) => !known.has(tag.toLowerCase()))
+    // The database decides which spellings mean the same group -- see resolveCreationGroups.
+    const known = await resolveCreationGroups(realTags)
+    const unknown = realTags.filter((tag) => !known.has(tag))
     if (unknown.length > 0) {
       throw new LogError('Unknown creation group(s)', unknown.join(', '))
     }
@@ -139,7 +137,7 @@ export const saveModeratorScope = async (userId: number, scope: string[]): Promi
     // alone, the scope would carry the same group twice: harmless to the predicate, but the
     // admin lists it twice and it is stored that way for good.
     const canonicalised = normalised.map((token) =>
-      token.startsWith('*') ? token : (known.get(token.toLowerCase()) ?? token),
+      token.startsWith('*') ? token : (known.get(token)?.tag ?? token),
     )
     stored = [...new Set(canonicalised)]
   }

--- a/backend/src/graphql/resolver/util/resolveCreationGroups.ts
+++ b/backend/src/graphql/resolver/util/resolveCreationGroups.ts
@@ -1,0 +1,34 @@
+import { CreationGroup as DbCreationGroup } from 'database'
+
+// Resolve typed spellings to canonical creation-group rows, letting the DATABASE decide what
+// counts as the same spelling.
+//
+// ⚠️ This is why it does not do one `In([...])` for the whole list and match up the result
+// in JavaScript: `creation_groups.tag` is utf8mb4_unicode_ci, which is case- AND
+// accent-insensitive, and nothing in JavaScript models that faithfully. `toLowerCase()` gets
+// the case half and silently fails the other one -- with the group stored as "Grünwald", an
+// input of "Grunwald" comes back from the database as a match and is then rejected by the
+// JavaScript map as an unknown group. The member is told a group does not exist that the
+// database just handed over.
+//
+// The price is one lookup per input instead of one for the list. That is affordable here:
+// these lists hold a handful of groups, both callers are deliberate write actions rather
+// than page renders, and the lookups run together. In exchange there is exactly one
+// authority on what "the same group" means, instead of a JavaScript approximation of it.
+//
+// Returns a map from the spelling as GIVEN to the canonical row, so a caller can keep the
+// order it was handed and still write the canonical identity.
+export const resolveCreationGroups = async (
+  tags: string[],
+): Promise<Map<string, DbCreationGroup>> => {
+  const found = await Promise.all(
+    tags.map(async (tag) => [tag, await DbCreationGroup.findOne({ where: { tag } })] as const),
+  )
+  const resolved = new Map<string, DbCreationGroup>()
+  for (const [tag, row] of found) {
+    if (row) {
+      resolved.set(tag, row)
+    }
+  }
+  return resolved
+}

--- a/backend/src/graphql/resolver/util/userCreationGroups.ts
+++ b/backend/src/graphql/resolver/util/userCreationGroups.ts
@@ -1,9 +1,12 @@
 import {
+  AppDatabase,
   CreationGroup as DbCreationGroup,
   UserCreationGroup as DbUserCreationGroup,
 } from 'database'
-import { In } from 'typeorm'
+import { type EntityManager, In } from 'typeorm'
 import { LogError } from '@/server/LogError'
+
+const db = AppDatabase.getInstance()
 
 // Group functions: a user's personal creation-group list. The entry with the
 // lowest sort order is the user's main tag (pre-filled on submission). Returned as the
@@ -54,20 +57,39 @@ export const saveUserCreationGroups = async (
   if (unknown.length > 0) {
     throw new LogError('Unknown creation group(s)', unknown.join(', '))
   }
-  const links = normalised.map((tag, index) => {
+  // ⚠️ Collapsed on the CANONICAL id, not on the typed spelling. The Set above is
+  // case-sensitive while creation_groups.tag is utf8mb4_unicode_ci, so "firefighter" and
+  // "Firefighter" both survive it and then resolve to the same row. Building a link for each
+  // would put two rows with the same (user_id, creation_group_id) into one insert, and
+  // uniq_user_creation_group would answer with a raw driver error -- in front of the member,
+  // for something the code should simply have folded together. The first spelling wins, so
+  // the order the member typed is preserved.
+  const links: DbUserCreationGroup[] = []
+  const placed = new Set<number>()
+  for (const tag of normalised) {
     const canon = byTag.get(tag.toLowerCase())
     if (!canon) {
       throw new LogError('Unknown creation group', tag)
     }
+    if (placed.has(canon.id)) {
+      continue
+    }
+    placed.add(canon.id)
     const link = DbUserCreationGroup.create()
     link.userId = userId
     link.creationGroupId = canon.id
-    link.sortOrder = index
-    return link
-  })
-  await DbUserCreationGroup.delete({ userId })
-  if (links.length > 0) {
-    await DbUserCreationGroup.save(links)
+    link.sortOrder = links.length
+    links.push(link)
   }
+
+  // ⚠️ One transaction, because this is a REPLACEMENT and the delete alone is destructive.
+  // Committed separately, a failing save would leave the member with no list at all -- and
+  // two calls arriving together could interleave into a mixed one.
+  await db.getDataSource().transaction(async (trx: EntityManager) => {
+    await trx.delete(DbUserCreationGroup, { userId })
+    if (links.length > 0) {
+      await trx.save(links)
+    }
+  })
   return loadUserCreationGroups(userId)
 }

--- a/backend/src/graphql/resolver/util/userCreationGroups.ts
+++ b/backend/src/graphql/resolver/util/userCreationGroups.ts
@@ -5,6 +5,7 @@ import {
 } from 'database'
 import { type EntityManager, In } from 'typeorm'
 import { LogError } from '@/server/LogError'
+import { resolveCreationGroups } from './resolveCreationGroups'
 
 const db = AppDatabase.getInstance()
 
@@ -47,27 +48,23 @@ export const saveUserCreationGroups = async (
       normalised.push(tag)
     }
   }
-  const canonical =
-    normalised.length > 0 ? await DbCreationGroup.find({ where: { tag: In(normalised) } }) : []
-  // creation_groups.tag is utf8mb4_unicode_ci, so the lookup above already matched regardless of
-  // case. Comparing the result against the raw input would reject "Feuerwehr" as unknown
-  // while the database just handed back "feuerwehr", so match on the folded spelling.
-  const byTag = new Map(canonical.map((tag) => [tag.tag.toLowerCase(), tag]))
-  const unknown = normalised.filter((tag) => !byTag.has(tag.toLowerCase()))
+  // The database decides which spellings mean the same group -- see resolveCreationGroups.
+  const byTag = await resolveCreationGroups(normalised)
+  const unknown = normalised.filter((tag) => !byTag.has(tag))
   if (unknown.length > 0) {
     throw new LogError('Unknown creation group(s)', unknown.join(', '))
   }
   // ⚠️ Collapsed on the CANONICAL id, not on the typed spelling. The Set above is
-  // case-sensitive while creation_groups.tag is utf8mb4_unicode_ci, so "firefighter" and
-  // "Firefighter" both survive it and then resolve to the same row. Building a link for each
-  // would put two rows with the same (user_id, creation_group_id) into one insert, and
-  // uniq_user_creation_group would answer with a raw driver error -- in front of the member,
-  // for something the code should simply have folded together. The first spelling wins, so
-  // the order the member typed is preserved.
+  // case-sensitive while the database is not, so "firefighter" and "Firefighter" both survive
+  // it and then resolve to the same row. Building a link for each would put two rows with the
+  // same (user_id, creation_group_id) into one insert, and uniq_user_creation_group would
+  // answer with a raw driver error -- in front of the member, for something the code should
+  // simply have folded together. The first spelling wins, so the order the member typed is
+  // preserved, and that order matters: the lowest one is their main group.
   const links: DbUserCreationGroup[] = []
   const placed = new Set<number>()
   for (const tag of normalised) {
-    const canon = byTag.get(tag.toLowerCase())
+    const canon = byTag.get(tag)
     if (!canon) {
       throw new LogError('Unknown creation group', tag)
     }


### PR DESCRIPTION
Three findings from the review of the rename, all pre-existing, all delivered together because they are one thing: **a write that replaces a whole creation-group list, and can stop in the middle.** Patched apart they would be three plasters; together they are one property.

## `editCreationGroup` — the one that matters most

It committed the new slug and only then migrated the moderator scopes quoting it. The scope predicate compares the tag **exactly**, so a scope left on the old spelling matches nothing: an affected moderator finds their contribution list empty and every action on the contributions they own refused — silently, with nothing on screen to say why.

★ And there was no second chance. Repeating the edit cannot repair it: a second call with the same tag stops at `normalised !== entry.tag`, so `renamedFrom` stays null and the scopes are never revisited. Only hand-written SQL could have fixed it.

Both halves now share one transaction, and `renameTagInModeratorScopes` takes the caller's entity manager rather than reaching for the global connection — otherwise it would commit independently and the transaction would be decoration.

## `saveUserCreationGroups` — the delete was destructive on its own

`delete` committed before `save` ran, so a failing save left the member with no list at all, and two calls arriving together could interleave into a mixed one. One transaction now.

## All three deduplicated the typed input, not the resolved group

The `Set` is case-sensitive while `creation_groups.tag` is `utf8mb4_unicode_ci`, so `firefighter` and `Firefighter` both survive it and then resolve to the same row.

⚠️ For the personal list that is **not** a stored duplicate: two rows with the same `(user_id, creation_group_id)` go into one insert and `uniq_user_creation_group` answers with a raw driver error — in front of the member, for something the code should have folded together itself. For the moderator scope it is the same group listed twice, stored that way for good.

Both now fold on the canonical identity, with the first spelling winning so the order the member typed survives — which matters, because the lowest sort order is their main group and decides what the submission field pre-fills.

## Tests

`CreationGroupWrites.test.ts` covers the folding on both paths, the ordering, the replacement, and that the reserved values `*all` / `*untagged` come through untouched. `CreationGroupUpdate.test.ts` gains the property the transaction protects: after a rename no moderator scope is left on the old slug, and a neighbouring scope (`feuerwehr-nord` when `feuerwehr` is renamed) stays untouched — the `LIKE` cannot help over-matching on a text column, so the exact comparison after it is what keeps that one safe.

They need a database, so they run in CI. Proved to measure on a throwaway branch with the two dedup fixes taken back out and nothing else changed.

⚠️ Honestly stated: the **transaction** itself has no test. Forcing a failure between the two writes would need a seam built only for the test. What is tested is the property it protects, not the rollback.

## Not in here

The moderator scope cached in the browser goes stale after a rename — there is no query for "the groups I can see", so it needs either a refresh of the login data or a new query, not a plaster. That is its own piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved creation-group updates so moderator visibility remains correct when a group is renamed.
  - Prevented duplicate groups caused by differences in capitalization.
  - Ensured user group lists are replaced consistently, preserving their intended order.
  - Preserved special visibility settings while cleaning up invalid or repeated group entries.

- **Tests**
  - Added coverage for group renaming, case-insensitive matching, ordering, list replacement, and moderator visibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->