### PR TITLE
feat(admin): group crea's contribution checklist by resubmission

### DIFF
--- a/admin/src/components/CreaEvaluationModal.spec.js
+++ b/admin/src/components/CreaEvaluationModal.spec.js
@@ -145,3 +145,140 @@ describe('CreaEvaluationModal — salutation', () => {
     expect(RAW_REPLY).toContain('[ANREDE]')
   })
 })
+
+// The batch checklist splits by resubmission (E-026): untouched contributions on top and
+// preselected, everything already put off below and unticked. "Put off" means here what it
+// means behind the modal - a date still ahead - so a date that has passed moves the
+// contribution back up into its own group instead of hiding among the pending ones.
+describe('CreaEvaluationModal — resubmission grouping', () => {
+  const HOUR = 60 * 60 * 1000
+  const past = () => new Date(Date.now() - 24 * HOUR).toISOString()
+  const future = () => new Date(Date.now() + 24 * HOUR).toISOString()
+
+  // One participant, one of each kind, deliberately NOT in group order: the component has
+  // to sort them, and a list that arrives pre-sorted could not tell us whether it does.
+  const siblings = () => [
+    contribution({ id: 1, memo: 'Nie zurueckgestellt' }),
+    contribution({ id: 2, memo: 'Wiedervorlage erreicht', resubmissionAt: past() }),
+    contribution({ id: 3, memo: 'Liegt in Wiedervorlage', resubmissionAt: future() }),
+    contribution({ id: 4, memo: 'Auch nie zurueckgestellt' }),
+  ]
+
+  const mountBatch = (clicked = 1) =>
+    mount(CreaEvaluationModal, {
+      props: { contribution: siblings().find((c) => c.id === clicked) },
+      global: { stubs, mocks: { $t: (key) => key } },
+    })
+
+  const open = async (wrapper) => {
+    wrapper.findComponent({ name: 'BModal' }).vm.$emit('shown')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await nextTick()
+  }
+
+  // The ids of the checkboxes in the order they are rendered, which is what the moderator
+  // reads top to bottom.
+  const renderedIds = (wrapper) =>
+    wrapper.findAll('input[id^="crea-pick-"]').map((input) => input.attributes('id'))
+
+  const mockSiblings = (list) => {
+    useApolloClient.mockReturnValue({
+      resolveClient: () => ({
+        query: vi.fn(async () => ({
+          data: { adminListContributions: { contributionList: list } },
+        })),
+      }),
+    })
+  }
+
+  beforeEach(() => {
+    useMutation.mockReturnValue({ mutate: vi.fn() })
+    mockSiblings(siblings())
+  })
+
+  it('orders the checklist untouched, due, then put off', async () => {
+    const wrapper = mountBatch()
+    await open(wrapper)
+    expect(renderedIds(wrapper)).toEqual([
+      'crea-pick-1',
+      'crea-pick-4',
+      'crea-pick-2',
+      'crea-pick-3',
+    ])
+  })
+
+  // Read the headings as elements, not as substrings of the rendered text: the due key
+  // has the other one as its prefix, so a text search cannot tell them apart.
+  const headings = (wrapper) =>
+    wrapper.findAll('p.crea-section-heading').map((heading) => heading.text())
+
+  it('heads the two resubmission groups and rules them off', async () => {
+    const wrapper = mountBatch()
+    await open(wrapper)
+    expect(headings(wrapper)).toEqual(['crea.resubmissionDue', 'crea.resubmission'])
+    expect(wrapper.findAll('hr.crea-section-rule')).toHaveLength(2)
+  })
+
+  it('preselects only what was never put off', async () => {
+    const wrapper = mountBatch()
+    await open(wrapper)
+    expect(wrapper.vm.selectedIds).toEqual([1, 4])
+  })
+
+  // Bernd's call, and the reason the middle group exists at all: a due contribution has
+  // been handled once before, so it does not come back preselected either.
+  it('leaves a due resubmission unticked', async () => {
+    const wrapper = mountBatch()
+    await open(wrapper)
+    expect(wrapper.vm.selectedIds).not.toContain(2)
+    expect(wrapper.vm.groupedContributions.due.map((c) => c.id)).toEqual([2])
+  })
+
+  // Whichever button was pressed, that contribution is the one the moderator asked about.
+  it('keeps the clicked contribution ticked inside the put-off group', async () => {
+    const wrapper = mountBatch(3)
+    await open(wrapper)
+    expect(wrapper.vm.selectedIds).toEqual([1, 3, 4])
+    expect(renderedIds(wrapper).at(-1)).toBe('crea-pick-3')
+  })
+
+  it('ticks nothing but the clicked one when everything is put off', async () => {
+    mockSiblings([
+      contribution({ id: 7, resubmissionAt: future() }),
+      contribution({ id: 8, resubmissionAt: future() }),
+    ])
+    const wrapper = mount(CreaEvaluationModal, {
+      props: { contribution: contribution({ id: 8, resubmissionAt: future() }) },
+      global: { stubs, mocks: { $t: (key) => key } },
+    })
+    await open(wrapper)
+    expect(wrapper.vm.selectedIds).toEqual([8])
+  })
+
+  // Nothing put off means nothing to separate: the participant whose contributions were
+  // never touched sees the plain preselected list the modal always showed.
+  it('shows no heading and no rule when nothing was put off', async () => {
+    mockSiblings([contribution({ id: 5 }), contribution({ id: 6 })])
+    const wrapper = mountBatch()
+    await open(wrapper)
+    expect(headings(wrapper)).toEqual([])
+    expect(wrapper.findAll('hr.crea-section-rule')).toHaveLength(0)
+    expect(wrapper.vm.selectedIds).toEqual([5, 6])
+  })
+
+  // A null date must not read as 1970 and drop the contribution into the due group -
+  // new Date(null) is the epoch, so the empty case has to be caught before parsing.
+  it('treats a missing date as never put off', async () => {
+    mockSiblings([
+      contribution({ id: 9, resubmissionAt: null }),
+      contribution({ id: 10, resubmissionAt: past() }),
+    ])
+    const wrapper = mount(CreaEvaluationModal, {
+      props: { contribution: contribution({ id: 9 }) },
+      global: { stubs, mocks: { $t: (key) => key } },
+    })
+    await open(wrapper)
+    expect(wrapper.vm.groupedContributions.open.map((c) => c.id)).toEqual([9])
+    expect(wrapper.vm.selectedIds).toEqual([9])
+  })
+})

