### PR TITLE
fix(admin): do not let the crea settings page save a form it has not read

### DIFF
--- a/admin/src/locales/de.json
+++ b/admin/src/locales/de.json
@@ -150,7 +150,8 @@
       "testModel": "Modell testen",
       "testNoText": "(kein Text in der Antwort)",
       "testOk": "Modell antwortet: {message}",
-      "title": "Crea-Einstellungen"
+      "title": "Crea-Einstellungen",
+      "unavailable": "Die Einstellungen sind noch nicht geladen. Speichern und Testen bleiben gesperrt, bis der Stand vom Server bekannt ist."
     },
     "signature": "Deine Signatur",
     "signatureHint": "Wird in Deinem Browser gespeichert und automatisch ans Ende des Vorschlags gesetzt.",

--- a/admin/src/locales/el.json
+++ b/admin/src/locales/el.json
@@ -150,7 +150,8 @@
       "testModel": "Test model",
       "testNoText": "(no text in the response)",
       "testOk": "Model responds: {message}",
-      "title": "Crea settings"
+      "title": "Crea settings",
+      "unavailable": "The settings are not loaded yet. Saving and testing stay disabled until the values from the server are known."
     },
     "signature": "Your signature",
     "signatureHint": "Saved in your browser (preview). Persistent storage will follow.",

--- a/admin/src/locales/en.json
+++ b/admin/src/locales/en.json
@@ -150,7 +150,8 @@
       "testModel": "Test model",
       "testNoText": "(no text in the response)",
       "testOk": "Model responds: {message}",
-      "title": "Crea settings"
+      "title": "Crea settings",
+      "unavailable": "The settings are not loaded yet. Saving and testing stay disabled until the values from the server are known."
     },
     "signature": "Your signature",
     "signatureHint": "Saved in your browser and added to the end of the reply automatically.",

--- a/admin/src/locales/es.json
+++ b/admin/src/locales/es.json
@@ -150,7 +150,8 @@
       "testModel": "Test model",
       "testNoText": "(no text in the response)",
       "testOk": "Model responds: {message}",
-      "title": "Crea settings"
+      "title": "Crea settings",
+      "unavailable": "The settings are not loaded yet. Saving and testing stay disabled until the values from the server are known."
     },
     "signature": "Your signature",
     "signatureHint": "Saved in your browser (preview). Persistent storage will follow.",

--- a/admin/src/locales/fr.json
+++ b/admin/src/locales/fr.json
@@ -150,7 +150,8 @@
       "testModel": "Test model",
       "testNoText": "(no text in the response)",
       "testOk": "Model responds: {message}",
-      "title": "Crea settings"
+      "title": "Crea settings",
+      "unavailable": "The settings are not loaded yet. Saving and testing stay disabled until the values from the server are known."
     },
     "signature": "Your signature",
     "signatureHint": "Saved in your browser (preview). Persistent storage will follow.",

--- a/admin/src/locales/it.json
+++ b/admin/src/locales/it.json
@@ -150,7 +150,8 @@
       "testModel": "Test model",
       "testNoText": "(no text in the response)",
       "testOk": "Model responds: {message}",
-      "title": "Crea settings"
+      "title": "Crea settings",
+      "unavailable": "The settings are not loaded yet. Saving and testing stay disabled until the values from the server are known."
     },
     "signature": "Your signature",
     "signatureHint": "Saved in your browser (preview). Persistent storage will follow.",

--- a/admin/src/locales/nl.json
+++ b/admin/src/locales/nl.json
@@ -150,7 +150,8 @@
       "testModel": "Test model",
       "testNoText": "(no text in the response)",
       "testOk": "Model responds: {message}",
-      "title": "Crea settings"
+      "title": "Crea settings",
+      "unavailable": "The settings are not loaded yet. Saving and testing stay disabled until the values from the server are known."
     },
     "signature": "Your signature",
     "signatureHint": "Saved in your browser (preview). Persistent storage will follow.",

--- a/admin/src/locales/pt.json
+++ b/admin/src/locales/pt.json
@@ -150,7 +150,8 @@
       "testModel": "Test model",
       "testNoText": "(no text in the response)",
       "testOk": "Model responds: {message}",
-      "title": "Crea settings"
+      "title": "Crea settings",
+      "unavailable": "The settings are not loaded yet. Saving and testing stay disabled until the values from the server are known."
     },
     "signature": "Your signature",
     "signatureHint": "Saved in your browser (preview). Persistent storage will follow.",

--- a/admin/src/locales/ru.json
+++ b/admin/src/locales/ru.json
@@ -150,7 +150,8 @@
       "testModel": "Test model",
       "testNoText": "(no text in the response)",
       "testOk": "Model responds: {message}",
