### PR TITLE
fix(frontend): let disabled input fields follow the dark mode

### DIFF
--- a/frontend/src/assets/scss/custom/gradido-custom/_input.scss
+++ b/frontend/src/assets/scss/custom/gradido-custom/_input.scss
@@ -14,6 +14,7 @@ $input-border-radius: $border-radius ;
 $input-border-radius-xl: $border-radius-xl ;
 $input-border-radius-lg: $border-radius-lg ;
 $input-border-radius-sm: $border-radius-sm ;
+
 // Bootstrap's own default is var(--bs-secondary-bg), which follows the colour mode;
 // pinning it to the $gray-200 literal here compiled .form-control:disabled to a fixed
 // #e9ecef that no variable can reach, so a disabled text field stayed light on the dark

--- a/frontend/src/assets/scss/custom/gradido-custom/_input.scss
+++ b/frontend/src/assets/scss/custom/gradido-custom/_input.scss
@@ -14,7 +14,15 @@ $input-border-radius: $border-radius ;
 $input-border-radius-xl: $border-radius-xl ;
 $input-border-radius-lg: $border-radius-lg ;
 $input-border-radius-sm: $border-radius-sm ;
-$input-disabled-bg: $gray-200 ;
+// Bootstrap's own default is var(--bs-secondary-bg), which follows the colour mode;
+// pinning it to the $gray-200 literal here compiled .form-control:disabled to a fixed
+// #e9ecef that no variable can reach, so a disabled text field stayed light on the dark
+// canvas. Its neighbour .form-select:disabled was never affected: $form-select-disabled-bg
+// took its value from $input-disabled-bg while that was still the variable, before this
+// line ran -- which is why the send form showed a dark community select above three light
+// fields whenever the balance was zero and disabled them.
+// In light mode --bs-secondary-bg IS #e9ecef, so nothing there changes.
+$input-disabled-bg: var(--#{$prefix}secondary-bg) ;
 $input-muted-bg: #f7fafe ;
 $input-focus-muted-bg: color.adjust($input-muted-bg, $lightness: 1%) ;
 $input-alternative-box-shadow: 0 1px 3px rgb(50 50 93 / 15%), 0 1px 0 rgb(0 0 0 / 2%) ;


### PR DESCRIPTION
## 🍰 Pullrequest

**Reported from stage1:** in the send form, the recipient, amount and message fields stay **light on the dark canvas** — but only while the account balance is zero, and only on the "send Gradido" tab. The community select directly above them stays dark. That asymmetry is what points at the cause.

Zero balance is the one state that disables those fields (`TransactionForm.vue`, `isFormDisabled`), so this is the disabled style, not the send form.

### One line, and it is an inherited one

`custom/gradido-custom/_input.scss` pinned `$input-disabled-bg` to the `$gray-200` **literal**, left over from the old theme. Bootstrap 5.3 defaults that same variable to `var(--bs-secondary-bg)` — which the colour-mode bridge already maps onto our `--surface-muted` token. A literal is beyond the reach of any variable, so the rule compiled to a fixed colour:

```css
.form-control:disabled { background-color: #e9ecef; }              /* pinned */
.form-select:disabled  { background-color: var(--bs-secondary-bg); } /* follows the mode */
```

The select escaped because `$form-select-disabled-bg` copies `$input-disabled-bg` while it is still the variable — Bootstrap's variables load before our overrides. Hence one dark select above three light fields.

Removing the override restores Bootstrap's own default.

### Measured, not assumed

The stylesheet was compiled with and without the change and the outputs diffed. The **entire** difference across 363 KB of CSS is two declarations:

| rule | before | after |
|---|---|---|
| `.form-control:disabled` | `#e9ecef` | `var(--bs-secondary-bg)` |
| `.form-floating > textarea:disabled ~ label::after` | `#e9ecef` | `var(--bs-secondary-bg)` |

The second is the same defect on the label backdrop of a disabled floating-label textarea; it just had not been noticed yet.

**Light mode does not change**, because `--bs-secondary-bg` *is* `#e9ecef` there. That is also why the override was removed rather than a dark-mode exception added: an exception would have preserved the mismatch between the field and the select next to it.

### Issues
- None

### Todo
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled input fields now adapt to the active color mode, including dark mode.
  * Light mode retains the existing visual appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->