### PR TITLE
fix(admin): open the message panel for moderator-entered contributions

### DIFF
--- a/admin/src/components/Tables/OpenCreationsTable.spec.js
+++ b/admin/src/components/Tables/OpenCreationsTable.spec.js
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { shallowMount } from '@vue/test-utils'
 import { createStore } from 'vuex'
+import { h } from 'vue'
 import OpenCreationsTable from './OpenCreationsTable.vue'
 
 vi.mock('../RowDetails', () => ({ default: { name: 'RowDetails' } }))
-vi.mock('../EditCreationFormular', () => ({ default: { name: 'EditCreationFormular' } }))
 vi.mock('../ContributionMessages/ContributionMessagesList', () => ({
   default: { name: 'ContributionMessagesList' },
 }))
@@ -99,7 +99,6 @@ describe('OpenCreationsTable', () => {
     expect(mockRow.toggleDetails).toHaveBeenCalled()
     expect(wrapper.vm.openRow).toEqual(mockRow)
     expect(wrapper.vm.slotIndex).toBe(0)
-    expect(wrapper.vm.creationUserData).toEqual(mockItems[0])
   })
 
   it('identifies if the item belongs to the current user', () => {
@@ -242,6 +241,87 @@ describe('OpenCreationsTable', () => {
         await wrapper.setProps({ items: [...mockItems] })
         expect(wrapper.vm.displayedCreationGroup(item)).toBe('music')
       })
+    })
+  })
+
+  // A contribution a moderator entered on someone's behalf used to take a separate path: its
+  // own button in the details column, and an edit form in the details row gated on
+  // confirmedAt. The list query no longer asks for that field, so the gate never held and the
+  // panel stayed empty. These tests render the two slots the automatic stub swallows.
+  describe('a contribution a moderator entered for someone else', () => {
+    const rowScope = (item, index) => ({
+      item,
+      index,
+      detailsShowing: true,
+      toggleDetails: () => {},
+    })
+
+    // Stands in for BTableLite: the automatic stub renders none of its scoped slots, so
+    // neither the details button nor the details panel would exist to look at.
+    const slotRenderingTable = {
+      name: 'BTableLite',
+      props: { items: { type: Array, default: () => [] } },
+      render() {
+        return h(
+          'div',
+          this.items.map((item, index) =>
+            h('div', { class: 'contribution-row' }, [
+              this.$slots['cell(editCreation)']?.(rowScope(item, index)),
+              this.$slots['row-details']?.(rowScope(item, index)),
+            ]),
+          ),
+        )
+      },
+    }
+
+    // Same reason, one level down: RowDetails carries the panel in a dynamically named slot.
+    const slotRenderingRowDetails = {
+      name: 'RowDetails',
+      props: { row: Object, slotName: String, type: String, index: Number },
+      render() {
+        return h('div', this.$slots[this.slotName]?.())
+      },
+    }
+
+    // And once more for the button -- the message badges sit inside it.
+    const slotRenderingButton = {
+      name: 'BButton',
+      render() {
+        return h('button', this.$slots.default?.())
+      },
+    }
+
+    const openItems = [
+      // written by the member
+      { id: 3, contributionStatus: 'PENDING', userId: 4, moderatorId: null, messagesCount: 1 },
+      // entered by a moderator on that member's behalf
+      { id: 4, contributionStatus: 'PENDING', userId: 5, moderatorId: 1, messagesCount: 1 },
+    ]
+
+    beforeEach(() => {
+      wrapper = shallowMount(OpenCreationsTable, {
+        props: { items: openItems, fields: mockFields, hideResubmission: false },
+        global: {
+          plugins: [store],
+          mocks: { $t: (key) => key },
+          stubs: {
+            BTableLite: slotRenderingTable,
+            RowDetails: slotRenderingRowDetails,
+            BButton: slotRenderingButton,
+            IBiChatDots: true,
+            IBiExclamationCircleFill: true,
+            IBiQuestionDiamond: true,
+          },
+        },
+      })
+    })
+
+    it('opens the same message panel as one written by the member', () => {
+      expect(wrapper.findAllComponents({ name: 'ContributionMessagesList' })).toHaveLength(2)
+    })
+
+    it('carries the unanswered-message badge like any other', () => {
+      expect(wrapper.findAllComponents({ name: 'IBiExclamationCircleFill' })).toHaveLength(2)
     })
   })
 

--- a/admin/src/components/Tables/OpenCreationsTable.vue
+++ b/admin/src/components/Tables/OpenCreationsTable.vue
@@ -99,20 +99,13 @@
           </BButton>
         </div>
       </template>
+      <!-- A contribution a moderator entered on someone's behalf is moderated like any other,
+           so it gets the same button and the same message badges. It used to get an edit
+           button of its own here, which also hid the badges -- an unanswered message on one of
+           these was invisible. See the row-details slot for the other half of that split. -->
       <template #cell(editCreation)="row">
         <div v-if="!myself(row.item)">
-          <BButton
-            v-if="row.item.moderatorId"
-            variant="info"
-            size="md"
-            :index="0"
-            class="me-2"
-            @click="rowToggleDetails(row, 0)"
-          >
-            <IBiX v-if="row.detailsShowing" />
-            <IBiPencilSquare v-else />
-          </BButton>
-          <BButton v-else @click="rowToggleDetails(row, 0)">
+          <BButton @click="rowToggleDetails(row, 0)">
             <IBiChatDots />
             <IBiExclamationCircleFill
               v-if="row.item.contributionStatus === 'PENDING' && row.item.messagesCount > 0"
