### PR TITLE
feat(frontend): download a transaction link as a printable thank-you cheque

### DIFF
--- a/frontend/src/components/GddSend/TransactionResultLink.vue
+++ b/frontend/src/components/GddSend/TransactionResultLink.vue
@@ -9,7 +9,9 @@
     ></clipboard-copy>
     <label>{{ $t('qrCode') }}</label>
     <div class="text-center">
-      <div><figure-qr-code :link="link" /></div>
+      <div>
+        <figure-qr-code :link="link" :cheque="{ kind: 'thankYou', amount, memo, validUntil }" />
+      </div>
       <div>
         <BButton variant="gradido" class="mt-4" data-test="close-btn" @click="$emit('on-back')">
           {{ $t('form.close') }}

--- a/frontend/src/components/QrCode/FigureQrCode.spec.js
+++ b/frontend/src/components/QrCode/FigureQrCode.spec.js
@@ -9,6 +9,19 @@ vi.mock('qrcanvas-vue', () => ({
   },
 }))
 
+const mockToastError = vi.fn()
+vi.mock('@/composables/useToast', () => ({
+  useAppToast: () => ({
+    toastError: mockToastError,
+  }),
+}))
+
+const mockDrawCheque = vi.fn().mockResolvedValue('data:image/png;base64,cheque')
+vi.mock('@/utils/thankYouCheque', () => ({
+  drawCheque: (...args) => mockDrawCheque(...args),
+  chequeFileName: (occasion, amount) => `${amount} GDD - ${occasion}.png`,
+}))
+
 class MockImage {
   constructor() {
     this.src = ''
@@ -17,6 +30,10 @@ class MockImage {
 }
 
 global.Image = MockImage
+
+const STORE = {
+  state: { firstName: 'Bernd', lastName: 'Hückstädt', username: 'bernd', gradidoId: 'uuid-1' },
+}
 
 describe('FigureQrCode', () => {
   let wrapper
@@ -30,6 +47,8 @@ describe('FigureQrCode', () => {
       global: {
         mocks: {
           $t: (key) => key,
+          $d: () => '26.08.2026',
+          $store: STORE,
         },
       },
     })
@@ -92,6 +111,83 @@ describe('FigureQrCode', () => {
       expect(wrapper.find('#download').attributes('href')).toEqual(
         'data:image/png;base64,mockedData',
       )
+    })
+  })
+
+  describe('thank-you cheque download', () => {
+    it('is hidden without the cheque prop', () => {
+      expect(wrapper.find('.test-download-cheque').exists()).toBe(false)
+    })
+
+    describe('thank-you cheque', () => {
+      beforeEach(async () => {
+        wrapper = createWrapper({
+          cheque: {
+            kind: 'thankYou',
+            amount: '20',
+            memo: 'Gradido-Café Berlin',
+            validUntil: '2026-08-26T00:00:00Z',
+          },
+        })
+        await wrapper.find('.test-download-cheque').trigger('click')
+      })
+
+      it('shows the link', () => {
+        expect(wrapper.find('.test-download-cheque').exists()).toBe(true)
+      })
+
+      it('passes sender name, gradido address and initials', () => {
+        expect(mockDrawCheque).toHaveBeenCalledWith(
+          expect.objectContaining({
+            kind: 'thankYou',
+            name: 'Bernd Hückstädt',
+            initials: 'BH',
+            memo: 'Gradido-Café Berlin',
+          }),
+        )
+      })
+
+      it('builds the headline from the sender and the amount', () => {
+        expect(mockDrawCheque.mock.calls[0][0].headline).toContain('Bernd')
+        expect(mockDrawCheque.mock.calls[0][0].headline).toContain('20')
+      })
+    })
+
+    describe('starting credit', () => {
+      beforeEach(async () => {
+        wrapper = createWrapper({
+          cheque: {
+            kind: 'startingBonus',
+            amount: '100',
+            memo: 'Dein Startguthaben!',
+            name: 'Startguthaben Postkarte',
+            validFrom: '2026-08-12T00:00:00Z',
+            validTo: '2030-12-31T00:00:00Z',
+          },
+        })
+        await wrapper.find('.test-download-cheque').trigger('click')
+      })
+
+      it('uses the community instead of a person', () => {
+        const data = mockDrawCheque.mock.calls[0][0]
+        expect(data.kind).toBe('startingBonus')
+        expect(data.community).toBeDefined()
+        expect(data.name).toBeUndefined()
+      })
+    })
+
+    describe('when a picture cannot be loaded', () => {
+      beforeEach(async () => {
+        mockDrawCheque.mockRejectedValueOnce(new Error('cannot load image'))
+        wrapper = createWrapper({
+          cheque: { kind: 'thankYou', amount: '20', memo: 'x', validUntil: '2026-08-26T00:00:00Z' },
+        })
+        await wrapper.find('.test-download-cheque').trigger('click')
+      })
+
+      it('does not fail silently', () => {
+        expect(mockToastError).toHaveBeenCalledWith('cannot load image')
+      })
     })
   })
 })

