### PR TITLE
chore(other): drop the dead browsers from the build target

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -92,7 +92,7 @@
   "browserslist": [
     "> 1%",
     "last 2 versions",
-    "not ie <= 10"
+    "not dead"
   ],
   "resolutions": {
     "strip-ansi": "6.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -118,7 +118,7 @@
   "browserslist": [
     "> 1%",
     "last 2 versions",
-    "not ie <= 10"
+    "not dead"
   ],
   "author": "Gradido-Akademie - https://www.gradido.net/",
   "license": "Apache-2.0",


### PR DESCRIPTION
A follow-up to the review of #3708, where a finding asked for an IE 11 fallback for `:has()`. The fallback would not have helped — the stylesheet uses CSS custom properties 94 times, which IE 11 does not support at all, so dark mode there is not degraded but absent. The real problem was underneath: the build target still claims IE 11.

The line read `not ie <= 10`, which excludes IE 10 and leaves IE 11 in. Resolved today, the target aimed at 34 browsers, among them:

```
ie 11 · ie_mob 10 · ie_mob 11 · bb 7 · bb 10 · baidu 13.52
```

`not dead` says what was meant, and keeps saying it without maintenance: it drops what has had no official support for two years. Measured before and after — the difference is exactly those six, and nothing is added.

**Nothing in the output changes.** The compiled `gradido.css` is byte-identical afterwards, so autoprefixer was not emitting anything on their account anyway. What changes is that the file no longer states a support level nobody honours, and no future review has to argue about it.

Frontend and admin carried the same line; both are updated.

Checked: frontend lint / test (739) / build, admin lint / stylelint / test (422) / build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported browser targeting to focus on currently maintained browsers.
  * Removed explicit support targeting for Internet Explorer 10 and earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->