@@ -165,29 +158,23 @@
           :index="0"
           @row-toggle-details="rowToggleDetails(row, 0)"
         >
+          <!-- Every contribution opens the same panel, whoever wrote it. A moderator-entered
+               one used to open an edit form instead, gated on confirmedAt -- a field the list
+               query no longer asks for, so the gate has been permanently false and the panel
+               permanently empty, on every tab. Moderating one of these means talking to the
+               member, which is what this panel is for, and the backend has allowed it all
+               along: neither writing a message nor changing the text checks who created it. -->
           <template #show-creation>
-            <div v-if="row.item.moderatorId">
-              <edit-creation-formular
-                v-if="row.item.confirmedAt === null"
-                type="singleCreation"
-                :item="row.item"
-                :row="row"
-                :creation-user-data="creationUserData"
-                @update-creation-data="$emit('update-contributions')"
-              />
-            </div>
-            <div v-else>
-              <contribution-messages-list
-                :contribution="row.item"
-                :resubmission-at="row.item.resubmissionAt"
-                :hide-resubmission="hideResubmission"
-                @update-status="updateStatus"
-                @reload-contribution="reloadContribution"
-                @update-contributions="updateContributions"
-                @search-for-email="$emit('search-for-email', $event)"
-                @resubmission-saved="$emit('resubmission-saved', $event)"
-              />
-            </div>
+            <contribution-messages-list
+              :contribution="row.item"
+              :resubmission-at="row.item.resubmissionAt"
+              :hide-resubmission="hideResubmission"
+              @update-status="updateStatus"
+              @reload-contribution="reloadContribution"
+              @update-contributions="updateContributions"
+              @search-for-email="$emit('search-for-email', $event)"
+              @resubmission-saved="$emit('resubmission-saved', $event)"
+            />
           </template>
         </row-details>
       </template>
@@ -216,7 +203,6 @@
 
 <script>
 import RowDetails from '../RowDetails'
-import EditCreationFormular from '../EditCreationFormular'
 import ContributionMessagesList from '../ContributionMessages/ContributionMessagesList'
 import { useDateFormatter } from '@/composables/useDateFormatter'
 import { creationGroupLabels, creationGroupOption } from '@/utils/creationGroupLabel'
@@ -232,7 +218,6 @@ const iconMap = {
 export default {
   name: 'OpenCreationsTable',
   components: {
-    EditCreationFormular,
     RowDetails,
     ContributionMessagesList,
   },
@@ -284,7 +269,6 @@ export default {
     return {
       slotIndex: 0,
       openRow: null,
-      creationUserData: {},
       groupChangeModal: false,
       pendingGroupChange: { contributionId: null, tag: '', fromLabel: '', toLabel: '' },
       // What the group dropdowns show, by contribution id, while a change is waiting for its
@@ -366,7 +350,6 @@ export default {
         row.toggleDetails()
         this.slotIndex = index
         this.openRow = row
-        this.creationUserData = row.item
       }
     },
     // Group functions: the group is editable while the contribution is still being worked


### PR DESCRIPTION
## What

A contribution a moderator enters on a member's behalf (`adminCreateContribution`) is now moderated like any other one: same button in the details column, same message panel when the row is opened.

## Why

It took a separate path in `OpenCreationsTable.vue`, branching on `moderatorId`:

- **the details column** got an edit button of its own, which also meant the unanswered-message badges were never drawn — a waiting message on one of these contributions was invisible;
- **the details row** rendered `EditCreationFormular` instead of `ContributionMessagesList`, gated on `row.item.confirmedAt === null`.

`confirmedAt` was dropped from the `adminListContributions` query in 8b8e6cfa0 (19 Dec 2025). Since then `row.item.confirmedAt` is `undefined`, `undefined === null` is false, and the gate has been permanently shut — the details row renders an empty `<div>`. It affects every tab, not only the open one, so the message history of such a contribution could not be read at all.

Rare enough not to be noticed for eight months: it only comes up when a moderator has to enter a contribution for someone else, for instance to re-file one that sat unconfirmed past its month.

## Why the message panel is the right target

The backend has allowed this all along; only the admin UI did not offer it.

- `UnconfirmedContributionAdminAddMessageRole` does not look at `moderatorId` — writing a message or a note works.
- `UnconfirmedContributionAdminRole.checkAuthorization` is in fact *more* permissive for them: a moderator without `MODERATOR_UPDATE_CONTRIBUTION_MEMO` may still edit the text.
- The "your contribution was changed by a moderator" mail stays suppressed, because `isCreatedFromUser()` keys on `moderatorId` and is untouched.
- A member may reply: `UnconfirmedContributionUserAddMessageRole` has no such check either. They still may not *edit* it, which is unchanged.

The moderator scope is unaffected — `adminListContributionMessages` and both mutations run `assertContributionInModeratorScope` as before.

## What it costs

`EditCreationFormular` was the only place a moderator could change the **amount** of such a contribution. Nothing that works today is lost: the form has been unreachable since December, and the amount of a member-written contribution was never editable here either. An amount field on the "change text" tab, for every contribution, would be a separate change.

`EditCreationFormular.vue` now has no caller. Removing it is left to a separate commit.

## Tests

Two new tests render the table's `cell(editCreation)` and `row-details` slots, which the automatic stubs swallow. Verified by putting the old template back in place: both fail (1 instead of 2), and only those two.

Local: `lint`, `stylelint`, `locales`, `test` (442 passing), `build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Moderator-entered contributions now include the same message button and conversation panel available for other contributions.
  * Unanswered-message indicators are displayed consistently across contribution types.

* **Bug Fixes**
  * Improved consistency in contribution details and messaging interactions within the open creations table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->