--- a/frontend/src/components/QrCode/FigureQrCode.vue
+++ b/frontend/src/components/QrCode/FigureQrCode.vue
@@ -13,11 +13,19 @@
       >
         {{ $t('download') }}
       </a>
+      <div v-if="cheque" class="mt-2">
+        <a href="#" class="test-download-cheque" @click.prevent="downloadCheque">
+          {{ $t('thank-you-cheque.download') }}
+        </a>
+      </div>
     </div>
   </div>
 </template>
 <script>
 import { QRCanvas } from 'qrcanvas-vue'
+import CONFIG from '@/config'
+import { drawCheque, chequeFileName } from '@/utils/thankYouCheque'
+import { useAppToast } from '@/composables/useToast'
 
 export default {
   name: 'FigureQrCode',
@@ -26,6 +34,19 @@ export default {
   },
   props: {
     link: { type: String, required: true },
+    /**
+     * When set, a second link "download thank-you cheque" appears. The sentences
+     * printed on the cheque are built here so that the call sites only have to
+     * pass raw data.
+     *
+     * thank-you cheque: { kind: 'thankYou',      amount, memo, validUntil }
+     * starting bonus:   { kind: 'startingBonus', amount, memo, name, validFrom, validTo }
+     */
+    cheque: { type: Object, default: null },
+  },
+  setup() {
+    const { toastError } = useAppToast()
+    return { toastError }
   },
   data() {
     return {
@@ -35,6 +56,39 @@ export default {
         data: this.link,
       },
     }
+  },
+  computed: {
+    isStartingBonus() {
+      return this.cheque?.kind === 'startingBonus'
+    },
+    /** For a starting bonus the contribution link's name states the occasion, otherwise the memo does. */
+    occasion() {
+      return this.isStartingBonus ? this.cheque.name : this.cheque?.memo
+    },
+    chequeData() {
+      if (!this.cheque) return null
+      const date = (value) => this.$d(new Date(value), 'short')
+      if (this.isStartingBonus) {
+        return {
+          kind: 'startingBonus',
+          community: CONFIG.COMMUNITY_NAME,
+          headline: this.$t('thank-you-cheque.starting-credit', { amount: this.cheque.amount }),
+          validLine: this.$t('thank-you-cheque.starting-credit-valid', {
+            from: date(this.cheque.validFrom),
+            to: date(this.cheque.validTo),
+          }),
+        }
+      }
+      const { firstName, lastName, username, gradidoId } = this.$store.state
+      return {
+        kind: 'thankYou',
+        name: `${firstName} ${lastName}`.trim(),
+        address: `${CONFIG.COMMUNITY_NAME}/${username || gradidoId}`,
+        initials: `${firstName?.[0] ?? ''}${lastName?.[0] ?? ''}`,
+        headline: `${firstName} ${this.$t('transaction-link.send_you')} ${this.cheque.amount} Gradido.`,
+        validLine: this.$t('thank-you-cheque.valid-until', { date: date(this.cheque.validUntil) }),
+      }
+    },
   },
   created() {
     const image = new Image()
@@ -53,6 +107,24 @@ export default {
       const canvas = this.$refs.canvas.$el
       const image = canvas.toDataURL('image/png')
       this.$refs.download.href = image
+    },
+    async downloadCheque() {
+      try {
+        const image = await drawCheque({
+          ...this.chequeData,
+          memo: this.cheque.memo,
+          hintLine: this.$t('thank-you-cheque.scan-qr'),
+          qrCanvas: this.$refs.canvas.$el,
+        })
+        const a = document.createElement('a')
+        a.href = image
+        a.download = chequeFileName(this.occasion, this.cheque.amount)
+        a.click()
+      } catch (error) {
+        // The cheque is only drawn on click. If one of its pictures fails to load,
+        // that must not stay silent.
+        this.toastError(error.message)
+      }
     },
   },
 }

--- a/frontend/src/components/TransactionLinks/TransactionLink.vue
+++ b/frontend/src/components/TransactionLinks/TransactionLink.vue
@@ -48,7 +48,13 @@
         <template #header>
           <h6 class="mb-0">{{ $t('qrCode') }}</h6>
         </template>