-      "title": "Crea settings"
+      "title": "Crea settings",
+      "unavailable": "The settings are not loaded yet. Saving and testing stay disabled until the values from the server are known."
     },
     "signature": "Your signature",
     "signatureHint": "Saved in your browser (preview). Persistent storage will follow.",

--- a/admin/src/locales/tr.json
+++ b/admin/src/locales/tr.json
@@ -150,7 +150,8 @@
       "testModel": "Test model",
       "testNoText": "(no text in the response)",
       "testOk": "Model responds: {message}",
-      "title": "Crea settings"
+      "title": "Crea settings",
+      "unavailable": "The settings are not loaded yet. Saving and testing stay disabled until the values from the server are known."
     },
     "signature": "Your signature",
     "signatureHint": "Saved in your browser (preview). Persistent storage will follow.",

--- a/admin/src/pages/CreaSettings.spec.js
+++ b/admin/src/pages/CreaSettings.spec.js
@@ -1,0 +1,163 @@
+// AI-GENERATED — not an architecture reference
+import { mount } from '@vue/test-utils'
+import { nextTick, ref } from 'vue'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import CreaSettings from './CreaSettings.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key) => key,
+    d: (value) => String(value),
+  }),
+}))
+
+// The server's answer. A real ref, not a plain object: the component watches it, and a
+// test needs to hand the answer over AFTER the mount to see the gate open.
+const creaSettingsResult = ref(null)
+const creaSettingsError = ref(null)
+
+const ANSWER = {
+  creaSettings: {
+    model: 'claude-opus-5',
+    effort: 'high',
+    fastMode: true,
+    defaultModel: 'claude-sonnet-5',
+  },
+}
+
+vi.mock('@vue/apollo-composable', () => ({
+  useMutation: vi.fn(() => ({ mutate: vi.fn() })),
+  useQuery: vi.fn(() => ({
+    result: creaSettingsResult,
+    error: creaSettingsError,
+  })),
+}))
+
+vi.mock('vuex', () => ({
+  useStore: vi.fn(() => ({
+    state: { moderator: { id: 0, name: 'test moderator', roles: ['ADMIN'] } },
+  })),
+}))
+
+vi.mock('@/composables/useToast', () => ({
+  useAppToast: () => ({ toastSuccess: vi.fn(), toastError: vi.fn() }),
+}))
+
+const mockBFormGroup = {
+  name: 'BFormGroup',
+  template: '<div class="mock-bformgroup"><slot></slot></div>',
+}
+const mockBFormInput = {
+  name: 'BFormInput',
+  props: ['modelValue'],
+  template: '<input data-testid="mock-bforminput" />',
+}
+const mockBFormSelect = {
+  name: 'BFormSelect',
+  props: ['modelValue', 'options'],
+  template: '<select data-testid="mock-bformselect"></select>',
+}
+const mockBFormCheckbox = {
+  name: 'BFormCheckbox',
+  props: ['modelValue'],
+  template: '<label class="mock-bformcheckbox"><slot></slot></label>',
+}
+// Declares `disabled` on purpose: without it the binding would land in attrs and the
+// assertions below would pass against an ungated button.
+const mockBButton = {
+  name: 'BButton',
+  props: ['disabled'],
+  template: '<button :disabled="disabled"><slot></slot></button>',
+}
+
+describe('CreaSettings', () => {
+  let wrapper
+
+  const createWrapper = () =>
+    mount(CreaSettings, {
+      global: {
+        stubs: {
+          BFormGroup: mockBFormGroup,
+          BFormInput: mockBFormInput,
+          BFormSelect: mockBFormSelect,
+          BFormCheckbox: mockBFormCheckbox,
+          BButton: mockBButton,
+        },
+        mocks: { $t: (key) => key },
+      },
+    })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    creaSettingsResult.value = null
+    creaSettingsError.value = null
+  })
+
+  // Both buttons submit the same form, and setCreaSettings overwrites all three settings
+  // at once. Before the answer is in, that form holds display defaults - so a click would
+  // clear the configured model and drop the effort level for the whole instance, and say
+  // it succeeded.
+  describe('before the settings have been read', () => {
+    beforeEach(() => {
+      wrapper = createWrapper()
+    })
+
+    it('does not let the form be saved', () => {
+      const buttons = wrapper.findAll('button')
+      expect(buttons).toHaveLength(2)
+      expect(buttons[0].attributes('disabled')).toBeDefined()
+    })
+
+    it('does not let the model be tested either', () => {
+      expect(wrapper.findAll('button')[1].attributes('disabled')).toBeDefined()
+    })
+
+    it('says why nothing can be done yet', () => {
+      expect(wrapper.text()).toContain('crea.settings.unavailable')
+    })
+  })
+
+  // Not a race: the error watcher only raises a toast, so a query that failed leaves the
+  // display defaults standing for as long as the page is open. The buttons have to stay
+  // shut, or the failure turns into a silent overwrite at the admin's leisure.
+  describe('when the query fails', () => {
+    it('keeps both buttons shut', async () => {
+      wrapper = createWrapper()
+      creaSettingsError.value = new Error('502 Bad Gateway')
+      await nextTick()
+
+      const buttons = wrapper.findAll('button')
+      expect(buttons[0].attributes('disabled')).toBeDefined()
+      expect(buttons[1].attributes('disabled')).toBeDefined()
+    })
+  })
+
+  describe('once the answer arrives', () => {
+    beforeEach(async () => {
+      wrapper = createWrapper()
+      creaSettingsResult.value = ANSWER
+      await nextTick()
+    })
+
+    it('releases both buttons', () => {
+      const buttons = wrapper.findAll('button')
+      expect(buttons[0].attributes('disabled')).toBeUndefined()
+      expect(buttons[1].attributes('disabled')).toBeUndefined()
+    })
+
+    it('drops the hint', () => {
+      expect(wrapper.text()).not.toContain('crea.settings.unavailable')
+    })
+
+    // The values must be the server's, not the display defaults the form starts from -
+    // otherwise the gate would be guarding an empty form and the test above would pass
+    // for the wrong reason.
+    it('shows what the server holds', () => {
+      expect(wrapper.vm.form).toEqual({
+        model: 'claude-opus-5',
+        effort: 'high',
+        fastMode: true,
+      })
+    })
+  })
+})