--- a/admin/src/components/CreaEvaluationModal.vue
+++ b/admin/src/components/CreaEvaluationModal.vue
@@ -801,6 +801,9 @@ const rewriteForDecision = async () => {
 // session (or after a re-login) never showed up without a full page reload.
 const onShown = async () => {
   moderatorSignature.value = loadSignature()
+  // Before the query, not after it: a slow connection must not move a contribution from
+  // one group to another, and the moderator asked for this list when they opened it.
+  openedAt.value = new Date()
   // Load the participant's open contributions: two or more -> batch checklist (no
   // auto-evaluate; the moderator prunes then presses "Bewerten"). Otherwise the single
   // contribution is evaluated right away, as before. Fall back to single on any error.
@@ -818,7 +821,6 @@ const onShown = async () => {
     loadedSalutation.value = siblings[0].user?.salutation ?? null
   }
   if (siblings.length >= 2) {
-    openedAt.value = new Date()
     contributions.value = siblings
     // Preselect what was never put off (E-026). Anything with a resubmission date has
     // been handled once already and starts unticked - also when the date has arrived,

--- a/admin/src/components/CreaEvaluationModal.vue
+++ b/admin/src/components/CreaEvaluationModal.vue
@@ -49,25 +49,32 @@
         </span>
       </div>
 
-      <!-- Batch mode (E-020): the participant's open contributions as a checklist, all
-           preselected; unchecking one leaves it out. Nothing runs until "Bewerten". -->
+      <!-- Batch mode (E-020): the participant's open contributions as a checklist, split
+           by resubmission (E-026). Untouched ones come preselected, anything put off
+           starts unticked; ticking is free either way. Nothing runs until "Bewerten". -->
       <template v-if="isBatch">
         <p class="mb-2 text-muted small">{{ $t('crea.selectHint') }}</p>
-        <div v-for="c in contributions" :key="c.id" class="form-check mb-2">
-          <input
-            :id="`crea-pick-${c.id}`"
-            v-model="selectedIds"
-            :value="c.id"
-            type="checkbox"
-            class="form-check-input"
-          />
-          <label :for="`crea-pick-${c.id}`" class="form-check-label d-block">
-            <span v-if="contributionMetaOf(c)" class="text-muted small d-block">
-              {{ contributionMetaOf(c) }}
-            </span>
-            <span class="text-break crea-original">{{ c.memo }}</span>
-          </label>
-        </div>
+        <template v-for="(section, index) in contributionSections" :key="section.key">
+          <hr v-if="index > 0" class="crea-section-rule" />
+          <p v-if="section.heading" class="crea-section-heading mb-2 fw-bold small">
+            {{ section.heading }}
+          </p>
+          <div v-for="c in section.items" :key="c.id" class="form-check mb-2">
+            <input
+              :id="`crea-pick-${c.id}`"
+              v-model="selectedIds"
+              :value="c.id"
+              type="checkbox"
+              class="form-check-input"
+            />
+            <label :for="`crea-pick-${c.id}`" class="form-check-label d-block">
+              <span v-if="contributionMetaOf(c)" class="text-muted small d-block">
+                {{ contributionMetaOf(c) }}
+              </span>
+              <span class="text-break crea-original">{{ c.memo }}</span>
+            </label>
+          </div>
+        </template>
       </template>
 
       <!-- Single mode: the one contribution verbatim, as before. -->
@@ -381,10 +388,48 @@ const supplementText = ref('')
 
 // Batch mode (E-020): the participant's open contributions, loaded when the modal
 // opens. Two or more -> batch mode (checklist + "Bewerten"); fewer -> the single
-// contribution path as before. selectedIds holds the ticked ones (all preselected).
+// contribution path as before. selectedIds holds the ticked ones.
 const contributions = ref([])
 const selectedIds = ref([])
 const isBatch = computed(() => contributions.value.length >= 2)
+
+// The clock the checklist is built against, taken once when the window opens. Grouping
+// and preselection have to agree on one instant, otherwise a contribution could count
+// as due in the list and as still pending for the tick.
+const openedAt = ref(new Date())
+
+// The checklist splits by resubmission (E-026). "Put off" means the same thing here as
+// behind the modal, where the list's "Wiedervorlage verbergen" hides exactly those whose
+// date still lies ahead (findContributions.ts): a date that has passed puts the
+// contribution back on the table. Three groups, in the order the moderator works them:
+//   open  - never put off
+//   due   - was put off, the date has arrived
+//   later - put off, the date is still ahead
+const groupedContributions = computed(() => {
+  const groups = { open: [], due: [], later: [] }
+  for (const c of contributions.value) {
+    if (!c.resubmissionAt) {
+      groups.open.push(c)
+      continue
+    }
+    // An unreadable date still means the contribution was handled once, so it counts as
+    // put off rather than falling back into the untouched group.
+    const at = new Date(c.resubmissionAt)
+    groups[at > openedAt.value ? 'later' : 'due'].push(c)
+  }
+  return groups
+})
+
+// Empty groups drop out entirely, so a participant with nothing put off sees the plain
+// list as before - no rule, no heading.
+const contributionSections = computed(() => {
+  const { open, due, later } = groupedContributions.value
+  return [
+    { key: 'open', heading: '', items: open },
+    { key: 'due', heading: t('crea.resubmissionDue'), items: due },
+    { key: 'later', heading: t('crea.resubmission'), items: later },
+  ].filter((section) => section.items.length > 0)
+})
 // "Crea liest den Beitrag" (one) vs "... die Beiträge" (several) while evaluating.
 const loadingText = computed(() => {
   const count = isBatch.value ? selectedIds.value.length : 1
@@ -773,8 +818,17 @@ const onShown = async () => {
     loadedSalutation.value = siblings[0].user?.salutation ?? null
   }
   if (siblings.length >= 2) {
+    openedAt.value = new Date()
     contributions.value = siblings
-    selectedIds.value = siblings.map((c) => c.id)
+    // Preselect what was never put off (E-026). Anything with a resubmission date has
+    // been handled once already and starts unticked - also when the date has arrived,
+    // because "seen before" is what decides, not "due today". The contribution whose
+    // button was clicked stays ticked wherever it sits: the moderator asked for it.
+    const preselected = new Set(groupedContributions.value.open.map((c) => c.id))
+    if (props.contribution?.id != null) {
+      preselected.add(props.contribution.id)
+    }
+    selectedIds.value = siblings.filter((c) => preselected.has(c.id)).map((c) => c.id)
   } else {
     contributions.value = []
     runEvaluation()
@@ -833,6 +887,12 @@ const copyResponse = async () => {
 <style scoped>
 .crea-original {
   white-space: pre-line;
+}
+
+/* Separates the checklist's resubmission groups (E-026). Tighter above than a stock
+   <hr> so the rule reads as belonging to the heading below it, not floating between. */
+.crea-section-rule {
+  margin: 1rem 0 0.5rem;
 }
 
 .crea-title-logo {

--- a/admin/src/locales/de.json
+++ b/admin/src/locales/de.json
@@ -118,6 +118,8 @@
     "previewBanner": "Vorschau ohne KI-Verbindung – ein Beispiel-Ergebnis. Optik, Datenbank und Anrede/Signatur sind echt.",
     "reasoning": "Begründung",
     "response": "Antwortvorschlag",
+    "resubmission": "Wiedervorlage",
+    "resubmissionDue": "Wiedervorlage fällig",
     "rewrite": "Für meine Entscheidung schreiben",
     "salutation": "Anrede",
     "salutationHint": "So wird dieser Mensch angesprochen. Änderst Du sie hier, zieht der Textvorschlag sofort mit. Mit „Anrede speichern“ steht sie beim nächsten Beitrag schon da.",

--- a/admin/src/locales/el.json
+++ b/admin/src/locales/el.json
@@ -118,6 +118,8 @@
     "previewBanner": "Preview without AI connection – a sample result. Layout, database and salutation/signature are real.",
     "reasoning": "Reasoning",
     "response": "Suggested reply",
+    "resubmission": "Υπενθύμιση",
+    "resubmissionDue": "Ληγμένη υπενθύμιση",
     "rewrite": "Write for my decision",
     "salutation": "Salutation",
     "salutationHint": "How this person is addressed. Change it here and the draft follows at once. Use Save salutation and next time it is already filled in.",

--- a/admin/src/locales/en.json
+++ b/admin/src/locales/en.json
@@ -118,6 +118,8 @@
     "previewBanner": "Preview without AI connection – a sample result. Layout, database and salutation/signature are real.",
     "reasoning": "Reasoning",
     "response": "Suggested reply",
+    "resubmission": "Resubmission",
+    "resubmissionDue": "Resubmission due",
     "rewrite": "Write for my decision",
     "salutation": "Salutation",
     "salutationHint": "How this person is addressed. Change it here and the draft follows at once. Use Save salutation and next time it is already filled in.",

--- a/admin/src/locales/es.json
+++ b/admin/src/locales/es.json
@@ -118,6 +118,8 @@
     "previewBanner": "Preview without AI connection – a sample result. Layout, database and salutation/signature are real.",
     "reasoning": "Reasoning",
     "response": "Suggested reply",
+    "resubmission": "Recordatorio",
+    "resubmissionDue": "Recordatorio vencido",
     "rewrite": "Write for my decision",
     "salutation": "Salutation",
     "salutationHint": "How this person is addressed. Change it here and the draft follows at once. Use Save salutation and next time it is already filled in.",

--- a/admin/src/locales/fr.json
+++ b/admin/src/locales/fr.json
@@ -118,6 +118,8 @@
     "previewBanner": "Preview without AI connection – a sample result. Layout, database and salutation/signature are real.",
     "reasoning": "Reasoning",
     "response": "Suggested reply",
+    "resubmission": "Rappel",
+    "resubmissionDue": "Rappel échu",
     "rewrite": "Write for my decision",
     "salutation": "Salutation",
     "salutationHint": "How this person is addressed. Change it here and the draft follows at once. Use Save salutation and next time it is already filled in.",

--- a/admin/src/locales/it.json
+++ b/admin/src/locales/it.json
@@ -118,6 +118,8 @@
     "previewBanner": "Preview without AI connection – a sample result. Layout, database and salutation/signature are real.",
     "reasoning": "Reasoning",
     "response": "Suggested reply",
+    "resubmission": "Promemoria",
+    "resubmissionDue": "Promemoria scaduto",
     "rewrite": "Write for my decision",
     "salutation": "Salutation",
     "salutationHint": "How this person is addressed. Change it here and the draft follows at once. Use Save salutation and next time it is already filled in.",

--- a/admin/src/locales/nl.json
+++ b/admin/src/locales/nl.json
@@ -118,6 +118,8 @@
     "previewBanner": "Preview without AI connection – a sample result. Layout, database and salutation/signature are real.",
     "reasoning": "Reasoning",
     "response": "Suggested reply",
+    "resubmission": "Herinnering",
+    "resubmissionDue": "Herinnering verlopen",
     "rewrite": "Write for my decision",
     "salutation": "Salutation",
     "salutationHint": "How this person is addressed. Change it here and the draft follows at once. Use Save salutation and next time it is already filled in.",

--- a/admin/src/locales/pt.json
+++ b/admin/src/locales/pt.json
@@ -118,6 +118,8 @@
     "previewBanner": "Preview without AI connection – a sample result. Layout, database and salutation/signature are real.",
     "reasoning": "Reasoning",
     "response": "Suggested reply",
+    "resubmission": "Lembrete",
+    "resubmissionDue": "Lembrete vencido",
     "rewrite": "Write for my decision",
     "salutation": "Salutation",
     "salutationHint": "How this person is addressed. Change it here and the draft follows at once. Use Save salutation and next time it is already filled in.",

--- a/admin/src/locales/ru.json
+++ b/admin/src/locales/ru.json
@@ -118,6 +118,8 @@
     "previewBanner": "Preview without AI connection – a sample result. Layout, database and salutation/signature are real.",
     "reasoning": "Reasoning",
     "response": "Suggested reply",
+    "resubmission": "Напоминание",
+    "resubmissionDue": "Напоминание истекло",
     "rewrite": "Write for my decision",
     "salutation": "Salutation",
     "salutationHint": "How this person is addressed. Change it here and the draft follows at once. Use Save salutation and next time it is already filled in.",

--- a/admin/src/locales/tr.json
+++ b/admin/src/locales/tr.json
@@ -118,6 +118,8 @@
     "previewBanner": "Preview without AI connection – a sample result. Layout, database and salutation/signature are real.",
     "reasoning": "Reasoning",
     "response": "Suggested reply",
+    "resubmission": "Hatırlatma",
+    "resubmissionDue": "Hatırlatma zamanı geldi",
     "rewrite": "Write for my decision",
     "salutation": "Salutation",
     "salutationHint": "How this person is addressed. Change it here and the draft follows at once. Use Save salutation and next time it is already filled in.",


### PR DESCRIPTION
## What this changes

Crea's batch checklist listed every open contribution of a participant in one block, all
preselected. It did not say which of them a moderator had already handled once and put off,
so a contribution waiting for its resubmission date went into the evaluation as if it were
untouched.

The checklist now splits into three groups, in the order a moderator works them:

| group | preselected |
|---|---|
| never put off | yes, as before |
| resubmission date reached | no |
| still put off | no |

A rule and a heading separate them. Empty groups drop out entirely, so a participant with
nothing put off sees the same plain list as before — no rule, no heading.

Both lower groups start unticked, including the due one: what decides is that the
contribution has been seen before, not whether its date has arrived. Ticking any of them by
hand works exactly as before. The contribution whose button was clicked stays ticked
wherever it sits, because that is the one the moderator asked about.

## Why "put off" means a date in the future

The same thing it means in the list behind the modal, where `hideResubmission` hides exactly
those whose date still lies ahead (`findContributions.ts`). A date that has passed puts the
contribution back on the table, which is why it gets its own group instead of sitting at the
bottom. Two places in one admin should not read the same word differently.

Grouping and preselection read one clock, taken when the window opens, so a contribution
cannot count as due in the list and as pending for the tick.

## Scope

Admin only. No backend change — `resubmissionAt` already comes with
`adminListContributions`. Ten locales get two keys each, following the wording each language
already uses for resubmission in this admin.

## Verification

- 8 new specs; 430 admin tests green, lint, stylelint, locales, build
- The new specs were measured rather than assumed: restoring the old preselection fails 5 of
  them, removing the ordering fails 3
- Deployed to the staging system and accepted there


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Batch contributions are grouped into open, due, and later resubmission sections.
  - Untouched contributions are preselected, while previously handled contributions remain unselected.
  - Contributions selected before opening the modal remain selected.
  - Added clear section separators and resubmission status labels.

- **Localization**
  - Added translated resubmission and due-status labels across supported languages.

- **Tests**
  - Added coverage for grouping, ordering, selection behavior, empty lists, and missing dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->