### PR TITLE
fix(workflow): let the bare-metal deploy test clone the repo it runs in

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -32,4 +32,10 @@ jobs:
         run: docker compose -f docker-compose.yml -f docker-compose.test.yml up --detach --no-deps mariadb
 
       - name: Deploy Bare Metal | Build image
-        run: docker build --network host -f ./deployment/bare_metal/Dockerfile --build-arg BRANCH_NAME=${{ github.ref_name }} --build-arg REPO_URL=https://github.com/${{ github.repository }}.git -t "gradido/deploy-bare-metal:local" .
+        # Both contexts go through the environment rather than into the script text. A branch
+        # name may contain $, backticks or semicolons, and a directly interpolated one would
+        # be expanded as shell source before the runner ever executes it.
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
+          REPO_URL: https://github.com/${{ github.repository }}.git
+        run: docker build --network host -f ./deployment/bare_metal/Dockerfile --build-arg "BRANCH_NAME=$BRANCH_NAME" --build-arg "REPO_URL=$REPO_URL" -t "gradido/deploy-bare-metal:local" .

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -32,4 +32,4 @@ jobs:
         run: docker compose -f docker-compose.yml -f docker-compose.test.yml up --detach --no-deps mariadb
 
       - name: Deploy Bare Metal | Build image
-        run: docker build --network host -f ./deployment/bare_metal/Dockerfile --build-arg BRANCH_NAME=${{ github.ref_name }} -t "gradido/deploy-bare-metal:local" .
+        run: docker build --network host -f ./deployment/bare_metal/Dockerfile --build-arg BRANCH_NAME=${{ github.ref_name }} --build-arg REPO_URL=https://github.com/${{ github.repository }}.git -t "gradido/deploy-bare-metal:local" .

--- a/deployment/bare_metal/Dockerfile
+++ b/deployment/bare_metal/Dockerfile
@@ -44,7 +44,9 @@ ENV BRANCH_NAME=$BRANCH_NAME
 # behaving as it always has.
 ARG REPO_URL=https://github.com/gradido/gradido.git
 # COPY . .
-RUN git clone $REPO_URL --branch $BRANCH_NAME
+# The destination is spelled out because every step below works in /app/gradido. git would
+# otherwise derive it from the URL, which was safe only while that URL was fixed.
+RUN git clone --branch "$BRANCH_NAME" "$REPO_URL" /app/gradido
 RUN cp /app/gradido/deployment/bare_metal/.env.dist /app/gradido/deployment/bare_metal/.env
 RUN sed -i 's/^URL_PROTOCOL=https$/URL_PROTOCOL=http/' /app/gradido/deployment/bare_metal/.env
 RUN sed -i 's/^COMMUNITY_HOST=gddhost.tld$/COMMUNITY_HOST=localhost/' /app/gradido/deployment/bare_metal/.env

--- a/deployment/bare_metal/Dockerfile
+++ b/deployment/bare_metal/Dockerfile
@@ -38,8 +38,13 @@ WORKDIR /app
 
 ARG BRANCH_NAME=master
 ENV BRANCH_NAME=$BRANCH_NAME
+# The repository to clone. It is an argument for the same reason BRANCH_NAME is: on a fork,
+# the branch under test exists only in that fork, and cloning gradido/gradido would fail
+# before a single line of start.sh has run. The default keeps a manual `docker build`
+# behaving as it always has.
+ARG REPO_URL=https://github.com/gradido/gradido.git
 # COPY . .
-RUN git clone https://github.com/gradido/gradido.git --branch $BRANCH_NAME 
+RUN git clone $REPO_URL --branch $BRANCH_NAME
 RUN cp /app/gradido/deployment/bare_metal/.env.dist /app/gradido/deployment/bare_metal/.env
 RUN sed -i 's/^URL_PROTOCOL=https$/URL_PROTOCOL=http/' /app/gradido/deployment/bare_metal/.env
 RUN sed -i 's/^COMMUNITY_HOST=gddhost.tld$/COMMUNITY_HOST=localhost/' /app/gradido/deployment/bare_metal/.env


### PR DESCRIPTION
## The problem

`deployment/bare_metal/Dockerfile` takes the branch under test as a build argument, but the
repository it clones is hardcoded:

```dockerfile
ARG BRANCH_NAME=master
RUN git clone https://github.com/gradido/gradido.git --branch $BRANCH_NAME
```

On a fork those two cannot resolve together. The branch exists only in the fork, so the clone
fails with `fatal: Remote branch <name> not found in upstream origin` and the job stops there
— before a single line of `start.sh` has run. **"Docker Build Test - Deploy Bare Metal" is red
on every fork branch, whatever it contains.**

## Why it is worth fixing

The job is not a docker build check. It renders every `.env.template` through `envsubst`,
generates the nginx configuration from the templates, and ends on `RUN ./start.sh $BRANCH_NAME`
against a real mariadb. It is the only place the deployment path is exercised end to end.

We run a staging server off our fork's own branches, so that verdict is missing exactly where
we deploy from — and a genuine break in `start.sh` or in a `.env.template` would look identical
to the standing failure.

## The change

`REPO_URL` becomes a build argument, passed from the workflow as `github.repository`, which is
always the repository the run belongs to.

- On this repo nothing changes: `github.repository` is `gradido/gradido`.
- On a fork the job clones that fork and can finally do its work.
- The `ARG` default keeps a manual `docker build` behaving as it always has.

`deployment/bare_metal/setup.md` deliberately keeps the literal URL — that one is instructions
for a human setting up a real server, not a build.

A second commit takes a zizmor finding on the same line: `github.ref_name` was interpolated
straight into the run script, and a git refname may contain `$`, backticks or semicolons, so
the value was shell source rather than data. Both contexts now travel as step environment
variables.

## Verified

The fix cannot be proven here, because on this repo it is a no-op by construction: a green run
on `gradido/gradido` only shows nothing broke. So it was proven on the fork, on a branch name
that exists **only** there — where the old Dockerfile fails by definition:

```
Gradido-Akademie/gradido @ proof-deploy-test-fork-clone   (run 31324635520)

Detect File Changes - Deploy Bare Metal    success
Docker Build Test - Deploy Bare Metal      success        <- red on every fork branch before

#8  [install 2/29] RUN git clone https://github.com/Gradido-Akademie/gradido.git \
                       --branch proof-deploy-test-fork-clone
#8  0.046 Cloning into 'gradido'...
#38 [start 3/3]   RUN ./start.sh proof-deploy-test-fork-clone
```

The job ran rather than skipping, the clone went to the fork, and `start.sh` executed. The
proof branch has been deleted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deployment builds can now use a configurable repository URL.
  - Branch names containing special characters are handled safely during builds.
  - Repository content is cloned into a consistent application directory.

- **Bug Fixes**
  - Improved deployment build reliability by correctly passing repository and branch settings through automated build tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->