### PR TITLE
feat(admin): clear or fill the whole Crea checklist in one click

### DIFF
--- a/admin/src/components/CreaEvaluationModal.spec.js
+++ b/admin/src/components/CreaEvaluationModal.spec.js
@@ -281,4 +281,36 @@ describe('CreaEvaluationModal — resubmission grouping', () => {
     expect(wrapper.vm.groupedContributions.open.map((c) => c.id)).toEqual([9])
     expect(wrapper.vm.selectedIds).toEqual([9])
   })
+
+  // A moderator's ask: with a long list, ticking the two she wants beats unticking the
+  // twenty she does not. One control for both directions, so it lives with the grouping
+  // tests -- what "all" means is exactly a question about the groups.
+  const toggleAll = (wrapper) => wrapper.find('button.crea-toggle-all')
+
+  it('clears the whole checklist in one click', async () => {
+    const wrapper = mountBatch()
+    await open(wrapper)
+    expect(wrapper.vm.selectedIds).toEqual([1, 4])
+    await toggleAll(wrapper).trigger('click')
+    expect(wrapper.vm.selectedIds).toEqual([])
+  })
+
+  // The way back takes the resubmission groups with it. They start unticked by design
+  // (E-026), but that governs the default, not what the moderator may ask for on purpose --
+  // and a control labelled "all" that quietly skipped two groups would be lying.
+  it('ticks every group on the way back, put-off ones included', async () => {
+    const wrapper = mountBatch()
+    await open(wrapper)
+    await toggleAll(wrapper).trigger('click')
+    await toggleAll(wrapper).trigger('click')
+    expect(wrapper.vm.selectedIds).toEqual([1, 4, 2, 3])
+  })
+
+  it('names the direction the next click would take', async () => {
+    const wrapper = mountBatch()
+    await open(wrapper)
+    expect(toggleAll(wrapper).text()).toBe('crea.deselectAll')
+    await toggleAll(wrapper).trigger('click')
+    expect(toggleAll(wrapper).text()).toBe('crea.selectAll')
+  })
 })

--- a/admin/src/components/CreaEvaluationModal.vue
+++ b/admin/src/components/CreaEvaluationModal.vue
@@ -53,7 +53,16 @@
            by resubmission (E-026). Untouched ones come preselected, anything put off
            starts unticked; ticking is free either way. Nothing runs until "Bewerten". -->
       <template v-if="isBatch">
-        <p class="mb-2 text-muted small">{{ $t('crea.selectHint') }}</p>
+        <div class="d-flex align-items-baseline gap-3 mb-2">
+          <p class="mb-0 text-muted small flex-grow-1">{{ $t('crea.selectHint') }}</p>
+          <button
+            type="button"
+            class="btn btn-link p-0 small text-nowrap crea-toggle-all"
+            @click="toggleAllPicks"
+          >
+            {{ selectedIds.length ? $t('crea.deselectAll') : $t('crea.selectAll') }}
+          </button>
+        </div>
         <template v-for="(section, index) in contributionSections" :key="section.key">
           <hr v-if="index > 0" class="crea-section-rule" />
           <p v-if="section.heading" class="crea-section-heading mb-2 fw-bold small">
@@ -430,6 +439,21 @@ const contributionSections = computed(() => {
     { key: 'later', heading: t('crea.resubmission'), items: later },
   ].filter((section) => section.items.length > 0)
 })