-        <BCardText><figure-qr-code class="text-center" :link="link" /></BCardText>
+        <BCardText>
+          <figure-qr-code
+            class="text-center"
+            :link="link"
+            :cheque="{ kind: 'thankYou', amount: String(amount), memo, validUntil }"
+          />
+        </BCardText>
         <template #footer>
           <em>{{ link }}</em>
         </template>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -725,6 +725,13 @@
   "status": "Status",
   "submitted": "Eingereicht",
   "success": "Erfolg",
+  "thank-you-cheque": {
+    "download": "Dank-Scheck herunterladen",
+    "scan-qr": "Damit die Gradido gutgeschrieben werden, scanne den QR-Code!",
+    "starting-credit": "Startguthaben {amount} Gradido",
+    "starting-credit-valid": "Dieses Startguthaben ist vom {from} bis zum {to} gültig.",
+    "valid-until": "Dieser Dank-Scheck ist bis zum {date} gültig."
+  },
   "time": {
     "days": "Tage",
     "hours": "Stunden",

--- a/frontend/src/locales/el.json
+++ b/frontend/src/locales/el.json
@@ -725,6 +725,13 @@
   "status": "Κατάσταση",
   "submitted": "Υποβλήθηκε",
   "success": "Επιτυχία",
+  "thank-you-cheque": {
+    "download": "Λήψη επιταγής ευχαριστίας",
+    "scan-qr": "Για να πιστωθούν τα Gradido, σάρωσε τον κωδικό QR!",
+    "starting-credit": "Αρχικό υπόλοιπο {amount} Gradido",
+    "starting-credit-valid": "Αυτό το αρχικό υπόλοιπο ισχύει από τις {from} έως τις {to}.",
+    "valid-until": "Αυτή η επιταγή ευχαριστίας ισχύει έως τις {date}."
+  },
   "time": {
     "days": "Ημέρες",
     "hours": "Ώρες",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -725,6 +725,13 @@
   "status": "Status",
   "submitted": "Submitted",
   "success": "Success",
+  "thank-you-cheque": {
+    "download": "Download thank-you cheque",
+    "scan-qr": "For the Gradido to be credited, scan the QR code!",
+    "starting-credit": "Starting bonus {amount} Gradido",
+    "starting-credit-valid": "This starting bonus is valid from {from} until {to}.",
+    "valid-until": "This thank-you cheque is valid until {date}."
+  },
   "time": {
     "days": "Days",
     "hours": "Hours",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -725,6 +725,13 @@
   "status": "Estado",
   "submitted": "Enviado",
   "success": "Lo lograste",
+  "thank-you-cheque": {
+    "download": "Descargar cheque de agradecimiento",
+    "scan-qr": "Para que se te acrediten los Gradidos, ¡escanea el código QR!",
+    "starting-credit": "Saldo inicial {amount} Gradido",
+    "starting-credit-valid": "Este saldo inicial es válido desde el {from} hasta el {to}.",
+    "valid-until": "Este cheque de agradecimiento es válido hasta el {date}."
+  },
   "time": {
     "days": "Días",
     "hours": "Horas",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -725,6 +725,13 @@
   "status": "Statu",
   "submitted": "Envoyé",
   "success": "Avec succès",
+  "thank-you-cheque": {
+    "download": "Télécharger le chèque de remerciement",
+    "scan-qr": "Pour l'accréditation du Gradido, scanner le code QR !",
+    "starting-credit": "Crédit de départ {amount} Gradido",
+    "starting-credit-valid": "Ce crédit de départ est valable du {from} au {to}.",
+    "valid-until": "Ce chèque de remerciement est valable jusqu'au {date}."
+  },
   "time": {
     "days": "Jours",
     "hours": "Heures",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -725,6 +725,13 @@
   "status": "Stato",
   "submitted": "Inviato",
   "success": "Successo",
+  "thank-you-cheque": {
+    "download": "Scarica l'assegno di ringraziamento",
+    "scan-qr": "Per ricevere l'accredito dei Gradido, scansiona il codice QR!",
+    "starting-credit": "Credito iniziale {amount} Gradido",
+    "starting-credit-valid": "Questo credito iniziale è valido dal {from} al {to}.",
+    "valid-until": "Questo assegno di ringraziamento è valido fino al {date}."
+  },
   "time": {
     "days": "Giorni",
     "hours": "Ore",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -725,6 +725,13 @@
   "status": "Status",
   "submitted": "Ingediend",
   "success": "Succes",
+  "thank-you-cheque": {
+    "download": "Bedankcheque downloaden",
+    "scan-qr": "Om de Gradidos bijgeschreven te krijgen, scan de QR-code!",
+    "starting-credit": "Startsaldo {amount} Gradido",
+    "starting-credit-valid": "Dit startsaldo is geldig van {from} tot {to}.",
+    "valid-until": "Deze bedankcheque is geldig tot {date}."
+  },
   "time": {
     "days": "Dagen",
     "hours": "Uren",

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -725,6 +725,13 @@
   "status": "Estado",
   "submitted": "Submetido",
   "success": "Sucesso",
+  "thank-you-cheque": {
+    "download": "Descarregar cheque de agradecimento",
+    "scan-qr": "Para que os Gradido sejam creditados, digitaliza o código QR!",
+    "starting-credit": "Saldo inicial {amount} Gradido",
+    "starting-credit-valid": "Este saldo inicial é válido de {from} até {to}.",
+    "valid-until": "Este cheque de agradecimento é válido até {date}."
+  },
   "time": {
     "days": "Dias",
     "hours": "Horas",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -725,6 +725,13 @@
   "status": "Статус",
   "submitted": "Внесено",
   "success": "Результат/Успех",
+  "thank-you-cheque": {
+    "download": "Скачать чек благодарности",
+    "scan-qr": "Чтобы получить начисление Gradido на счёт, отсканируйте QR-код!",
+    "starting-credit": "Стартовый баланс {amount} Gradido",
+    "starting-credit-valid": "Этот стартовый баланс действителен с {from} до {to}.",
+    "valid-until": "Этот чек благодарности действителен до {date}."
+  },
   "time": {
     "days": "Дни",
     "hours": "Часы",

--- a/frontend/src/locales/tr.json
+++ b/frontend/src/locales/tr.json
@@ -727,7 +727,7 @@
   "success": "Başarılı",
   "thank-you-cheque": {
     "download": "Teşekkür çekini indir",
-    "scan-qr": "Senin hesabına Gradido transferi için QR kodu tarayın!",
+    "scan-qr": "Senin hesabına Gradido transferi için QR kodu tara!",
     "starting-credit": "Başlangıç bakiyesi {amount} Gradido",
     "starting-credit-valid": "Bu başlangıç bakiyesi {from} ile {to} arasında geçerli.",
     "valid-until": "Bu teşekkür çeki {date} tarihine kadar geçerli."

--- a/frontend/src/locales/tr.json
+++ b/frontend/src/locales/tr.json
@@ -725,6 +725,13 @@
   "status": "Durum",
   "submitted": "Gönderildi",
   "success": "Başarılı",
+  "thank-you-cheque": {
+    "download": "Teşekkür çekini indir",
+    "scan-qr": "Senin hesabına Gradido transferi için QR kodu tarayın!",
+    "starting-credit": "Başlangıç bakiyesi {amount} Gradido",
+    "starting-credit-valid": "Bu başlangıç bakiyesi {from} ile {to} arasında geçerli.",
+    "valid-until": "Bu teşekkür çeki {date} tarihine kadar geçerli."
+  },
   "time": {
     "days": "Günler",
     "hours": "Saatler",

--- a/frontend/src/utils/thankYouCheque.js
+++ b/frontend/src/utils/thankYouCheque.js
@@ -1,0 +1,282 @@
+// AI-GENERATED — not an architecture reference
+
+/**
+ * Draws a thank-you cheque or a starting-bonus cheque as a PNG.
+ *
+ * Layout (pixels at 300 dpi):
+ *
+ *   image  1783 x 850  =  151 x 72 mm
+ *   |- white margin 106 px (9 mm) on the left and on the right
+ *   `- cheque 1571 x 850  =  133 x 72 mm, with a thin grey cutting line
+ *      |- header 150 px: logo, leaves, sender or community
+ *      `- body   700 px: leaf watermark, text on the left, QR on the right
+ *
+ * The white margin serves two purposes. It makes the image flat enough for three
+ * cheques to fit on one text page — applications that ignore the print size
+ * stretch the image to column width, which shrinks the cheque instead of making
+ * it taller. And it indents a single cheque placed inside the text of an
+ * invitation letter.
+ *
+ * The QR is not generated again. It is copied from the canvas that is already on
+ * screen, so it carries the same data and the same error correction level.
+ */
+
+const WIDTH = 1783
+const HEIGHT = 850
+const MARGIN = 106 // 9 mm of white on each side
+const CHEQUE_WIDTH = WIDTH - 2 * MARGIN
+const HEADER = 150
+const BODY = HEIGHT - HEADER
+const PADDING = 55 // inner padding of the cheque
+const QR_BOX = 360 // fixed box width so the QR looks the same for any link length
+const QR_GAP = 40
+
+const FONT = '"Open Sans", Helvetica, Arial, sans-serif'
+const HEADLINE_SIZE = 62
+const MEMO_SIZE = 38
+const MEMO_GAP = 32 // baseline to baseline, measured against the approved mockup
+const FOOTER_SIZE = 29
+const MEMO_MAX_LINES = 2
+const BLOCK_GAP = 20
+const PADDING_MIN = 24
+
+const COLOR_TEXT = 'rgb(56, 56, 56)'
+const COLOR_MEMO = '#4b4b4b'
+const COLOR_GREEN = '#4a6741'
+const COLOR_HEADER_BG = '#f5f5f5'
+const COLOR_CUT_LINE = '#a8a8a8'
+const COLOR_AVATAR = '#5b7c99'
+
+const IMAGES = {
+  logo: '/img/brand/gradido-logo.png',
+  leaves: '/img/template/Blaetter.png',
+  watermark: '/img/svg/Gradido_Blaetter_Mainpage.svg',
+}
+
+const loadImage = (source) =>
+  new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onload = () => resolve(image)
+    image.onerror = () => reject(new Error(`cannot load image: ${source}`))
+    image.src = source
+  })
+
+/**
+ * Wraps text at word boundaries and truncates after `maxLines` with an ellipsis.
+ * Canvas does not wrap on its own, so every line has to be drawn separately.
+ */
+export const wrapText = (ctx, text, maxWidth, maxLines = Infinity) => {
+  const words = String(text ?? '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .filter(Boolean)
+  if (!words.length) return []
+
+  const lines = []
+  let current = ''
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word
+    if (ctx.measureText(candidate).width <= maxWidth || !current) {
+      current = candidate
+      continue
+    }
+    lines.push(current)
+    current = word
+    if (lines.length === maxLines) break
+  }
+  if (lines.length < maxLines) lines.push(current)
+
+  const truncated = lines.length === maxLines && lines.join(' ') !== words.join(' ')
+  if (truncated) {
+    let last = lines[maxLines - 1]
+    while (last && ctx.measureText(`${last} …`).width > maxWidth) {
+      last = last.replace(/\s*\S+$/, '')
+    }
+    lines[maxLines - 1] = `${last.replace(/[\s,;:–-]+$/, '')} …`
+  }
+  return lines
+}
+
+// Characters Windows rejects in file names, plus control characters. Spaces and
+// hyphens are kept on purpose so that "Dank-Scheck" keeps its hyphen.
+// eslint-disable-next-line no-control-regex
+const WINDOWS_FORBIDDEN = /[<>:"/\\|?*\u0000-\u001f]/g
+const WINDOWS_RESERVED = new Set([
+  'CON',
+  'PRN',
+  'AUX',
+  'NUL',
+  ...Array.from({ length: 9 }, (_, i) => `COM${i + 1}`),
+  ...Array.from({ length: 9 }, (_, i) => `LPT${i + 1}`),
+])
+
+/**
+ * Builds the file name from whichever field names the occasion: the memo for a
+ * thank-you cheque, the contribution link's name for a starting bonus. The amount
+ * goes first so that a folder holding several cheques sorts in a useful way.
+ *
+ * Windows forbids more characters than macOS does and rejects names ending in a
+ * dot or a space. Both are handled here, otherwise the download fails silently.
+ */
+export const chequeFileName = (occasion, amount, maxChars = 50) => {
+  let name = String(occasion ?? '')
+    .replace(WINDOWS_FORBIDDEN, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (name.length > maxChars) {
+    const atWordEnd = name.slice(0, maxChars).replace(/\s+\S*$/, '')
+    name = (atWordEnd.length >= maxChars * 0.6 ? atWordEnd : name.slice(0, maxChars)).replace(
+      /[\s,;:–-]+$/,
+      '',
+    )
+  }
+  name = name.replace(/[\s.]+$/, '')
+
+  if (!name || WINDOWS_RESERVED.has(name.toUpperCase())) name = 'Gradido-Scheck'
+  const prefix = amount ? `${amount} GDD - ` : ''
+  return `${prefix}${name}.png`
+}
+
+const drawHeader = (ctx, { logo, leaves, kind, name, address, initials, community }) => {
+  ctx.fillStyle = COLOR_HEADER_BG
+  ctx.fillRect(MARGIN, 0, CHEQUE_WIDTH, HEADER)
+  ctx.fillStyle = '#e4e4e4'
+  ctx.fillRect(MARGIN, HEADER - 2, CHEQUE_WIDTH, 2)
+
+  const leavesHeight = 212
+  const leavesWidth = leaves.width * (leavesHeight / leaves.height)
+  ctx.drawImage(leaves, MARGIN + (CHEQUE_WIDTH - leavesWidth) / 2, -30, leavesWidth, leavesHeight)
+
+  const logoHeight = 70
+  const logoWidth = logo.width * (logoHeight / logo.height)
+  ctx.drawImage(logo, MARGIN + 46, (HEADER - logoHeight) / 2, logoWidth, logoHeight)
+
+  const right = WIDTH - MARGIN - 46
+  ctx.textAlign = 'right'
+  ctx.fillStyle = COLOR_GREEN
+
+  if (kind === 'startingBonus') {
+    ctx.font = `700 29px ${FONT}`
+    ctx.textBaseline = 'middle'
+    ctx.fillText(community ?? '', right, HEADER / 2)
+  } else {
+    ctx.font = `700 25px ${FONT}`
+    ctx.textBaseline = 'alphabetic'
+    ctx.fillText(name ?? '', right, HEADER / 2 - 4)
+    ctx.font = `400 24px ${FONT}`
+    ctx.fillText(address ?? '', right, HEADER / 2 + 30)
+
+    const size = 78
+    ctx.font = `400 24px ${FONT}`
+    const addressWidth = ctx.measureText(address ?? '').width
+    ctx.font = `700 25px ${FONT}`
+    const nameWidth = ctx.measureText(name ?? '').width
+    const centerX = right - Math.max(nameWidth, addressWidth) - 20 - size / 2
+    ctx.beginPath()
+    ctx.arc(centerX, HEADER / 2, size / 2, 0, Math.PI * 2)
+    ctx.fillStyle = COLOR_AVATAR
+    ctx.fill()
+    ctx.fillStyle = '#fff'
+    ctx.font = `600 29px ${FONT}`
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText(initials ?? '', centerX, HEADER / 2 + 1)
+  }
+  ctx.textAlign = 'left'
+  ctx.textBaseline = 'alphabetic'
+}
+
+/**
+ * @param {object} data
+ * @param {HTMLCanvasElement} data.qrCanvas the canvas the QR has already been drawn on
+ * @param {'thankYou'|'startingBonus'} data.kind
+ * @param {string} data.headline  "Bernd sends you 20 Gradido." or "Starting bonus 20 Gradido"
+ * @param {string} data.memo      free text, truncated to two lines
+ * @param {string} data.hintLine  "... scan the QR code!"
+ * @param {string} data.validLine "... is valid until 26.08.2026."
+ * @returns {Promise<string>} the PNG as a data URL
+ */
+export const drawCheque = async (data) => {
+  const [logo, leaves, watermark] = await Promise.all([
+    loadImage(IMAGES.logo),
+    loadImage(IMAGES.leaves),
+    loadImage(IMAGES.watermark),
+  ])
+
+  const canvas = document.createElement('canvas')
+  canvas.width = WIDTH
+  canvas.height = HEIGHT
+  const ctx = canvas.getContext('2d')
+
+  ctx.fillStyle = '#fff'
+  ctx.fillRect(0, 0, WIDTH, HEIGHT)
+
+  drawHeader(ctx, { logo, leaves, ...data })
+
+  // Leaf watermark at 125 % of the body height, aligned to the top and placed to
+  // the left of the QR. It runs out of the image at the bottom on purpose, which
+  // keeps both leaf tips visible.
+  ctx.save()
+  ctx.beginPath()
+  ctx.rect(MARGIN, HEADER, CHEQUE_WIDTH, BODY)
+  ctx.clip()
+  const watermarkHeight = BODY * 1.25
+  const watermarkWidth = watermark.width * (watermarkHeight / watermark.height)
+  ctx.drawImage(
+    watermark,
+    WIDTH - MARGIN - 425 - watermarkWidth,
+    HEADER,
+    watermarkWidth,
+    watermarkHeight,
+  )
+  ctx.restore()
+
+  const qrSize = Math.min(data.qrCanvas.width, QR_BOX)
+  const column = CHEQUE_WIDTH - 2 * PADDING - QR_BOX - QR_GAP
+
+  ctx.font = `600 ${MEMO_SIZE}px ${FONT}`
+  const memoLines = wrapText(ctx, data.memo, column, MEMO_MAX_LINES)
+
+  const topBlock =
+    Math.round(HEADLINE_SIZE * 1.2) + (memoLines.length ? MEMO_GAP : 0) + memoLines.length * 49
+  const spare = Math.max(2 * PADDING_MIN, BODY - topBlock - qrSize - BLOCK_GAP)
+  const paddingTop = Math.round(spare * 0.55)
+
+  const left = MARGIN + PADDING
+  let y = HEADER + paddingTop + HEADLINE_SIZE
+
+  ctx.fillStyle = COLOR_TEXT
+  ctx.font = `700 ${HEADLINE_SIZE}px ${FONT}`
+  ctx.fillText(data.headline ?? '', left, y)
+
+  ctx.fillStyle = COLOR_MEMO
+  ctx.font = `600 ${MEMO_SIZE}px ${FONT}`
+  y += MEMO_GAP + MEMO_SIZE
+  memoLines.forEach((line, i) => ctx.fillText(line, left, y + i * 49))
+
+  // QR at the bottom right, centred inside a box of fixed width
+  const qrX = WIDTH - MARGIN - PADDING - QR_BOX + (QR_BOX - qrSize) / 2
+  const qrY = HEIGHT - Math.round(spare * 0.45) - qrSize
+  ctx.drawImage(data.qrCanvas, qrX, qrY, qrSize, qrSize)
+
+  // Footer lines on the left, aligned with the bottom of the QR and drawn from
+  // the bottom up. The web address sits a little lower than the rest.
+  ctx.fillStyle = COLOR_TEXT
+  ctx.font = `700 ${FOOTER_SIZE}px ${FONT}`
+  const lineHeight = Math.round(FOOTER_SIZE * 1.6)
+  const webGap = 22
+  const bottom = qrY + qrSize - 15
+
+  ctx.fillText('www.gradido.net', left, bottom)
+  ctx.fillText(data.validLine ?? '', left, bottom - lineHeight - webGap)
+  ctx.fillText(data.hintLine ?? '', left, bottom - 2 * lineHeight - webGap)
+
+  // Cutting line last so that nothing paints over it
+  ctx.strokeStyle = COLOR_CUT_LINE
+  ctx.lineWidth = 2
+  ctx.strokeRect(MARGIN + 1, 1, CHEQUE_WIDTH - 2, HEIGHT - 2)
+
+  return canvas.toDataURL('image/png')
+}

--- a/frontend/src/utils/thankYouCheque.spec.js
+++ b/frontend/src/utils/thankYouCheque.spec.js
@@ -1,0 +1,90 @@
+// AI-GENERATED — not an architecture reference
+
+import { describe, it, expect } from 'vitest'
+import { chequeFileName, wrapText } from './thankYouCheque'
+
+// There is no canvas in the test environment. `wrapText` only needs measureText,
+// mocked here with a fixed character width so the line breaks are predictable.
+const ctxWithCharWidth = (width) => ({
+  measureText: (text) => ({ width: text.length * width }),
+})
+
+describe('chequeFileName', () => {
+  it('takes the occasion and puts the amount first', () => {
+    expect(chequeFileName('Gradido-Café Berlin', '20')).toBe('20 GDD - Gradido-Café Berlin.png')
+  })
+
+  it('keeps hyphens so that "Dank-Scheck" stays "Dank-Scheck"', () => {
+    expect(chequeFileName('Dank-Scheck Nr. 012', '5')).toBe('5 GDD - Dank-Scheck Nr. 012.png')
+  })
+
+  it('replaces characters Windows forbids in file names', () => {
+    const name = chequeFileName('Café um 12:00 / Saal <A> "groß" | Nr?*', '20')
+    expect(name).not.toMatch(/[<>:"/\\|?*]/)
+    expect(name.endsWith('.png')).toBe(true)
+  })
+
+  it('truncates long names at a word boundary, not mid-word', () => {
+    const occasion = 'Vortrag Nürtingen, Donnerstag 16. August, Stadthalle Süd, Eingang West'
+    const name = chequeFileName(occasion, '20')
+    const core = name.replace(/^20 GDD - /, '').replace(/\.png$/, '')
+    expect(core.length).toBeLessThanOrEqual(50)
+    expect(core).not.toMatch(/\s$/)
+    // whole words only, no dangling fragment at the end
+    expect(occasion).toContain(core)
+  })
+
+  it('never ends on a dot or a space — Windows rejects such names', () => {
+    expect(chequeFileName('Bis später...', '3')).toBe('3 GDD - Bis später.png')
+    expect(chequeFileName('Danke   ', '3')).toBe('3 GDD - Danke.png')
+  })
+
+  it('falls back to a fixed name when the occasion is empty', () => {
+    expect(chequeFileName('', '10')).toBe('10 GDD - Gradido-Scheck.png')
+    expect(chequeFileName(null, '10')).toBe('10 GDD - Gradido-Scheck.png')
+  })
+
+  it('avoids the names Windows reserves', () => {
+    expect(chequeFileName('nul', '1')).toBe('1 GDD - Gradido-Scheck.png')
+    expect(chequeFileName('COM1', '1')).toBe('1 GDD - Gradido-Scheck.png')
+  })
+
+  it('leaves out the amount when none is given', () => {
+    expect(chequeFileName('Gradido-Café', null)).toBe('Gradido-Café.png')
+  })
+})
+
+describe('wrapText', () => {
+  const ctx = ctxWithCharWidth(10)
+
+  it('returns no line for empty text', () => {
+    expect(wrapText(ctx, '', 100)).toEqual([])
+    expect(wrapText(ctx, null, 100)).toEqual([])
+  })
+
+  it('keeps short text on one line', () => {
+    expect(wrapText(ctx, 'kurz', 100)).toEqual(['kurz'])
+  })
+
+  it('breaks at word boundaries', () => {
+    expect(wrapText(ctx, 'eins zwei drei', 100)).toEqual(['eins zwei', 'drei'])
+  })
+
+  it('truncates after the allowed number of lines and adds an ellipsis', () => {
+    const lines = wrapText(ctx, 'eins zwei drei vier fünf sechs sieben', 100, 2)
+    expect(lines).toHaveLength(2)
+    expect(lines[1].endsWith('…')).toBe(true)
+  })
+
+  it('does not truncate when the text fits anyway', () => {
+    const lines = wrapText(ctx, 'eins zwei', 100, 2)
+    expect(lines).toEqual(['eins zwei'])
+    expect(lines.join('')).not.toContain('…')
+  })
+
+  it('keeps a single overlong word instead of losing it', () => {
+    expect(wrapText(ctx, 'Donaudampfschifffahrtsgesellschaft', 50)).toEqual([
+      'Donaudampfschifffahrtsgesellschaft',
+    ])
+  })
+})


### PR DESCRIPTION
Turns a transaction link into a printable PNG, so a Gradido link can be handed over on paper — at a cafe table, on a topic stand, or inside the text of an invitation letter.

## What it looks like

The cheque follows the layout Bernd has been using since 2023, with two changes he asked for: the background is the leaf watermark from the account page instead of a landscape photo, and the top right shows the **gradido address** instead of the e-mail address.

## Where the button is

A second link below the existing QR download. It shows up wherever a link's QR is shown:

- right after a link was created
- in the transaction list, via the link's menu

Both use the same component, so one change covers both.

## Two sizes, both measured

| | |
|---|---|
| cheque | **133 x 72 mm** — the size of a 20 euro note, so it fits any wallet that takes bank notes |
| image  | **151 x 72 mm** — 9 mm of white on each side |

The white margin is not decoration. An application that ignores the print size stretches the image to column width; with the margin included, that shrinks the cheque instead of making it taller, so **three cheques still fit on one page**. The same margin indents a single cheque placed inside running text. A thin grey line marks where to cut.

## Locale keys

Four new keys in all ten languages, under `thank-you-cheque`. Two of them exist because paper differs from a chat message: there is nothing to click on a sheet of paper, so the cheque says *scan the QR code* rather than *click the link*, and it names itself a thank-you cheque rather than a link.

The existing warning *"anyone can redeem this link"* deliberately stays **off** the cheque — it addresses the sender, not the person receiving it. Its place remains the creation screen.

## Notes for review

- **No new dependency and no server work.** The QR is already drawn on a canvas; the cheque copies that canvas rather than generating a second QR. All picture parts were already in `public/img/`.
- **The image carries no dpi marker.** `toDataURL` does not write one, and adding it by hand would help only in applications that read it — the others would still stretch the image. Leaving it out makes every application behave the same way, and the white margin is what keeps three cheques on a page either way.
- **The drawing starts on click**, so a picture that fails to load surfaces as a toast instead of staying silent.
- **The admin side is deliberately not part of this.** Starting-bonus cheques will follow separately: the admin has its own copy of `FigureQrCode` without any download mechanism, does not have the leaf images, and keeps its own locales. Whether to duplicate the drawing or share it is an open question worth deciding on its own.

## Checked locally

- `bunx turbo test --filter=frontend` — 900 tests, 92 files
- `bunx turbo lint --filter=frontend` — no errors
- `bunx turbo build --filter=frontend`
- `bun scripts/sortLocales.ts` plus a locale audit — 575 keys, all ten languages consistent
- The drawing itself rendered in a real browser and inspected as a PNG, for a short memo, an overlong memo, and a starting bonus
- The file-name test was proved to measure by putting the bug back in: three tests fail with it, none without


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added downloadable thank-you and starting-credit cheques from QR code views.
  * Cheques include transaction details, personalized messaging, validity dates, and QR codes.
  * Added clear download options and error notifications when cheque generation fails.
* **Localization**
  * Added thank-you cheque translations across supported languages, including download, scanning, credit, and expiration labels.
* **Tests**
  * Added coverage for cheque rendering, downloads, formatting, filenames, localized content, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->