### PR TITLE
feat(backend): count any activity for Gradido as common good

### DIFF
--- a/backend/src/apis/anthropic/crea/outputSchema.ts
+++ b/backend/src/apis/anthropic/crea/outputSchema.ts
@@ -6,7 +6,7 @@
 // supported (our schema does not use them). Keys are camelCase to map 1:1 onto
 // the GraphQL model (`CreaEvaluation`) without a translation layer.
 
-// Taxonomy category keys (design doc `D`, taxonomy_version 1). Append-only.
+// Taxonomy category keys (design doc `D`, taxonomy_version 2). Append-only.
 // `other` is a v1 pragmatic fallback for activities that do not fit a bucket
 // (e.g. an unclear contribution that still needs a category slot).
 export const CREA_CATEGORY_KEYS = [
@@ -44,6 +44,10 @@ export const CREA_CATEGORY_KEYS = [
   'cultural_events',
   'social_movement',
   'common_good_network',
+  // Spreading, building or attending Gradido itself. Kept apart from
+  // `social_movement` (engagement in OTHER movements) on purpose: only the
+  // separation shows how much of a community's effort goes into its own reach.
+  'gradido_engagement',
   // civic_and_infrastructure
   'public_space_maintenance',
   'nonprofit_support',
@@ -63,6 +67,7 @@ export const CREA_APPLIED_RULE_KEYS = [
   'confirm_retiree_beyond',
   'confirm_retiree_unconditional',
   'confirm_hours_above',
+  'confirm_gradido_engagement',
   'inquire_direct_beneficiary',
   'inquire_own_need',
   'inquire_private_pet',

--- a/backend/src/apis/anthropic/crea/ruleset.ts
+++ b/backend/src/apis/anthropic/crea/ruleset.ts
@@ -3,7 +3,9 @@
 //
 // v1 SEED: this is a compact, faithful distillation of the reviewed design
 // files E (Schoepfungsregeln), G (Verhaltens-Spezifikation) and D (Taxonomie),
-// including Bernd's 08.07. redline (E-012). It is deliberately a seed for the
+// including Bernd's 08.07. redline (E-012) and his 12.08. rule change (E-029:
+// any activity for Gradido counts, attending an event as much as helping at
+// one). It is deliberately a seed for the
 // thin slice DO-1; the canonical full port of E/G/D (and later per-community
 // overrides via the rule UI, roadmap step 2) replaces it. The rule text lives
 // in German because it is user-facing domain content, like the wallet locales.
@@ -24,9 +26,9 @@
 // ephemeral`), so keep them stable -- any edit invalidates the prompt cache for
 // that prompt's callers.
 
-export const CREA_RULESET_VERSION = 1
+export const CREA_RULESET_VERSION = 2
 export const CREA_BEHAVIOR_VERSION = 7
-export const CREA_TAXONOMY_VERSION = 1
+export const CREA_TAXONOMY_VERSION = 2
 
 // --- shared between the contribution window and CreaChat ---------------------
 
@@ -84,8 +86,10 @@ Automatisch bestätigen (Positiv-Liste, nach den sieben Taxonomie-Domänen):
 - Bildung & Wissen: kostenlose Nachhilfe, gemeinwohlorientierte Workshops/Vorträge, frei zugängliche Bildung, ehrenamtliche Bildungsarbeit.
 - Nahrung & Landwirtschaft: Anbau über den Eigenbedarf hinaus, SoLaWi, Foodsharing, Gemeinschaftsgarten, Kochen für Bedürftige.
 - Zivilgesellschaft & Infrastruktur: Pflege öffentlicher Plätze, gemeinnützige Vereine, Nachbarschaftshilfe-Projekte, Zukunftsprojekte.
-Grenzfälle: Hilfe für Freunde/Familie/Mitbewohner hängt am Zustand des Empfängers (bedürftig = Gemeinwohl; gesund und könnte direkt mit Gradido danken -> Rückfrage). Spirituelle/Energiearbeit: in einer Gruppe oder für einen kranken/alten Menschen = Gemeinwohl; rein für die eigene Entwicklung -> Rückfrage. Eigene Kinder: Erziehung/Begleitung = Gemeinwohl; Haushalt/Kochen, nicht explizit den Kindern gewidmet -> Rückfrage.
-Braucht eine Rückfrage (kein automatisches Gemeinwohl): individuelle Leistung für jemanden, der direkt mit Gradido danken könnte; Eigenbedarf/privater Haushalt; private Haustierhaltung; rein private spirituelle/persönliche Entwicklung; gewerbliche/kommerzielle Tätigkeit; vage, leere oder unklare Angaben (dann freundlich um eine genauere Beschreibung bitten, nicht ablehnen).
+- Gradido selbst: JEDE Tätigkeit für Gradido ist Gemeinwohl, denn sie alle verbreiten Gradido — anderen von Gradido erzählen und dafür werben; mitbauen und mitpflegen (Programmieren, Testen, Übersetzen, Texte, Grafik, Moderation, Rückmeldungen zur Software); und Gradido-Veranstaltungen: Gradido-Café, Gradido-Vortrag, Montagskonferenz, Online-Konferenzen, Webinare, Messe- und Infostände. Der BESUCH zählt dabei genauso wie die Mitarbeit, vor Ort wie online — wer teilnimmt, trägt Gradido weiter. Auch bezahlte Gradido-Arbeit zählt. Nicht darunter fällt die bloße Nutzung des eigenen Kontos (Beiträge einreichen, Kontostand ansehen, mit Gradido bezahlen).
+Grenzfälle: Hilfe für Freunde/Familie/Mitbewohner hängt am Zustand des Empfängers (bedürftig = Gemeinwohl; gesund und könnte direkt mit Gradido danken -> Rückfrage). Von Gradido erzählt: hat jemand bei einer sonst individuellen Leistung von Gradido erzählt ("dem Nachbarn beim Umzug geholfen und ihm dabei von Gradido erzählt"), ist der Beitrag Gemeinwohl — das Erzählen ist Werbung für Gradido; bestätigen, keine Rückfrage. Spirituelle/Energiearbeit: in einer Gruppe oder für einen kranken/alten Menschen = Gemeinwohl; rein für die eigene Entwicklung -> Rückfrage. Eigene Kinder: Erziehung/Begleitung = Gemeinwohl; Haushalt/Kochen, nicht explizit den Kindern gewidmet -> Rückfrage.
+Braucht eine Rückfrage (kein automatisches Gemeinwohl): individuelle Leistung für jemanden, der direkt mit Gradido danken könnte; Eigenbedarf/privater Haushalt; private Haustierhaltung; rein private spirituelle/persönliche Entwicklung; gewerbliche/kommerzielle Tätigkeit (ausgenommen Tätigkeiten für Gradido selbst); vage, leere oder unklare Angaben (dann freundlich um eine genauere Beschreibung bitten, nicht ablehnen) — nennt ein knapper Eintrag aber eine Gradido-Veranstaltung ("Gradido-Café besucht", "Gradido-Café bei Bernd", "Montagskonferenz"), genügt das als Beschreibung: bestätigen, nicht nachfragen.
+Erstkontakt — die warme Begrüßung: Reicht ein neues Mitglied ohne Historie als ersten Beitrag den Besuch einer Gradido-Veranstaltung ein, ist das der Moment, in dem ein Mensch bei Gradido ankommt. Bestätige, und freue Dich ausdrücklich, dass er oder sie da war — eine herzliche Willkommens-Note gleich im ersten Satz. Dieser Mensch soll sich willkommen fühlen, nicht geprüft.
 
 # 7 Sonderrollen
 Es gibt kein Profilfeld für den Status — Du erkennst ihn nur, wenn er im Beitrag steht oder in der Historie geklärt wurde.
@@ -126,7 +130,8 @@ ${creationRules(true)}
 Gib zu jedem Urteil eine Konfidenz aus. Setze das flag "stunden_geschaetzt", wenn Du die Gesamtstunden auf die Tätigkeiten schätzen musstest. Erfinde keine Fakten: Name, Datum, Status, eingetragene Stunden kommen aus dem System; Prozess-/Zeitdetails erfindest Du nie. Das flag "anrede_unsicher" setzt der Code, nicht Du.
 
 # 9 Regel-Schlüssel für das Feld appliedRule (append-only)
-confirm_positive_list, confirm_recipient_in_need, confirm_own_children, confirm_child_contributor, confirm_retiree_beyond, confirm_retiree_unconditional, confirm_hours_above; inquire_direct_beneficiary, inquire_own_need, inquire_private_pet, inquire_private_spiritual, inquire_commercial, inquire_unclear, inquire_hours_below.
+confirm_positive_list, confirm_recipient_in_need, confirm_own_children, confirm_child_contributor, confirm_retiree_beyond, confirm_retiree_unconditional, confirm_hours_above, confirm_gradido_engagement; inquire_direct_beneficiary, inquire_own_need, inquire_private_pet, inquire_private_spiritual, inquire_commercial, inquire_unclear, inquire_hours_below.
+confirm_gradido_engagement gilt für alles aus dem Gradido-Punkt in Kapitel 6: erzählen und werben, mitbauen, an einer Gradido-Veranstaltung teilnehmen oder mitwirken — auch für "individuelle Leistung, aber von Gradido erzählt" und für den Erstkontakt-Besuch.
 
 # 10 Kategorisierung (Taxonomie D)
 Ordne jede Tätigkeit einer categoryKey aus der globalen Taxonomie zu und setze den passenden outputType (material_good, service, care, knowledge oder stewardship). Passt nichts, nutze "other".

--- a/backend/src/apis/anthropic/crea/ruleset.ts
+++ b/backend/src/apis/anthropic/crea/ruleset.ts
@@ -78,7 +78,7 @@ Keine Stunden-Rückfrage bei Rentnern oder Kranken.
 
 # 6 Schöpfungsregeln — was als Gemeinwohl gilt
 Grundregel: nicht WAS jemand tut entscheidet, sondern FÜR WEN und ZU WELCHEM ZWECK. Gemeinwohl = Ehrenamt / Freiwilligen-Engagement, im Unterschied zu einer individuellen Leistung von Mensch zu Mensch.
-Automatisch bestätigen (Positiv-Liste, nach den sieben Taxonomie-Domänen):
+Automatisch bestätigen (Positiv-Liste — die sieben Taxonomie-Domänen, dazu Gradido selbst):
 - Fürsorge & Unterstützung: Pflege/Begleitung alter, kranker, behinderter oder bedürftiger Menschen (auch psychisch, auch Freunde/Mitbewohner, wenn der Empfänger bedürftig ist); Hilfe in sozialen/finanziellen Notlagen; akute Nothilfe.
 - Kinder & Elternschaft: Betreuung von Kindern in Familie/Gemeinschaft; Erziehung und Begleitung der eigenen Kinder; Jugend-Mentoring.
 - Natur & Umwelt: Natur-/Arten-/Tierschutz im gemeinnützigen Rahmen (Tierheim, Gnadenhof, Wildtierhilfe), Müllsammeln, Aufforstung, Nachhaltigkeitsinitiativen.


### PR DESCRIPTION
## What

Bernd's rule change (design decision E-029): **any activity for Gradido counts as common good** — because all of it spreads Gradido.

- **Telling and promoting** — telling others about Gradido, explaining it, sharing it.
- **Building and maintaining** — code, testing, translation, texts, graphics, moderation, feedback on the software.
- **Events — attending *and* helping** — Gradido café, talks, the Monday conference, online conferences, webinars, info stands. **Attending counts as much as helping**, on site and online.

Paid Gradido work counts too. Merely using one's own account (submitting contributions, checking the balance, paying with Gradido) does not — that does not spread anything.

## Why this is more than one list entry

Until now Crea's rules did not know Gradido engagement at all. The positive list covered care, children, nature, culture, education, food and civic work — not the work on and for Gradido itself. Two rules actively worked against it:

1. **"Attended a Gradido café" hit the terse-entry inquiry.** A first-time visitor's very first contribution got a follow-up question instead of a welcome. That entry is now explicitly enough of a description, and a first contribution naming a Gradido event is confirmed with an explicit welcome. It is a person's first impression of Gradido.
2. **"Helped my neighbour move and told him about Gradido" fell through the direct-beneficiary rule.** Telling someone about Gradido now lifts an otherwise individual favour into common good — practically the most important half of this change.

## How

The rule text lives in the shared `creationRules()`, so it reaches **both** surfaces — the contribution window and CreaChat — from one place.

- New taxonomy key `gradido_engagement` under `culture_and_community`. Deliberately kept apart from `social_movement` (engagement in *other* movements): only the separation makes it measurable how much of a community's effort goes into its own reach.
- New rule key `confirm_gradido_engagement`.
- Both **appended**, nothing renamed — the keys stay append-only as the design docs require.
- `CREA_RULESET_VERSION` and `CREA_TAXONOMY_VERSION` go to 2.

## Checks

- Backend `typecheck` and `lint` green.
- Crea unit tests: 41 passing locally. `records.test.ts` cannot run here (`shared-native` needs the Rust toolchain) — it reads the version constants symbolically, so bumping them cannot break it, but CI confirms.
- `applied_rule` and `category_key` are `varchar(48)`; the new values are 27 and 18 characters. No migration.
- The admin only queries `appliedRule` / `categoryKey`, it does not translate them — no locale keys needed.
- No new file, so no `AI-GENERATED` marker (edits to existing files do not get one).

⚠️ This edit invalidates the prompt cache for both Crea prompts, by design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recognition for Gradido engagement activities, including promotion, development, events, paid work, and first-contact welcomes.
  * Added support for confirming Gradido engagement classifications.

* **Updates**
  * Updated taxonomy and ruleset versions to version 2.
  * Clarified that Gradido activities, including event attendance, qualify as Gemeinwohl while ordinary account use remains excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->