+
+// One control for both directions, read off the sections so it can never fall out of step
+// with what the checklist shows. Asked for by a moderator for the clearing half: with a
+// long list, ticking the two she wants is quicker than unticking the twenty she does not.
+//
+// Selecting all takes the resubmission groups with it. They start unticked by design
+// (E-026) -- but that governs the DEFAULT, not what the moderator may ask for on purpose;
+// ticking them by hand was free before this button existed.
+const allPickIds = computed(() =>
+  contributionSections.value.flatMap((section) => section.items.map((c) => c.id)),
+)
+
+function toggleAllPicks() {
+  selectedIds.value = selectedIds.value.length ? [] : [...allPickIds.value]
+}
 // "Crea liest den Beitrag" (one) vs "... die Beiträge" (several) while evaluating.
 const loadingText = computed(() => {
   const count = isBatch.value ? selectedIds.value.length : 1

--- a/admin/src/locales/de.json
+++ b/admin/src/locales/de.json
@@ -108,6 +108,7 @@
       "deny": "Ablehnen",
       "inquire": "Rückfrage"
     },
+    "deselectAll": "Alle abwählen",
     "deviation": "Deine Entscheidung",
     "evaluate": "Bewerten",
     "flags": "Bitte prüfen",
@@ -133,6 +134,7 @@
     "salutationSave": "Anrede speichern",
     "salutationSaveFailed": "Die Anrede konnte nicht gespeichert werden.",
     "salutationSaved": "Anrede gespeichert.",
+    "selectAll": "Alle auswählen",
     "selectHint": "Wähle die Beiträge, die Crea zusammen bewerten soll.",
     "settings": {
       "adminOnly": "Diese Einstellungen sind nur für Administratoren sichtbar.",

--- a/admin/src/locales/el.json
+++ b/admin/src/locales/el.json
@@ -108,6 +108,7 @@
       "deny": "Reject",
       "inquire": "Inquire"
     },
+    "deselectAll": "Αποεπιλογή όλων",
     "deviation": "Your decision",
     "evaluate": "Evaluate",
     "flags": "Please review",
@@ -133,6 +134,7 @@
     "salutationSave": "Save salutation",
     "salutationSaveFailed": "The salutation could not be saved.",
     "salutationSaved": "Salutation saved.",
+    "selectAll": "Επιλογή όλων",
     "selectHint": "Select the contributions Crea should evaluate together.",
     "settings": {
       "adminOnly": "These settings are visible to administrators only.",

--- a/admin/src/locales/en.json
+++ b/admin/src/locales/en.json
@@ -108,6 +108,7 @@
       "deny": "Reject",
       "inquire": "Inquire"
     },
+    "deselectAll": "Deselect all",
     "deviation": "Your decision",
     "evaluate": "Evaluate",
     "flags": "Please review",
@@ -133,6 +134,7 @@
     "salutationSave": "Save salutation",
     "salutationSaveFailed": "The salutation could not be saved.",
     "salutationSaved": "Salutation saved.",
+    "selectAll": "Select all",
     "selectHint": "Select the contributions Crea should evaluate together.",
     "settings": {
       "adminOnly": "These settings are visible to administrators only.",

--- a/admin/src/locales/es.json
+++ b/admin/src/locales/es.json
@@ -108,6 +108,7 @@
       "deny": "Reject",
       "inquire": "Inquire"
     },
+    "deselectAll": "Deseleccionar todo",
     "deviation": "Your decision",
     "evaluate": "Evaluate",
     "flags": "Please review",
@@ -133,6 +134,7 @@
     "salutationSave": "Save salutation",
     "salutationSaveFailed": "The salutation could not be saved.",
     "salutationSaved": "Salutation saved.",
+    "selectAll": "Seleccionar todo",
     "selectHint": "Select the contributions Crea should evaluate together.",
     "settings": {
       "adminOnly": "These settings are visible to administrators only.",

--- a/admin/src/locales/fr.json
+++ b/admin/src/locales/fr.json
@@ -108,6 +108,7 @@
       "deny": "Reject",
       "inquire": "Inquire"
     },
+    "deselectAll": "Tout désélectionner",
     "deviation": "Your decision",
     "evaluate": "Evaluate",
     "flags": "Please review",
@@ -133,6 +134,7 @@
     "salutationSave": "Save salutation",
     "salutationSaveFailed": "The salutation could not be saved.",
     "salutationSaved": "Salutation saved.",
+    "selectAll": "Tout sélectionner",
     "selectHint": "Select the contributions Crea should evaluate together.",
     "settings": {
       "adminOnly": "These settings are visible to administrators only.",

--- a/admin/src/locales/it.json
+++ b/admin/src/locales/it.json
@@ -108,6 +108,7 @@
       "deny": "Reject",
       "inquire": "Inquire"
     },
+    "deselectAll": "Deseleziona tutto",
     "deviation": "Your decision",
     "evaluate": "Evaluate",
     "flags": "Please review",
@@ -133,6 +134,7 @@
     "salutationSave": "Save salutation",
     "salutationSaveFailed": "The salutation could not be saved.",
     "salutationSaved": "Salutation saved.",
+    "selectAll": "Seleziona tutto",
     "selectHint": "Select the contributions Crea should evaluate together.",
     "settings": {
       "adminOnly": "These settings are visible to administrators only.",

--- a/admin/src/locales/nl.json
+++ b/admin/src/locales/nl.json
@@ -108,6 +108,7 @@
       "deny": "Reject",
       "inquire": "Inquire"
     },
+    "deselectAll": "Alles deselecteren",
     "deviation": "Your decision",
     "evaluate": "Evaluate",
     "flags": "Please review",
@@ -133,6 +134,7 @@
     "salutationSave": "Save salutation",
     "salutationSaveFailed": "The salutation could not be saved.",
     "salutationSaved": "Salutation saved.",
+    "selectAll": "Alles selecteren",
     "selectHint": "Select the contributions Crea should evaluate together.",
     "settings": {
       "adminOnly": "These settings are visible to administrators only.",

--- a/admin/src/locales/pt.json
+++ b/admin/src/locales/pt.json
@@ -108,6 +108,7 @@
       "deny": "Reject",
       "inquire": "Inquire"
     },
+    "deselectAll": "Desmarcar tudo",
     "deviation": "Your decision",
     "evaluate": "Evaluate",
     "flags": "Please review",
@@ -133,6 +134,7 @@
     "salutationSave": "Save salutation",
     "salutationSaveFailed": "The salutation could not be saved.",
     "salutationSaved": "Salutation saved.",
+    "selectAll": "Selecionar tudo",
     "selectHint": "Select the contributions Crea should evaluate together.",
     "settings": {
       "adminOnly": "These settings are visible to administrators only.",

--- a/admin/src/locales/ru.json
+++ b/admin/src/locales/ru.json
@@ -108,6 +108,7 @@
       "deny": "Reject",
       "inquire": "Inquire"
     },
+    "deselectAll": "Снять выбор",
     "deviation": "Your decision",
     "evaluate": "Evaluate",
     "flags": "Please review",
@@ -133,6 +134,7 @@
     "salutationSave": "Save salutation",
     "salutationSaveFailed": "The salutation could not be saved.",
     "salutationSaved": "Salutation saved.",
+    "selectAll": "Выбрать все",
     "selectHint": "Select the contributions Crea should evaluate together.",
     "settings": {
       "adminOnly": "These settings are visible to administrators only.",

--- a/admin/src/locales/tr.json
+++ b/admin/src/locales/tr.json
@@ -108,6 +108,7 @@
       "deny": "Reject",
       "inquire": "Inquire"
     },
+    "deselectAll": "Seçimi kaldır",
     "deviation": "Your decision",
     "evaluate": "Evaluate",
     "flags": "Please review",
@@ -133,6 +134,7 @@
     "salutationSave": "Save salutation",
     "salutationSaveFailed": "The salutation could not be saved.",
     "salutationSaved": "Salutation saved.",
+    "selectAll": "Tümünü seç",
     "selectHint": "Select the contributions Crea should evaluate together.",
     "settings": {
       "adminOnly": "These settings are visible to administrators only.",


### PR DESCRIPTION
## 🍰 Pullrequest

**Asked for by a moderator.** In Crea's batch checklist, everything untouched comes preselected. With a long list of open contributions, ticking the two she wants evaluated beats unticking the twenty she does not — and there was no way to clear the list.

One control, next to the hint right above the list it governs, naming the direction the next click would take:

- **"Alle abwählen"** while anything is ticked
- **"Alle auswählen"** once nothing is

### Why there, and why one button

Next to the hint, the hand goes straight from the sentence into the list. In the footer, a long list sits between the control and its effect — you click at the bottom and see nothing happen at the top; and the footer belongs to the closing actions, so a third element there makes "what do I press now?" harder.

A header checkbox governing other checkboxes was the other candidate. It needs an indeterminate third state for "some selected", and it reads as one more contribution in the list — worst exactly where it is needed, in a long one.

### What "all" includes

Selecting all takes the resubmission groups with it. They start unticked **by design** (E-026, they have been handled once already) — but that governs the *default*, not what the moderator may ask for on purpose; ticking them by hand was free before this button existed. A control labelled "all" that quietly skipped two groups would be lying. There is a test for it.

The ids come from the rendered sections rather than a second list, so the button cannot fall out of step with what the checklist shows.

### Checked

- `vitest` — 52 files, 440 tests, green. Three new ones: clearing, the way back including the put-off groups, and the label flip. They assert presence, so a green run is already the proof — `trigger('click')` on a missing button throws.
- `eslint`, `stylelint`, `sortLocales` — clean.
- Both keys in **all ten** admin locales. The admin eslint carries no `no-missing-keys-in-other-locales`, so nothing would have reported a gap.
- Deployed to ki-playground and verified at the **served artefact**: the delivered `CreationConfirm` chunk is byte-identical to the local build across 159,063 bytes; the only differences are the 7–8 byte content hashes of the sibling chunks it imports.

### Issues
- None

### Todo
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Select all/Deselect all control for contributions in the Crea evaluation checklist.
  - The control includes all visible contributions, including resubmissions, and updates its label based on the next available action.
  - Added translations for the new selection controls across supported languages.

- **Tests**
  - Added coverage for clearing default selections, selecting all contributions, and updating the control label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->