### PR TITLE
perf(backend): drop two writes and a filter the creation-group paths never needed

### DIFF
--- a/backend/src/graphql/resolver/ContributionResolver.ts
+++ b/backend/src/graphql/resolver/ContributionResolver.ts
@@ -55,7 +55,11 @@ import { UpdateUnconfirmedContributionContext } from '@/interactions/updateUncon
 import { Context, getClientTimezoneOffset, getUser } from '@/server/context'
 import { LogError } from '@/server/LogError'
 import { attachContributionCreationGroups } from './util/attachContributionCreationGroups'
-import { setContributionCreationGroups } from './util/contributionCreationGroups'
+import {
+  linkContributionCreationGroups,
+  resolveContributionCreationGroups,
+  setContributionCreationGroups,
+} from './util/contributionCreationGroups'
 import {
   COMMUNITY_WINDOW_MONTHS,
   contributionFrontendLink,
@@ -120,6 +124,10 @@ export class ContributionResolver {
     const contributionDateObj = new Date(contributionDate)
     validateContribution(creations, amount, contributionDateObj, clientTimezoneOffset)
 
+    // Group functions: resolved before the row exists, so a lookup that fails leaves no
+    // half-written contribution behind.
+    const canonicalGroups = await resolveContributionCreationGroups(creationGroups ?? [])
+
     const contribution = DbContribution.create()
     contribution.userId = user.id
     contribution.amount = amount
@@ -128,10 +136,17 @@ export class ContributionResolver {
     contribution.memo = memo
     contribution.contributionType = ContributionType.USER
     contribution.contributionStatus = ContributionStatus.PENDING
+    // Group functions: stamped on the entity, the same way adminCreateContribution does it,
+    // and for the same reason. A row on its way in has no links to replace and no stamp to
+    // correct, so setContributionCreationGroups would spend a delete that can never match
+    // plus an update on the row inserted one statement earlier. The stamp is written whether
+    // or not a group was chosen -- that is what tells "deliberately no group" apart from
+    // "never said anything".
+    contribution.creationGroupsSetAt = new Date()
 
     logger.trace('contribution to save', contribution)
     await DbContribution.save(contribution)
-    await setContributionCreationGroups(contribution.id, creationGroups ?? [])
+    await linkContributionCreationGroups(contribution.id, canonicalGroups)
     await EVENT_CONTRIBUTION_CREATE(user, contribution, amount)
 
     return new UnconfirmedContribution(contribution)

--- a/backend/src/graphql/resolver/CreationGroupAssignment.test.ts
+++ b/backend/src/graphql/resolver/CreationGroupAssignment.test.ts
@@ -163,6 +163,19 @@ describe('only the group field puts a contribution into a group', () => {
     expect(await listMemos('music')).toContain(ASSIGNED_MUSIC)
   })
 
+  // The stamp is what tells "deliberately no group" apart from "never said anything". Two
+  // features read it and neither would complain if it went missing: the submission field
+  // pre-fills from the last contribution that carries one, and the legacy-hashtag adoption
+  // deliberately passes over any contribution that has one. Submitting writes it either way
+  // -- a group was chosen, or none was -- and it rides along on the insert, so a change to
+  // that path could drop it without a single other test noticing.
+  it('stamps every submission, whether or not a group was chosen', async () => {
+    const withGroup = await DbContribution.findOneOrFail({ where: { memo: ASSIGNED_MUSIC } })
+    const withoutGroup = await DbContribution.findOneOrFail({ where: { memo: DELIBERATELY_NONE } })
+    expect(withGroup.creationGroupsSetAt).toBeInstanceOf(Date)
+    expect(withoutGroup.creationGroupsSetAt).toBeInstanceOf(Date)
+  })
+
   it('ignores a hashtag in a contribution assigned to another group', async () => {
     // The memo says "#music", the group field says sports. The field wins.
     expect(await listMemos('music')).not.toContain(ASSIGNED_ELSEWHERE)

--- a/backend/src/graphql/resolver/util/contributionCreationGroups.ts
+++ b/backend/src/graphql/resolver/util/contributionCreationGroups.ts
@@ -6,22 +6,21 @@ import {
 import { In } from 'typeorm'
 import { LogError } from '@/server/LogError'
 
-// Group functions: set (replace) the structured creation groups of a contribution.
+// Group functions: turn what the caller typed into the canonical CreationGroup rows.
 //
-// This also stamps creation_groups_set_at, including when the group is set to "none". That stamp
-// is what separates "deliberately no group" from "never said anything", which is the only
-// thing the submission pre-fill needs to know.
+// Kept apart from the writing on purpose, and that is what makes it safe to call first: a
+// rejected tag leaves the contribution exactly as it was, instead of stripping its groups on
+// the way to the error.
 //
 // `strict` decides what happens to a tag that is not in the canonical list. On submission it
 // is false on purpose: the field only offers real groups, and a member is not the right
 // person to stop over a stale option. Where a MODERATOR moves a contribution, it is true --
 // dropping the tag there would empty the group, report success, and take the contribution
 // out of every group queue at once. That happened, and only a test caught it.
-export const setContributionCreationGroups = async (
-  contributionId: number,
+export const resolveContributionCreationGroups = async (
   tags: string[],
   { strict = false }: { strict?: boolean } = {},
-): Promise<void> => {
+): Promise<DbCreationGroup[]> => {
   const seen = new Set<string>()
   const normalised: string[] = []
   for (const raw of tags) {
@@ -37,8 +36,6 @@ export const setContributionCreationGroups = async (
       normalised.push(tag)
     }
   }
-  // Resolved before anything is written, so a rejected tag leaves the contribution as it was
-  // instead of stripping its groups on the way to the error.
   const canonical =
     normalised.length > 0 ? await DbCreationGroup.find({ where: { tag: In(normalised) } }) : []
   if (strict) {
@@ -50,9 +47,19 @@ export const setContributionCreationGroups = async (
       throw new LogError('Unknown creation group(s)', unknown.join(', '))
     }
   }
+  return canonical
+}
 
-  await DbContributionCreationGroup.delete({ contributionId })
-  await DbContribution.update({ id: contributionId }, { creationGroupsSetAt: new Date() })
+// Link a contribution to the groups it belongs to. Writes only -- nothing is cleared first,
+// so this alone is right for a row that was just inserted and cannot have links yet. To
+// REPLACE the list of an existing contribution, use setContributionCreationGroups.
+//
+// ⚠️ Whoever calls this instead of setContributionCreationGroups also owes the
+// creation_groups_set_at stamp; on a fresh row that belongs on the entity, before the insert.
+export const linkContributionCreationGroups = async (
+  contributionId: number,
+  canonical: DbCreationGroup[],
+): Promise<void> => {
   if (canonical.length === 0) {
     return
   }
@@ -64,4 +71,20 @@ export const setContributionCreationGroups = async (
       return link
     }),
   )
+}
+
+// Group functions: replace the structured creation groups of an EXISTING contribution.
+//
+// This also stamps creation_groups_set_at, including when the group is set to "none". That stamp
+// is what separates "deliberately no group" from "never said anything", which is the only
+// thing the submission pre-fill needs to know.
+export const setContributionCreationGroups = async (
+  contributionId: number,
+  tags: string[],
+  { strict = false }: { strict?: boolean } = {},
+): Promise<void> => {
+  const canonical = await resolveContributionCreationGroups(tags, { strict })
+  await DbContributionCreationGroup.delete({ contributionId })
+  await DbContribution.update({ id: contributionId }, { creationGroupsSetAt: new Date() })
+  await linkContributionCreationGroups(contributionId, canonical)
 }

--- a/backend/src/graphql/resolver/util/contributions.ts
+++ b/backend/src/graphql/resolver/util/contributions.ts
@@ -175,10 +175,14 @@ const creationGroupsWithContributions = async (
     .distinct(true)
     .innerJoin('contribution_creation_groups', 'cgt', 'cgt.contribution_id = Contribution.id')
     .innerJoin('creation_groups', 'gt', 'gt.id = cgt.creation_group_id')
-    .andWhere('gt.tag IN (:...tags)', { tags })
   narrow(queryBuilder)
   const rows: Array<{ tag: string }> = await queryBuilder.getRawMany()
   const present = new Set(rows.map((row) => row.tag))
+  // Narrowed to the caller's list here rather than in SQL. Both callers hand in the WHOLE
+  // canonical list, so an "IN (every group there is)" could never exclude a row -- the inner
+  // join already reaches creation_groups and nothing else -- while the parameter it ships
+  // grows with every group ever created. This line also covers the one thing that predicate
+  // could not: a group added between the caller reading its list and this query running.
   // Returned in the order the canonical list came in, so the dropdown keeps its sorting.
   return tags.filter((tag) => present.has(tag))
 }


### PR DESCRIPTION
Two findings from the review of the creation-group work, both pure efficiency. No
behaviour changes -- and proving that is what the tests below are for.

## The submission path replaced links it cannot have

`setContributionCreationGroups` exists to REPLACE the groups of a contribution: clear the
links, stamp `creation_groups_set_at`, write the new ones. `createContribution` called it
on a row that was inserted one statement earlier, where the delete can never match a link
and the update rewrites a column of a row that is still warm.

Split into the two halves it was already made of, and both paths share them:

- `resolveContributionCreationGroups` turns what the caller typed into canonical rows
- `linkContributionCreationGroups` writes the links

`createContribution` now resolves *before* the insert -- which also means a tag that
cannot be resolved leaves no half-written contribution behind -- and stamps on the
entity, the way `adminCreateContribution` has done it all along, for the reason already
written in its comment. `setContributionCreationGroups` goes on doing the replacing for
the moderator path, out of those same two halves, so nothing is spelled out twice.

### and the stamp only had a test by accident

The stamp is what tells "deliberately no group" apart from "never said anything". Two
features read it -- the submission pre-fill and the legacy-hashtag adoption -- but
nothing asserted it where it is written; it was covered sideways, through two pre-fill
tests in another file. Now it is named and asserted on the submission path itself.

Measured rather than assumed: on a throwaway branch with only the stamp line removed,
exactly three tests fail -- the new one plus those two pre-fill tests -- with 654
passing. On this branch all nine fork CI runs are green.

## A group filter that can never exclude a row

The dropdown query narrowed on `gt.tag IN (:...tags)`. Both callers hand in the whole
canonical list, and every row the inner join can reach is in it by construction, so the
predicate has never excluded anything -- while shipping a parameter that grows with every
group ever created, on both of the wallet list renders that ask.

The intersection was already being done in JavaScript on the way out, and it has to stay
there in any case: it is what keeps the dropdown in the canonical order, and it covers
the one thing the predicate could not -- a group added between the caller reading its
list and this query running.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contributions now reliably record when creation-group assignment is set, including when no group is selected.
  * Creation-group assignments are validated, normalized, and linked more consistently during contribution submission.
  * Improved filtering of contributions by their associated creation groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->