### PR TITLE
fix(admin): name the icon-only buttons in the moderation table

### DIFF
--- a/admin/src/components/ContributionMessages/ContributionMessagesFormular.vue
+++ b/admin/src/components/ContributionMessages/ContributionMessagesFormular.vue
@@ -78,6 +78,13 @@
               @focus="captureCreaField"
             />
           </BTab>
+          <!-- The memo is the only part of the contribution itself a moderator edits here. The
+               amount is deliberately NOT editable -- not in this dialog and nowhere else in
+               moderation, and the same for every contribution, whether a member submitted it or
+               a moderator entered it on their behalf (confirmed 2026-08-11). A wrong amount is
+               corrected by denying or deleting the contribution and entering it again, not by
+               overwriting it. The absence of an amount field here is the decision, not a gap --
+               do not add one without revisiting it. -->
           <BTab>
             <template #title>
               <span id="memo-tab-title">{{ $t('moderator.memo') }}</span>

--- a/admin/src/components/Tables/OpenCreationsTable.spec.js
+++ b/admin/src/components/Tables/OpenCreationsTable.spec.js
@@ -323,6 +323,17 @@ describe('OpenCreationsTable', () => {
     it('carries the unanswered-message badge like any other', () => {
       expect(wrapper.findAllComponents({ name: 'IBiExclamationCircleFill' })).toHaveLength(2)
     })
+
+    // The button holds an icon and nothing else, so without these a screen reader can only
+    // announce "button", and hovering tells a moderator nothing either.
+    it('is named for screen readers and as a tooltip', () => {
+      const buttons = wrapper.findAll('button')
+      expect(buttons).toHaveLength(2)
+      buttons.forEach((button) => {
+        expect(button.attributes('aria-label')).toBe('details')
+        expect(button.attributes('title')).toBe('details')
+      })
+    })
   })
 
   it('gets correct status icon', () => {

--- a/admin/src/components/Tables/OpenCreationsTable.vue
+++ b/admin/src/components/Tables/OpenCreationsTable.vue
@@ -22,12 +22,19 @@
           style="background-color: #dc3545; color: white"
         />
       </template>
+      <!-- The action buttons of a row carry an icon and nothing else, so title and aria-label
+           are the only thing that names them: a tooltip for the moderator, an accessible name
+           for a screen reader. Both reuse the key the column header already uses, so a button
+           is called what the column above it is called. The filter button further down has
+           carried this since it was written; the rest of the row had not. -->
       <template #cell(bookmark)="row">
         <div v-if="!myself(row.item)">
           <BButton
             variant="danger"
             size="md"
             class="me-2"
+            :title="$t('delete')"
+            :aria-label="$t('delete')"
             @click="$emit('show-overlay', row.item, 'delete')"
           >
             <IBiTrash />
@@ -105,7 +112,11 @@
            these was invisible. See the row-details slot for the other half of that split. -->
       <template #cell(editCreation)="row">
         <div v-if="!myself(row.item)">
-          <BButton @click="rowToggleDetails(row, 0)">
+          <BButton
+            :title="$t('details')"
+            :aria-label="$t('details')"
+            @click="rowToggleDetails(row, 0)"
+          >
             <IBiChatDots />
             <IBiExclamationCircleFill
               v-if="row.item.contributionStatus === 'PENDING' && row.item.messagesCount > 0"
@@ -121,7 +132,12 @@
         </div>
       </template>
       <template #cell(chatCreation)="row">
-        <BButton v-if="row.item.messagesCount > 0" @click="rowToggleDetails(row, 0)">
+        <BButton
+          v-if="row.item.messagesCount > 0"
+          :title="$t('details')"
+          :aria-label="$t('details')"
+          @click="rowToggleDetails(row, 0)"
+        >
           <IBiChatDots />
         </BButton>
         <collapse-icon v-else :visible="row.detailsShowing" @click="rowToggleDetails(row, 0)" />
@@ -132,6 +148,8 @@
             variant="warning"
             size="md"
             class="me-2"
+            :title="$t('deny')"
+            :aria-label="$t('deny')"
             @click="$emit('show-overlay', row.item, 'deny')"
           >
             <IBiX />
@@ -144,6 +162,8 @@
             variant="success"
             size="md"
             class="me-2"
+            :title="$t('save')"
+            :aria-label="$t('save')"
             @click="$emit('show-overlay', row.item, 'confirm')"
           >
             <IBiCheck />


### PR DESCRIPTION
Follow-up to #3724 and #3725.

## What

Five buttons in a contribution row of the moderation table carry an icon and nothing else. They now get `title` and `aria-label`:

| column | icon | key |
|---|---|---|
| `bookmark` | 🗑 | `delete` |
| `editCreation` | 💬 | `details` |
| `chatCreation` | 💬 | `details` |
| `deny` | ✕ | `deny` |
| `confirm` | ✓ | `save` |

Each reuses the key its own column header already uses, so a button is called what the column above it is called — **no new translation string**, in any language. Behaviour is unchanged; the visible effect is a tooltip on hover.

## Why all five, when only one was reported

coderabbit flagged the details button on #3724 (outside-diff, 🟠 Major). The finding is correct but **pre-existing** — that column held two unlabelled buttons before #3724 and now holds one. The other four are the same gap in the same row. Fixing only the reported one would leave a half-labelled table and the twin details button in `chatCreation` still silent.

The convention is already in this file: the filter button has carried `title` + `aria-label` since it was written, and the Crea button is named through its image `alt`.

## Deliberately not included

The collapse arrow in the `chatCreation` column. It is a `<div>` with a click handler, not a button — it cannot be reached by keyboard at all. Labelling it would hide that rather than fix it. That is its own question.

## The amount field

This also records in `ContributionMessagesFormular.vue` why there is no amount input on the "change text" tab: the amount is deliberately not editable in moderation, and the same for every contribution, whether a member submitted it or a moderator entered it on their behalf. A wrong amount is corrected by denying or deleting and entering again.

`EditCreationFormular`, removed in #3725, was the last place that had such a field — unreachable since December 2025. Without a note, its absence now reads as something that was lost, and the next cleanup would "restore" it.

## Tests

One new assertion on the details button, in the slot-rendering harness added in #3724: it must carry both attributes. It asserts presence with a concrete value, so a green run is itself the proof that the attributes reach the rendered button.

Local: `lint`, `stylelint`, `locales`, `test` (435 passing), `build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added descriptive labels and tooltips to open creation action buttons, including delete, details, chat, deny, and confirm actions.
  * Improved screen-reader support for detail actions.

* **Documentation**
  * Clarified contribution correction guidance within the administration form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->