--- a/admin/src/pages/CreaSettings.vue
+++ b/admin/src/pages/CreaSettings.vue
@@ -27,12 +27,20 @@
         </BFormCheckbox>
         <small class="text-muted d-block mt-1">{{ $t('crea.settings.fastModeHint') }}</small>
       </BFormGroup>
-      <BButton variant="primary" :disabled="saving" @click="save">
+      <BButton variant="primary" :disabled="saving || !settingsLoaded" @click="save">
         {{ $t('save') }}
       </BButton>
-      <BButton variant="secondary" class="ms-2" :disabled="testing" @click="test">
+      <BButton
+        variant="secondary"
+        class="ms-2"
+        :disabled="testing || !settingsLoaded"
+        @click="test"
+      >
         {{ $t('crea.settings.testModel') }}
       </BButton>
+      <small v-if="!settingsLoaded" class="text-muted d-block mt-2">
+        {{ $t('crea.settings.unavailable') }}
+      </small>
     </div>
     <div v-else>{{ $t('crea.settings.adminOnly') }}</div>
   </div>
@@ -56,8 +64,15 @@ const { toastSuccess, toastError } = useAppToast()
 
 const isAdmin = computed(() => store.state.moderator.roles.includes('ADMIN'))
 
+// The form holds display defaults until the query answers, never the server's values, and
+// setCreaSettings overwrites all three settings at once. So nothing here may be submitted
+// before settingsLoaded turns true - otherwise one click clears the configured model and
+// drops the effort level for the whole instance, confirmed by a success toast. That is not
+// only a race: a query that failed leaves the defaults standing for as long as the page is
+// open, because the error watcher below only raises a toast.
 const form = ref({ model: '', effort: 'disabled', fastMode: false })
 const defaultModel = ref('')
+const settingsLoaded = ref(false)
 const saving = ref(false)
 const testing = ref(false)
 
@@ -96,6 +111,7 @@ watch(
         fastMode: settings.fastMode ?? false,
       }
       defaultModel.value = settings.defaultModel
+      settingsLoaded.value = true
     }
   },
   { immediate: true },


### PR DESCRIPTION
## The problem

The Crea settings page starts as display defaults — empty model, effort `disabled`, fast
mode off — and is replaced only when the query answers. Both buttons were bound to their
in-flight flag alone, so a click before that answer submits the defaults, and
`setCreaSettings` overwrites all three settings at once.

The configured model falls back to the server default, the effort level drops to off, and a
green toast confirms it. Nothing records what was there before, and Crea keeps working —
which is why it would not be noticed quickly.

Every visit refetches over the network, so on a good day the window is one round trip. The
worse case needs no race at all: when the query fails — a restart, a 502, a dropped
connection — the error watcher only raises a toast and the form is never replaced, so the
buttons stay live for as long as the page is open.

## The change

Save and the model test now wait for the answer, and say why while they wait. The test
button matters as much as Save here, because it submits the same form.

## Verification

Adds the page's first spec, which is where the invariant now lives. Measured rather than
assumed: with the gate removed — the state this commit replaces — three of its tests fail;
with the flag never set, two others do.

Admin only, one added locale key per language. All checks green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear message when Crea settings are unavailable or still loading.
  * Save and test actions remain disabled until settings load successfully.
  * Added translations for the unavailable-settings message across supported languages.

* **Bug Fixes**
  * Prevented users from interacting with settings actions when server values are unavailable.

* **Tests**
  * Added coverage for loading, failed requests, and successfully loaded settings states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->