### PR TITLE
docs(other): warn that deploy defaults take effect one run later

### DIFF
--- a/deployment/bare_metal/start.sh
+++ b/deployment/bare_metal/start.sh
@@ -82,13 +82,20 @@ fi
 : ${NGINX_SSL_CERTIFICATE:=/etc/letsencrypt/live/$COMMUNITY_HOST/fullchain.pem}
 : ${NGINX_SSL_CERTIFICATE_KEY:=/etc/letsencrypt/live/$COMMUNITY_HOST/privkey.pem}
 # ⚠️ Whatever is added in this block takes effect one deploy LATER than it lands.
-# This script updates itself at the git pull further down, so the run that brings
-# a new default in is still the old file executing. A default here and the
-# .env.template line that depends on it must therefore NOT ship in the same
-# commit: that first run pulls the new template and processes it with the old
-# logic, leaving NAME=$NAME in the generated .env and failing the frontend build -
-# which is what took stage1 down twice. Ship the default first, and whatever it
-# protects one deploy later.
+# This script updates itself at the git pull further down, so the run that carries
+# a change to this block into the repository is still the old file executing.
+#
+# When adding a new flag, that means two separate deploys:
+#   1. add its default here, and nothing else
+#   2. one deploy later, add the matching NAME=$NAME line to the .env.template
+#      that needs it
+#
+# Both in one commit fails: that first run pulls the new .env.template and feeds
+# it to the old logic, which has no default for the name. envsubst leaves
+# NAME=$NAME in the generated .env, dotenv-expand follows that self-reference
+# forever, and the frontend build dies with "Maximum call stack size exceeded" -
+# after the services have already been stopped. It took stage1 down on #3718 and
+# again on #3719.
 #
 # A server that has its own .env never reads .env.dist, so a flag added there
 # after that .env was written is simply unknown here. The substitution below

--- a/deployment/bare_metal/start.sh
+++ b/deployment/bare_metal/start.sh
@@ -81,6 +81,15 @@ fi
 # set env variables dynamic if not already set in .env or .env.dist
 : ${NGINX_SSL_CERTIFICATE:=/etc/letsencrypt/live/$COMMUNITY_HOST/fullchain.pem}
 : ${NGINX_SSL_CERTIFICATE_KEY:=/etc/letsencrypt/live/$COMMUNITY_HOST/privkey.pem}
+# ⚠️ Whatever is added in this block takes effect one deploy LATER than it lands.
+# This script updates itself at the git pull further down, so the run that brings
+# a new default in is still the old file executing. A default here and the
+# .env.template line that depends on it must therefore NOT ship in the same
+# commit: that first run pulls the new template and processes it with the old
+# logic, leaving NAME=$NAME in the generated .env and failing the frontend build -
+# which is what took stage1 down twice. Ship the default first, and whatever it
+# protects one deploy later.
+#
 # A server that has its own .env never reads .env.dist, so a flag added there
 # after that .env was written is simply unknown here. The substitution below
 # lists only the names it finds in the environment, so an unknown one is left in


### PR DESCRIPTION
Follow-up to #3719.

`start.sh` updates itself at the `git pull` further down, so the run that brings a new default in is still the old file executing. #3719 shipped the default **and** the `.env.template` line that depends on it in the same commit — so the first run after that merge pulled the new template and processed it with the old logic, left `MATCHING_ACTIVE=$MATCHING_ACTIVE` in the generated `.env`, and failed the frontend build exactly as #3718 had.

**The code was right, the order was not.** `start.sh` on disk now carries the default, so the next run works without any further change; this note records why, where the next default will be written.

Rule it states: a default in that block and the thing that depends on it must not ship in the same commit — ship the default first, whatever it protects one deploy later.

`bash -n` clean. No behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deployment guidance clarifying when updated defaults take effect.
  * Documented the recommended order for committing default changes and dependent template updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->